### PR TITLE
feat(web): pixel colors follow node variant + per-pixel cycling for multi-data

### DIFF
--- a/packages/web/__tests__/pixel-palette.test.ts
+++ b/packages/web/__tests__/pixel-palette.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { VARIANT_ACCENT, assignNodeVariants, multiDataPixelColor } from '../src/lib/pixel-palette'
+
+describe('assignNodeVariants', () => {
+  it('gives the first node of each independent type the original (orange) accent', () => {
+    const variants = assignNodeVariants([
+      { id: 'api', type: 'endpoint' },
+      { id: 'db', type: 'database' },
+    ])
+    expect(variants.get('api')?.color).toBe(VARIANT_ACCENT[0])
+    expect(variants.get('db')?.color).toBe(VARIANT_ACCENT[0])
+  })
+
+  it('cycles successive same-type-pool nodes through the palette', () => {
+    const variants = assignNodeVariants([
+      { id: 'svc-a', type: 'service' },
+      { id: 'svc-b', type: 'service' },
+      { id: 'svc-c', type: 'service' },
+    ])
+    expect(variants.get('svc-a')?.color).toBe(VARIANT_ACCENT[0])
+    expect(variants.get('svc-b')?.color).toBe(VARIANT_ACCENT[1])
+    expect(variants.get('svc-c')?.color).toBe(VARIANT_ACCENT[2])
+  })
+
+  it('shares a counter between service and custom nodes (they fall back to the same sprite)', () => {
+    const variants = assignNodeVariants([
+      { id: 'svc', type: 'service' },
+      { id: 'cust', type: 'custom' },
+    ])
+    expect(variants.get('svc')?.color).toBe(VARIANT_ACCENT[0])
+    expect(variants.get('cust')?.color).toBe(VARIANT_ACCENT[1])
+  })
+
+  it('first variant has no filter, subsequent variants set a hue-rotate filter', () => {
+    const variants = assignNodeVariants([
+      { id: 'a', type: 'service' },
+      { id: 'b', type: 'service' },
+    ])
+    expect(variants.get('a')?.filter).toBeUndefined()
+    expect(variants.get('b')?.filter).toBeTruthy()
+  })
+})
+
+describe('multiDataPixelColor', () => {
+  it('returns palette[index] for direct indices and wraps around at the end', () => {
+    expect(multiDataPixelColor(0)).toBe(VARIANT_ACCENT[0])
+    expect(multiDataPixelColor(1)).toBe(VARIANT_ACCENT[1])
+    expect(multiDataPixelColor(VARIANT_ACCENT.length)).toBe(VARIANT_ACCENT[0])
+  })
+})

--- a/packages/web/src/components/FlowCanvas.tsx
+++ b/packages/web/src/components/FlowCanvas.tsx
@@ -19,6 +19,7 @@ import { useFlowAnimation, type EdgeFlowRef, type StepEdgeMapping } from '../hoo
 import { useFlowGraphLayout } from '../hooks/useFlowGraphLayout'
 import { DataPixel } from './DataPixel'
 import { DataPopup } from './DataPopup'
+import { assignNodeVariants, multiDataPixelColor } from '../lib/pixel-palette'
 import type { Flow, FlowStep } from '../types'
 
 const nodeTypes: NodeTypes = {
@@ -226,11 +227,24 @@ function FlowCanvasInner({
     [pinnedEdge, edgeStepsById]
   )
 
-  // Build a map from node id to node type for pixel coloring
+  // Build a map from node id to node type and variant color for pixel coloring.
+  // Variant colors mirror the sprite-filter cycle in flow-layout so a node's
+  // animated pixels match the visible hue of its sprite, even when several
+  // nodes of the same type share the fallback service sprite.
   const nodeTypeMap = useMemo(() => {
+    const variants = assignNodeVariants(
+      flow.flow.nodes.map((n) => ({ id: n.id, type: n.type ?? 'service' }))
+    )
     const map = new Map<string, { type: string; color?: string }>()
     for (const n of flow.flow.nodes) {
-      map.set(n.id, { type: n.type ?? 'service', color: n.color })
+      // Custom-typed nodes with an explicit hex color keep that color (it
+      // already drives the sprite tint). Other nodes use their variant color
+      // so the pixel matches the cycled sprite hue.
+      const explicit = n.type === 'custom' && n.color ? n.color : undefined
+      map.set(n.id, {
+        type: n.type ?? 'service',
+        color: explicit ?? variants.get(n.id)?.color,
+      })
     }
     return map
   }, [flow])
@@ -600,7 +614,9 @@ function FlowCanvasInner({
           }
           const edgeStep = edgeFlow.step ?? animState.activeStep!
 
-          // If the step has array data, render one pixel per data object with stagger
+          // If the step has array data, render one pixel per data object with
+          // stagger. Each pixel gets a distinct color cycling through the
+          // variant palette unless the data entry has its own `color`.
           if (Array.isArray(edgeStep.data)) {
             return edgeStep.data.map((dataObj, dataIndex) => (
               <DataPixel
@@ -609,6 +625,7 @@ function FlowCanvasInner({
                 reverse={edgeFlow.reverse}
                 sourceNodeType={sourceInfo.type}
                 sourceNodeColor={sourceInfo.color}
+                pixelColor={dataObj.color ?? multiDataPixelColor(dataIndex)}
                 step={edgeStep}
                 containerRef={containerRef}
                 onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}
@@ -618,6 +635,12 @@ function FlowCanvasInner({
             ))
           }
 
+          // Single-object data: respect an explicit `data.color` if set, else
+          // fall back to the source node's variant color via sourceNodeColor.
+          const singleColor =
+            edgeStep.data && typeof edgeStep.data === 'object' && !Array.isArray(edgeStep.data)
+              ? edgeStep.data.color
+              : undefined
           return (
             <DataPixel
               key={`${edgeFlow.edgeId}-${edgeFlow.reverse ? 'r' : 'f'}-${edgeFlowIndex}`}
@@ -625,6 +648,7 @@ function FlowCanvasInner({
               reverse={edgeFlow.reverse}
               sourceNodeType={sourceInfo.type}
               sourceNodeColor={sourceInfo.color}
+              pixelColor={singleColor}
               step={edgeStep}
               containerRef={containerRef}
               onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}

--- a/packages/web/src/lib/flow-layout.ts
+++ b/packages/web/src/lib/flow-layout.ts
@@ -2,6 +2,7 @@ import ELK from 'elkjs'
 import type { Edge, Node } from '@xyflow/react'
 import type { Flow } from '../types'
 import type { FlowNodeData } from '../components/nodes/FlowNode'
+import { assignNodeVariants } from './pixel-palette'
 
 const elk = new ELK()
 
@@ -712,42 +713,22 @@ export function buildReactFlowGraph(
 
   // Color-variant cycle: when several nodes share the same sprite and have no
   // custom icon, each successive one gets a different CSS filter so viewers
-  // can tell them apart at a glance. The accent palette parallels the sprite
-  // filter so the label, drop-shadow, and progress bar match the sprite's
-  // visible hue.
-  const VARIANT_CYCLE: string[] = [
-    '', // original (orange)
-    'hue-rotate(210deg)', // purple
-    'hue-rotate(90deg)', // green
-    'hue-rotate(140deg)', // blue
-    'hue-rotate(320deg)', // red
-    'hue-rotate(60deg) saturate(1.2)', // yellow (was grey)
-  ]
-  const VARIANT_ACCENT: string[] = [
-    '#ff8a4a', // orange
-    '#b47aff', // purple
-    '#4aff7a', // green
-    '#4a9eff', // blue
-    '#ff6b6b', // red
-    '#ffd84a', // yellow
-  ]
-  const spriteVariantCounters = new Map<string, number>()
-
-  // Nodes that fall back to the service sprite (e.g. `custom`) share the same
-  // variant counter, so five `custom` + five `service` nodes cycle through
-  // the six colors as a single pool instead of restarting per type.
-  const FALLBACK_SPRITE_KEY = 'service'
-  const TYPES_SHARING_SERVICE_SPRITE = new Set(['service', 'custom'])
+  // can tell them apart at a glance. The same palette is reused for animated
+  // pixel colors in FlowCanvas so a node's data pixels match its sprite hue.
+  const variants = assignNodeVariants(
+    topology.orderedIds.map((id) => ({
+      id,
+      type: topology.nodeSnapshots.get(id)?.nodeType ?? 'service',
+    }))
+  )
 
   const nodes: Node<FlowNodeData>[] = topology.orderedIds.map((id) => {
     const snapshot = topology.nodeSnapshots.get(id)
     const position = positionMap.get(id) ?? defaultPosition()
     const nodeType = snapshot?.nodeType ?? 'service'
-    const counterKey = TYPES_SHARING_SERVICE_SPRITE.has(nodeType) ? FALLBACK_SPRITE_KEY : nodeType
-    const n = spriteVariantCounters.get(counterKey) ?? 0
-    const variantFilter = VARIANT_CYCLE[n % VARIANT_CYCLE.length] || undefined
-    const variantColor = VARIANT_ACCENT[n % VARIANT_ACCENT.length]
-    spriteVariantCounters.set(counterKey, n + 1)
+    const variant = variants.get(id)
+    const variantFilter = variant?.filter
+    const variantColor = variant?.color ?? '#ff8a4a'
 
     return {
       id,

--- a/packages/web/src/lib/pixel-palette.ts
+++ b/packages/web/src/lib/pixel-palette.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared color-variant palette for sprite filters and animated pixel colors.
+ * When several nodes resolve to the same fallback sprite, each successive one
+ * cycles to a different hue — both the node's CSS filter and the data
+ * pixel's drop-shadow read from this palette so they always agree.
+ */
+
+export const VARIANT_FILTER: readonly string[] = [
+  '', // original (orange)
+  'hue-rotate(210deg)', // purple
+  'hue-rotate(90deg)', // green
+  'hue-rotate(140deg)', // blue
+  'hue-rotate(320deg)', // red
+  'hue-rotate(60deg) saturate(1.2)', // yellow
+]
+
+export const VARIANT_ACCENT: readonly string[] = [
+  '#ff8a4a', // orange
+  '#b47aff', // purple
+  '#4aff7a', // green
+  '#4a9eff', // blue
+  '#ff6b6b', // red
+  '#ffd84a', // yellow
+]
+
+const FALLBACK_SPRITE_KEY = 'service'
+const TYPES_SHARING_SERVICE_SPRITE = new Set(['service', 'custom'])
+
+export interface NodeVariant {
+  filter: string | undefined
+  color: string
+}
+
+/**
+ * Compute per-node variant assignments in the same order they're laid out.
+ * `nodes` must be in the same canonical order across all callers (this is
+ * what `topology.orderedIds` provides) so flow-layout's sprite filter and
+ * FlowCanvas's pixel color land on the same index for the same node.
+ */
+export function assignNodeVariants(
+  nodes: Array<{ id: string; type: string }>
+): Map<string, NodeVariant> {
+  const counters = new Map<string, number>()
+  const out = new Map<string, NodeVariant>()
+  for (const node of nodes) {
+    const counterKey = TYPES_SHARING_SERVICE_SPRITE.has(node.type) ? FALLBACK_SPRITE_KEY : node.type
+    const n = counters.get(counterKey) ?? 0
+    counters.set(counterKey, n + 1)
+    out.set(node.id, {
+      filter: VARIANT_FILTER[n % VARIANT_FILTER.length] || undefined,
+      color: VARIANT_ACCENT[n % VARIANT_ACCENT.length],
+    })
+  }
+  return out
+}
+
+/**
+ * Pick a palette color by index for multi-data pixels. Each pixel in a
+ * multi-data step gets a distinct default hue cycling through VARIANT_ACCENT.
+ */
+export function multiDataPixelColor(index: number): string {
+  return VARIANT_ACCENT[index % VARIANT_ACCENT.length]
+}


### PR DESCRIPTION
## Summary

Two animated-pixel coloring fixes:

### 1. Same-sprite nodes now have matching pixel hues

Before: `DataPixel` resolved its drop-shadow color from a hard-coded `NODE_COLORS` map keyed on raw node type. Two nodes that share the fallback sprite (e.g. \`api\` typed \`endpoint\` and \`worker\` typed \`service\`) appeared identically orange on the canvas but emitted pixels with mismatched shadows — \`api\` blue, \`worker\` grey — even though the visible sprite hue is the same.

Now: per-node variant assignment (filter + accent color) lives in a shared \`lib/pixel-palette.ts\` module. \`flow-layout.ts\` uses it for the sprite CSS filter; \`FlowCanvas\` builds \`nodeTypeMap\` with the same variant color so the pixel drop-shadow tracks the visible sprite hue.

### 2. Multi-data steps cycle the palette per pixel

When \`step.data\` is an array, multiple pixels travel together on one edge with a 120 ms stagger but previously shared a single color. Each pixel now gets a distinct hue from \`VARIANT_ACCENT\` by index (\`multiDataPixelColor(i)\`), unless the data entry has its own \`color\` set — explicit \`data.color\` always wins.

## Resolution order for a pixel's color
1. Explicit \`pixelColor\` prop on \`DataPixel\` (multi-data palette cycling, or single \`data.color\`)
2. \`sourceNodeColor\` (the source node's variant color, mirrors sprite hue)
3. Legacy \`NODE_COLORS[type]\` map (kept as a final fallback)

## Test plan
- [x] New unit tests for \`assignNodeVariants\` and \`multiDataPixelColor\` in \`packages/web/__tests__/pixel-palette.test.ts\` (5 cases).
- [x] All 16 web tests pass; \`npx tsc --noEmit\` clean; prettier clean.
- [ ] Visual: open \`examples/self-loops.yaml\` (api + worker both render with the same orange sprite) — pixels emitted from both should now have the same orange drop-shadow.
- [ ] Visual: api → api self-loop's multi-data step has 3 pixels — should show 3 different colors cycling through the palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a centralized color variant system for nodes, ensuring consistent visual styling based on node types.
  * Enhanced pixel overlay coloring with support for custom color specification per data point.

* **Tests**
  * Added comprehensive test coverage for color variant assignment and pixel color cycling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->