### PR TITLE
feat(web): render self-loops as a small loop over the top-right

### DIFF
--- a/examples/self-loops.yaml
+++ b/examples/self-loops.yaml
@@ -1,0 +1,67 @@
+meta:
+  title: Self-loops
+  path: examples/self-loops
+  description: Demonstrates steps where from and to are the same node — internal work, retries, and recursive processing.
+
+flow:
+  nodes:
+    - id: client
+      label: Client
+      type: actor
+    - id: api
+      label: API Gateway
+      type: endpoint
+    - id: worker
+      label: Worker
+      type: service
+    - id: db
+      label: Database
+      type: database
+
+  steps:
+    - from: client
+      to: api
+      data: POST /jobs
+
+    # Self-loop: API runs internal validation before forwarding.
+    - from: api
+      to: api
+      data:
+        label: validate request
+        fields:
+          - name: schema_check
+            type: bool
+          - name: rate_limit
+            type: bool
+
+    - from: api
+      to: worker
+      data: enqueued job
+
+    # Self-loop: worker iterates internally (retry / batch processing).
+    - from: worker
+      to: worker
+      data:
+        label: process batch (retry x3)
+        fields:
+          - name: attempt
+            type: int
+            changed: true
+          - name: backoff_ms
+            type: int
+
+    - from: worker
+      to: db
+      data: write result
+
+    # Self-loop on the database: trigger fires a follow-up update.
+    - from: db
+      to: db
+      data: trigger update_audit_log
+
+    - from: worker
+      to: api
+      data: job complete
+    - from: api
+      to: client
+      data: "200 OK"

--- a/examples/self-loops.yaml
+++ b/examples/self-loops.yaml
@@ -1,7 +1,7 @@
 meta:
   title: Self-loops
   path: examples/self-loops
-  description: Demonstrates steps where from and to are the same node — internal work, retries, and recursive processing.
+  description: Demonstrates steps where from and to are the same node — internal work, retries, recursive processing — plus broadcasts and multi-data steps.
 
 flow:
   nodes:
@@ -14,6 +14,9 @@ flow:
     - id: worker
       label: Worker
       type: service
+    - id: cache
+      label: Cache
+      type: cache
     - id: db
       label: Database
       type: database
@@ -23,35 +26,50 @@ flow:
       to: api
       data: POST /jobs
 
-    # Self-loop: API runs internal validation before forwarding.
+    # Self-loop with multiple data payloads sent at once — three independent
+    # checks fire on the same internal step.
     - from: api
       to: api
       data:
-        label: validate request
-        fields:
-          - name: schema_check
-            type: bool
-          - name: rate_limit
-            type: bool
+        - label: schema validation
+          fields:
+            - name: body
+              type: JSON
+        - label: auth check
+          fields:
+            - name: token
+              type: JWT
+        - label: rate limit
+          fields:
+            - name: bucket
+              type: string
 
+    # Broadcast: API fans out to both worker and cache in a single step.
     - from: api
-      to: worker
+      to: [worker, cache]
       data: enqueued job
 
-    # Self-loop: worker iterates internally (retry / batch processing).
+    # Self-loop with multi-data: worker reports retry + metric in parallel.
     - from: worker
       to: worker
       data:
-        label: process batch (retry x3)
-        fields:
-          - name: attempt
-            type: int
-            changed: true
-          - name: backoff_ms
-            type: int
+        - label: process batch (retry x3)
+          fields:
+            - name: attempt
+              type: int
+              changed: true
+            - name: backoff_ms
+              type: int
+        - label: emit metrics
+          fields:
+            - name: latency_ms
+              type: float
+            - name: throughput
+              type: int
 
+    # Broadcast write: worker writes to db and invalidates cache at once.
     - from: worker
-      to: db
+      to: [db, cache]
       data: write result
 
     # Self-loop on the database: trigger fires a follow-up update.
@@ -59,9 +77,25 @@ flow:
       to: db
       data: trigger update_audit_log
 
-    - from: worker
-      to: api
-      data: job complete
+    # Multiple sources delivering to the same node at once — worker reports
+    # completion while cache confirms invalidation; api receives both in parallel.
+    - parallel:
+        - from: worker
+          to: api
+          data:
+            label: job complete
+            fields:
+              - name: job_id
+                type: uuid
+              - name: duration_ms
+                type: int
+        - from: cache
+          to: api
+          data:
+            label: cache invalidated
+            fields:
+              - name: keys_evicted
+                type: int
     - from: api
       to: client
       data: "200 OK"

--- a/packages/web/__tests__/flow-layout.test.ts
+++ b/packages/web/__tests__/flow-layout.test.ts
@@ -165,7 +165,9 @@ describe('buildReactFlowGraph', () => {
     const topology = buildFlowTopology(selfLoopFlow)
     const graph = buildReactFlowGraph(topology, new Map([['worker', { x: 0, y: 0 }]]))
 
-    const loopEdge = graph.edges.find((edge) => edge.source === 'worker' && edge.target === 'worker')
+    const loopEdge = graph.edges.find(
+      (edge) => edge.source === 'worker' && edge.target === 'worker'
+    )
 
     expect(loopEdge).toBeTruthy()
     expect(loopEdge?.sourceHandle).toBe('right')

--- a/packages/web/__tests__/flow-layout.test.ts
+++ b/packages/web/__tests__/flow-layout.test.ts
@@ -155,6 +155,27 @@ describe('buildReactFlowGraph', () => {
     expect(dbEdge?.sourceHandle).not.toBe(cacheEdge?.sourceHandle)
   })
 
+  it('renders self-loop edges as an ear over the top-right with right→top ports', () => {
+    const selfLoopFlow = {
+      flow: {
+        nodes: [{ id: 'worker', label: 'Worker', type: 'service' }],
+        steps: [{ from: 'worker', to: 'worker', data: { label: 'retry' } }],
+      },
+    } as Flow
+    const topology = buildFlowTopology(selfLoopFlow)
+    const graph = buildReactFlowGraph(topology, new Map([['worker', { x: 0, y: 0 }]]))
+
+    const loopEdge = graph.edges.find((edge) => edge.source === 'worker' && edge.target === 'worker')
+
+    expect(loopEdge).toBeTruthy()
+    expect(loopEdge?.sourceHandle).toBe('right')
+    expect(loopEdge?.targetHandle).toBe('top')
+    // Ear extends above the node (negative y) and to the right of it (x > NODE_WIDTH).
+    const path = (loopEdge?.data as { elkPath?: string } | undefined)?.elkPath
+    expect(path).toBeDefined()
+    expect(path).toMatch(/-\d/) // contains a negative coordinate (route loops above y=0)
+  })
+
   it('keeps an explicit orthogonal path from layout routing data when provided', () => {
     const topology = buildFlowTopology(orderFlow)
     const graph = buildReactFlowGraph(

--- a/packages/web/__tests__/flow-layout.test.ts
+++ b/packages/web/__tests__/flow-layout.test.ts
@@ -8,6 +8,7 @@ import {
   buildOrthogonalPath,
   bundleSharedSourcePrefixes,
   inferPortAssignmentsFromRoutes,
+  NODE_WIDTH,
 } from '../src/lib/flow-layout.ts'
 
 const orderFlow = {
@@ -172,10 +173,17 @@ describe('buildReactFlowGraph', () => {
     expect(loopEdge).toBeTruthy()
     expect(loopEdge?.sourceHandle).toBe('right')
     expect(loopEdge?.targetHandle).toBe('top')
-    // Ear extends above the node (negative y) and to the right of it (x > NODE_WIDTH).
     const path = (loopEdge?.data as { elkPath?: string } | undefined)?.elkPath
     expect(path).toBeDefined()
-    expect(path).toMatch(/-\d/) // contains a negative coordinate (route loops above y=0)
+    const points = [...path!.matchAll(/[ML]\s*(-?\d+(?:\.\d+)?)\s*(-?\d+(?:\.\d+)?)/g)].map(
+      ([, x, y]) => ({ x: Number(x), y: Number(y) })
+    )
+    expect(points.length).toBeGreaterThanOrEqual(5)
+    // Ear exits the right port: second point sits further right than the first.
+    expect(points[1].x).toBeGreaterThan(points[0].x)
+    // Route extends past the node's right edge and rises above y=0.
+    expect(Math.max(...points.map((p) => p.x))).toBeGreaterThan(NODE_WIDTH)
+    expect(Math.min(...points.map((p) => p.y))).toBeLessThan(0)
   })
 
   it('keeps an explicit orthogonal path from layout routing data when provided', () => {

--- a/packages/web/src/lib/flow-layout.ts
+++ b/packages/web/src/lib/flow-layout.ts
@@ -430,6 +430,29 @@ export function inferPortAssignmentsFromRoutes(
 }
 
 const MIN_SHARED_STUB_LENGTH = 120
+const SELF_LOOP_OFFSET = 32
+
+/**
+ * Build a self-loop "ear" route — exits the node's right port, hooks up and
+ * over the top-right corner, and re-enters via the top port. Returns the
+ * route in the same shape ELK would produce so it flows through the rest of
+ * the rendering pipeline (path extension, RoadEdge, pixel animation).
+ */
+function buildSelfLoopRoute(position: Position): {
+  route: RoutePoint[]
+  assignment: EdgePortAssignment
+} {
+  const sourceAnchor = anchorForHandle(position, 'right')
+  const targetAnchor = anchorForHandle(position, 'top')
+  const route: RoutePoint[] = [
+    sourceAnchor,
+    { x: sourceAnchor.x + SELF_LOOP_OFFSET, y: sourceAnchor.y },
+    { x: sourceAnchor.x + SELF_LOOP_OFFSET, y: targetAnchor.y - SELF_LOOP_OFFSET },
+    { x: targetAnchor.x, y: targetAnchor.y - SELF_LOOP_OFFSET },
+    targetAnchor,
+  ]
+  return { route, assignment: { source: 'right', target: 'top' } }
+}
 
 export function bundleSharedSourcePrefixes(
   routes: Map<string, RoutePoint[]>,
@@ -675,8 +698,10 @@ export function buildReactFlowGraph(
   const edges: Edge[] = topology.displayEdges.map((edge) => {
     const sourcePos = positionMap.get(edge.source) ?? defaultPosition()
     const targetPos = positionMap.get(edge.target) ?? defaultPosition()
-    const assignment = portAssignments?.get(edge.id)
-    const rawRoute = routes?.get(edge.id) ?? []
+    const isSelfLoop = edge.source === edge.target
+    const selfLoop = isSelfLoop ? buildSelfLoopRoute(sourcePos) : null
+    const assignment = selfLoop?.assignment ?? portAssignments?.get(edge.id)
+    const rawRoute = selfLoop?.route ?? routes?.get(edge.id) ?? []
     const extendedRoute = extendRouteToNodeCenters(rawRoute, assignment)
     const elkPath = buildOrthogonalPath(extendedRoute)
 
@@ -685,9 +710,11 @@ export function buildReactFlowGraph(
       source: edge.source,
       target: edge.target,
       sourceHandle:
+        selfLoop?.assignment.source ??
         portAssignments?.get(edge.id)?.source ??
         pickHandleWithPeers(sourcePos, targetPos, outgoingBySource.get(edge.source) ?? []),
       targetHandle:
+        selfLoop?.assignment.target ??
         portAssignments?.get(edge.id)?.target ??
         pickHandleWithPeers(targetPos, sourcePos, incomingByTarget.get(edge.target) ?? []),
       data: {


### PR DESCRIPTION
## Summary
- Steps with `from === to` previously rendered as a degenerate straight line — `pushLayoutEdge` skips self-loops, so ELK never produced a route, and React Flow's `getSmoothStepPath` collapsed source and target onto the same point.
- `buildReactFlowGraph` now detects self-loops and synthesizes a small orthogonal "ear" route: right port → up → over the top → into the top port. Path flows through the existing pipeline (`extendRouteToNodeCenters`, `RoadEdge`, pixel animation) so the road and the animated data pixel just work.
- Adds `examples/self-loops.yaml` with self-loops on the API gateway (validation), worker (retry), and database (audit-log trigger) to exercise the feature end-to-end.

## Test plan
- [ ] `openhop push examples/self-loops.yaml` and confirm the three self-loops render as visible ear-shaped loops above each node.
- [ ] Confirm the data pixel animates around the loop at the same cadence as normal edges.
- [ ] Confirm flows without self-loops still layout/render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new example workflow demonstrating self-loop and fan-out patterns across API, worker, DB, and cache interactions.
  * Enhanced flow visualization to render self-loops with clearer orthogonal loop paths and consistent handle assignments.

* **Tests**
  * Added a unit test validating self-loop rendering, handle assignments, and routing metadata in the flow visualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->