### PR TITLE
style: fix prettier format violations breaking CI

### DIFF
--- a/packages/cli/__tests__/contract.test.ts
+++ b/packages/cli/__tests__/contract.test.ts
@@ -67,9 +67,9 @@ beforeAll(() => {
 
 describe('top-level flags', () => {
   it('--version prints the package version', () => {
-    const pkg = JSON.parse(
-      readFileSync(resolve(here, '..', 'package.json'), 'utf-8'),
-    ) as { version: string }
+    const pkg = JSON.parse(readFileSync(resolve(here, '..', 'package.json'), 'utf-8')) as {
+      version: string
+    }
     const r = run(['--version'])
     expect(r.status).toBe(0)
     expect(r.stdout.trim()).toBe(pkg.version)
@@ -141,10 +141,14 @@ describe('help --json: agent introspection', () => {
     for (const [name, spec] of Object.entries(doc.commands)) {
       expect(Array.isArray(spec.exitCodes), `${name}.exitCodes`).toBe(true)
       expect(Array.isArray(spec.examples), `${name}.examples`).toBe(true)
-      expect((spec.exitCodes as number[]).length, `${name} has at least one exit code`)
-        .toBeGreaterThan(0)
-      expect((spec.examples as string[]).length, `${name} has at least one example`)
-        .toBeGreaterThan(0)
+      expect(
+        (spec.exitCodes as number[]).length,
+        `${name} has at least one exit code`
+      ).toBeGreaterThan(0)
+      expect(
+        (spec.examples as string[]).length,
+        `${name} has at least one example`
+      ).toBeGreaterThan(0)
     }
   })
 
@@ -202,7 +206,7 @@ describe('--json on every data-emitting command', () => {
     // At least one error has resolvable line+col. We don't pin exact numbers
     // because schema details may shift; the contract is that positions exist.
     const positioned = doc.errors.filter(
-      (e) => typeof e.line === 'number' && typeof e.col === 'number',
+      (e) => typeof e.line === 'number' && typeof e.col === 'number'
     )
     expect(positioned.length).toBeGreaterThan(0)
     expect(positioned[0].line).toBeGreaterThan(0)

--- a/packages/cli/__tests__/contract.test.ts
+++ b/packages/cli/__tests__/contract.test.ts
@@ -55,6 +55,10 @@ function run(args: string[], input?: string): RunResult {
   }
 }
 
+// Detects ANSI escape sequences. The regex literally needs the escape
+// control character (\x1b) — that's what we're trying to detect — so the
+// no-control-regex rule is intentionally disabled for this one line.
+// eslint-disable-next-line no-control-regex
 const ANSI = /\x1b\[[0-9;]*[A-Za-z]/
 
 beforeAll(() => {

--- a/packages/cli/__tests__/init.test.ts
+++ b/packages/cli/__tests__/init.test.ts
@@ -10,13 +10,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import {
-  buildClients,
-  runInit,
-  renderTable,
-  type ClientSpec,
-  type FsLike,
-} from '../src/init.js'
+import { buildClients, runInit, renderTable, type ClientSpec, type FsLike } from '../src/init.js'
 
 /** Build an in-memory fs-like surface for tests. */
 function makeFs(initial: { dirs?: string[]; files?: string[] } = {}): FsLike & {

--- a/packages/cli/__tests__/validate.test.ts
+++ b/packages/cli/__tests__/validate.test.ts
@@ -17,17 +17,16 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import YAML from 'yaml'
 
-import {
-  offsetToLineCol,
-  pathStringToSegments,
-  resolvePosition,
-} from '../src/validate.js'
+import { offsetToLineCol, pathStringToSegments, resolvePosition } from '../src/validate.js'
 
 const REPO_CLI = join(__dirname, '..')
 const ENTRY = join(REPO_CLI, 'src/index.ts')
 const TSX = join(REPO_CLI, '../../node_modules/.bin/tsx')
 
-function runCli(args: string[], input?: string): { stdout: string; stderr: string; status: number } {
+function runCli(
+  args: string[],
+  input?: string
+): { stdout: string; stderr: string; status: number } {
   const r = spawnSync(TSX, [ENTRY, ...args], {
     input,
     encoding: 'utf-8',
@@ -173,9 +172,7 @@ flow:
       expect(Array.isArray(out.errors)).toBe(true)
       expect(out.errors.length).toBeGreaterThan(0)
       // At least one error should land on the node-2 region (lines 7-8).
-      const positioned = out.errors.filter(
-        (e: { line?: number }) => typeof e.line === 'number'
-      )
+      const positioned = out.errors.filter((e: { line?: number }) => typeof e.line === 'number')
       expect(positioned.length).toBeGreaterThan(0)
       const lines = positioned.map((e: { line: number }) => e.line)
       expect(Math.min(...lines)).toBeGreaterThanOrEqual(5)
@@ -200,9 +197,7 @@ flow:
       const r = runCli(['validate', file, '--json'])
       expect(r.status).toBe(3)
       const out = JSON.parse(r.stdout)
-      const fromErr = out.errors.find((e: { path: string }) =>
-        e.path.includes('from')
-      )
+      const fromErr = out.errors.find((e: { path: string }) => e.path.includes('from'))
       expect(fromErr).toBeDefined()
       expect(fromErr.suggestion).toMatch(/Did you mean "client"/)
       // line/col should be set since the path resolves.

--- a/packages/cli/src/get.ts
+++ b/packages/cli/src/get.ts
@@ -1,13 +1,5 @@
 import { Command } from 'commander'
-import {
-  errorMessage,
-  bold,
-  dim,
-  red,
-  emitJson,
-  errStderr,
-  logStderr,
-} from './utils.js'
+import { errorMessage, bold, dim, red, emitJson, errStderr, logStderr } from './utils.js'
 import { ExitCode } from './exit-codes.js'
 
 /** Register `openhop get <id>` — fetch a single flow by id.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,10 +50,7 @@ if (process.argv.includes('--api-version')) {
 
 const program = new Command()
 
-program
-  .name('openhop')
-  .description('OpenHop — Data Flow Visualization CLI')
-  .version('0.1.0')
+program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0')
 
 // --- serve ---
 program

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -167,7 +167,7 @@ const realFs: FsLike = {
 export function findSourceSkill(
   startUrl: string = import.meta.url,
   fs: FsLike = realFs,
-  cwd: string = process.cwd(),
+  cwd: string = process.cwd()
 ): string | null {
   const here = dirname(fileURLToPath(startUrl))
   const candidates = [
@@ -192,7 +192,7 @@ export function runInit(
   opts: InitOptions,
   clients: ClientSpec[],
   sourceSkill: string | null,
-  fs: FsLike = realFs,
+  fs: FsLike = realFs
 ): { results: InstallResult[]; sourceMissing: boolean } {
   if (!sourceSkill) {
     return { results: [], sourceMissing: true }
@@ -287,9 +287,7 @@ export function registerInit(program: Command): void {
       // Validate --client filter early so we can return exit 2 (usage error).
       if (opts.client && !clients.some((c) => c.id === opts.client)) {
         const known = clients.map((c) => c.id).join(', ')
-        process.stderr.write(
-          `error: unknown --client "${opts.client}". Known clients: ${known}\n`,
-        )
+        process.stderr.write(`error: unknown --client "${opts.client}". Known clients: ${known}\n`)
         process.exit(EXIT_USAGE)
       }
 
@@ -298,7 +296,7 @@ export function registerInit(program: Command): void {
 
       if (sourceMissing) {
         process.stderr.write(
-          'error: could not locate bundled skills/openhop/ — is this a damaged install?\n',
+          'error: could not locate bundled skills/openhop/ — is this a damaged install?\n'
         )
         process.exit(EXIT_GENERIC)
       }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -29,9 +29,7 @@ export function padRight(str: string, len: number): string {
 // ---------------------------------------------------------------------------
 
 const noColor =
-  process.env.NO_COLOR !== undefined ||
-  process.env.TERM === 'dumb' ||
-  !process.stderr.isTTY
+  process.env.NO_COLOR !== undefined || process.env.TERM === 'dumb' || !process.stderr.isTTY
 
 const ansi = (open: number, close: number) => (s: string) =>
   noColor ? s : `\x1b[${open}m${s}\x1b[${close}m`


### PR DESCRIPTION
## Summary

CI's `npm run format:check` step has been failing on master for several commits. Local dev runs exercised tsc/vitest but not prettier `--check`. Reformat 7 files; no semantic changes.

## Root cause

The CLI work batch (df889f7 onwards) added several new files (`contract.test.ts`, `validate.test.ts`, `get.ts`, `init.ts`, `index.ts` edits, `utils.ts`, `init.test.ts`) that the tooling ran tsc + vitest on but never prettier. CI's `format:check` step caught it; my local pushes did not.

## Test plan

- [x] `prettier --check` clean
- [x] tsc --noEmit clean
- [x] All 82 CLI tests still pass (utils 9, init 20, validate 17, contract 36)
- [ ] CI passes on this branch

## Process note

Going forward — branch + PR + green-CI before merging to master, instead of pushing straight to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)