### PR TITLE
fix(web): use single ELK pass to keep edges from cutting through nodes

### DIFF
--- a/packages/web/__tests__/flow-layout.test.ts
+++ b/packages/web/__tests__/flow-layout.test.ts
@@ -126,6 +126,53 @@ describe('computeElkLayout', () => {
 
     expect(intersects).toBe(false)
   })
+
+  it('routes api to cache around the worker node when both share the api source layer', async () => {
+    const yaml = readFileSync(new URL('../../../examples/self-loops.yaml', import.meta.url), 'utf8')
+    const parsed = parseFlowYaml(yaml)
+    expect(parsed.success).toBe(true)
+    if (!parsed.success || !parsed.data) return
+
+    const { computeElkLayout, NODE_WIDTH, NODE_HEIGHT } = await import('../src/lib/flow-layout.ts')
+    const topology = buildFlowTopology(parsed.data as Flow)
+    const layout = await computeElkLayout(topology)
+    const edge = topology.displayEdges.find(
+      (candidate) => candidate.source === 'api' && candidate.target === 'cache'
+    )
+    const route = edge ? layout.routes.get(edge.id) : null
+    const worker = layout.positions.get('worker')
+
+    expect(edge).toBeTruthy()
+    expect(route).toBeTruthy()
+    expect(worker).toBeTruthy()
+
+    const workerBox = {
+      left: worker!.x,
+      right: worker!.x + NODE_WIDTH,
+      top: worker!.y,
+      bottom: worker!.y + NODE_HEIGHT,
+    }
+
+    const passesThroughWorker = (route ?? []).some((point, index, points) => {
+      if (index === 0) return false
+      const prev = points[index - 1]
+      if (prev.x === point.x) {
+        if (point.x < workerBox.left || point.x > workerBox.right) return false
+        const segTop = Math.min(prev.y, point.y)
+        const segBottom = Math.max(prev.y, point.y)
+        return segBottom > workerBox.top && segTop < workerBox.bottom
+      }
+      if (prev.y === point.y) {
+        if (point.y < workerBox.top || point.y > workerBox.bottom) return false
+        const segLeft = Math.min(prev.x, point.x)
+        const segRight = Math.max(prev.x, point.x)
+        return segRight > workerBox.left && segLeft < workerBox.right
+      }
+      return false
+    })
+
+    expect(passesThroughWorker).toBe(false)
+  })
 })
 
 describe('buildReactFlowGraph', () => {
@@ -309,5 +356,48 @@ describe('bundleSharedSourcePrefixes', () => {
       { x: 520, y: 140 },
       { x: 780, y: 360 },
     ])
+  })
+
+  it('keeps each route orthogonal when two edges share a target-side approach but have different trunks', () => {
+    // Two edges land on the same target's `left` port from different sources.
+    // The edges have *different* natural trunks (api's vertical leg at x=466
+    // vs worker's at x=774). Before the fix, bundleSharedTargetSuffixes only
+    // shifted the penultimate point of each route to the group-wide approachX,
+    // stranding the earlier bend that formed the L-corner on the route's own
+    // trunk and leaving a diagonal segment in the path.
+    const apiRoute = [
+      { x: 456, y: 370 },
+      { x: 466, y: 370 },
+      { x: 466, y: 120 },
+      { x: 964, y: 120 },
+    ]
+    const workerRoute = [
+      { x: 764, y: 370 },
+      { x: 774, y: 370 },
+      { x: 774, y: 120 },
+      { x: 964, y: 120 },
+    ]
+    const routes = bundleSharedSourcePrefixes(
+      new Map([
+        ['e-api-cache', apiRoute],
+        ['e-worker-cache', workerRoute],
+      ]),
+      new Map([
+        ['e-api-cache', { source: 'right', target: 'left' }],
+        ['e-worker-cache', { source: 'right', target: 'left' }],
+      ])
+    )
+
+    const isOrthogonal = (route: { x: number; y: number }[]) =>
+      route.every((point, index) => {
+        if (index === 0) return true
+        const prev = route[index - 1]
+        return prev.x === point.x || prev.y === point.y
+      })
+
+    const apiResult = routes.get('e-api-cache')!
+    const workerResult = routes.get('e-worker-cache')!
+    expect(isOrthogonal(apiResult)).toBe(true)
+    expect(isOrthogonal(workerResult)).toBe(true)
   })
 })

--- a/packages/web/src/lib/flow-layout.ts
+++ b/packages/web/src/lib/flow-layout.ts
@@ -578,9 +578,14 @@ function bundleSharedTargetSuffixes(
       for (const item of bent) {
         const route = item.route
         const tail = route[route.length - 1]
+        // Shift each route's own approach trunk (the x of its penultimate
+        // bend) — not the group-wide naturalApproachX — so any earlier bend
+        // that formed the orthogonal corner with the trunk moves with it.
+        // Otherwise the corner gets stranded and the route becomes diagonal.
+        const ownApproachX = route[route.length - 2].x
         const shifted = route
           .slice(0, -1)
-          .map((p) => (p.x === naturalApproachX ? { x: approachX, y: p.y } : p))
+          .map((p) => (p.x === ownApproachX ? { x: approachX, y: p.y } : p))
         shifted[shifted.length - 1] = { x: approachX, y: tail.y }
         routes.set(item.edgeId, dedupeRoutePoints([...shifted, tail]))
       }
@@ -600,9 +605,10 @@ function bundleSharedTargetSuffixes(
       for (const item of bent) {
         const route = item.route
         const tail = route[route.length - 1]
+        const ownApproachY = route[route.length - 2].y
         const shifted = route
           .slice(0, -1)
-          .map((p) => (p.y === naturalApproachY ? { x: p.x, y: approachY } : p))
+          .map((p) => (p.y === ownApproachY ? { x: p.x, y: approachY } : p))
         shifted[shifted.length - 1] = { x: tail.x, y: approachY }
         routes.set(item.edgeId, dedupeRoutePoints([...shifted, tail]))
       }
@@ -866,20 +872,17 @@ function extractElkLayout(graph: Awaited<ReturnType<typeof elk.layout>>) {
 }
 
 export async function computeElkLayout(topology: FlowTopology): Promise<ElKLayoutResult> {
-  const firstPass = extractElkLayout(await elk.layout(buildElkGraph(topology)))
-  const inferredAssignments = inferPortAssignmentsFromRoutes(
-    topology,
-    firstPass.positions,
-    firstPass.routes
-  )
-  const secondPass = extractElkLayout(
-    await elk.layout(buildElkGraph(topology, inferredAssignments))
-  )
-  const bundledRoutes = bundleSharedSourcePrefixes(secondPass.routes, inferredAssignments)
+  // Single pass without FIXED_SIDE port constraints. ELK's free-port routing
+  // exits each node at the position closest to the route's natural direction,
+  // which avoids edges getting forced through intermediate layers when an
+  // inferred side ('right') would place the port at the side's midpoint.
+  const layout = extractElkLayout(await elk.layout(buildElkGraph(topology)))
+  const portAssignments = inferPortAssignmentsFromRoutes(topology, layout.positions, layout.routes)
+  const bundledRoutes = bundleSharedSourcePrefixes(layout.routes, portAssignments)
 
   return {
-    positions: secondPass.positions,
+    positions: layout.positions,
     routes: bundledRoutes,
-    portAssignments: inferredAssignments,
+    portAssignments,
   }
 }


### PR DESCRIPTION
## Summary
With `examples/self-loops.yaml`, the road from `api` to `cache` rendered straight through the `worker` node. Root cause was the two-pass ELK strategy in `computeElkLayout`:

1. **Pass 1** (no port constraints) gave a clean route for `api → cache`:
   `(456,290) → (466,290) → (466,93) → (964,93)` — exiting api's top-right and going up over worker.
2. `inferPortAssignmentsFromRoutes` correctly inferred `source='right'`, `target='left'`.
3. **Pass 2** (with `FIXED_SIDE`) placed the right port at the side's midpoint (y=370) and re-ran orthogonal routing, producing `(456,370) → (844,370) → (844,120) → (964,120)` — a horizontal trunk at y=370 that cuts straight through worker.

The second pass throws away pass 1's port-position information and forces ELK to re-solve from a worse starting state.

**Fix**: drop pass 2. Pass 1's routes already match the inferred handles (since the inference is computed from those very routes), and they avoid intermediate nodes correctly because ELK has full freedom to place ports.

The defensive own-trunk shift in `bundleSharedTargetSuffixes` from the earlier commit is kept as it remains correct.

## Test plan
- [x] New regression test loads `examples/self-loops.yaml` and asserts the `api → cache` route never crosses the worker bbox.
- [x] Existing 9 tests still pass (10/10 total) — including the order-flow rate-limit avoidance test that exercises the same routing path.
- [ ] Visual confirmation: refresh a flow page after merge — `api → cache` should clear worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge routing to prevent diagonal segments and maintain orthogonal paths when multiple routes share the same target approach.
  * Enhanced layout computation efficiency by streamlining the ELK layout process.

* **Tests**
  * Added comprehensive test coverage for edge bundling and routing calculations to ensure route orthogonality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->