### PR TITLE
feat(web): pixel drop-shadow follows node variant + cycles per multi-data pixel

### DIFF
--- a/packages/web/__tests__/flow-layout.test.ts
+++ b/packages/web/__tests__/flow-layout.test.ts
@@ -80,6 +80,20 @@ describe('buildFlowTopology', () => {
       ['order-service', 'audit'],
     ])
   })
+
+  it('assigns the same variant color to first nodes of different sprite pools (matching sprite hue)', () => {
+    // api is `endpoint`, order-service is `service`. Both are the first node
+    // in their respective sprite pools, so both render with the original
+    // (orange) sprite — and both get the same VARIANT_ACCENT[0] accent so
+    // their animated pixel drop-shadows match the visible sprite hue.
+    const topology = buildFlowTopology(orderFlow)
+    const apiVariant = topology.nodeVariants.get('api')
+    const svcVariant = topology.nodeVariants.get('order-service')
+    expect(apiVariant?.color).toBeDefined()
+    expect(svcVariant?.color).toBe(apiVariant?.color)
+    expect(apiVariant?.filter).toBeUndefined()
+    expect(svcVariant?.filter).toBeUndefined()
+  })
 })
 
 describe('computeElkLayout', () => {

--- a/packages/web/__tests__/pixel-palette.test.ts
+++ b/packages/web/__tests__/pixel-palette.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   VARIANT_ACCENT,
   assignNodeVariants,
-  multiDataPixelColor,
-  multiDataPixelFilter,
+  stepPixelColor,
+  stepPixelFilter,
 } from '../src/lib/pixel-palette'
 
 describe('assignNodeVariants', () => {
@@ -46,21 +46,21 @@ describe('assignNodeVariants', () => {
   })
 })
 
-describe('multiDataPixelColor', () => {
+describe('stepPixelColor', () => {
   it('returns palette[index] and wraps around at the end', () => {
-    expect(multiDataPixelColor(0)).toBe(VARIANT_ACCENT[0])
-    expect(multiDataPixelColor(1)).toBe(VARIANT_ACCENT[1])
-    expect(multiDataPixelColor(VARIANT_ACCENT.length)).toBe(VARIANT_ACCENT[0])
+    expect(stepPixelColor(0)).toBe(VARIANT_ACCENT[0])
+    expect(stepPixelColor(1)).toBe(VARIANT_ACCENT[1])
+    expect(stepPixelColor(VARIANT_ACCENT.length)).toBe(VARIANT_ACCENT[0])
   })
 })
 
-describe('multiDataPixelFilter', () => {
+describe('stepPixelFilter', () => {
   it('returns undefined for index 0 (the original orange sprite, no filter)', () => {
-    expect(multiDataPixelFilter(0)).toBeUndefined()
+    expect(stepPixelFilter(0)).toBeUndefined()
   })
 
   it('returns a hue-rotate filter for subsequent indices', () => {
-    expect(multiDataPixelFilter(1)).toMatch(/hue-rotate/)
-    expect(multiDataPixelFilter(2)).toMatch(/hue-rotate/)
+    expect(stepPixelFilter(1)).toMatch(/hue-rotate/)
+    expect(stepPixelFilter(2)).toMatch(/hue-rotate/)
   })
 })

--- a/packages/web/__tests__/pixel-palette.test.ts
+++ b/packages/web/__tests__/pixel-palette.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { VARIANT_ACCENT, assignNodeVariants, multiDataPixelColor } from '../src/lib/pixel-palette'
+
+describe('assignNodeVariants', () => {
+  it('gives the first node of each independent type the original (orange) accent', () => {
+    const variants = assignNodeVariants([
+      { id: 'api', type: 'endpoint' },
+      { id: 'db', type: 'database' },
+    ])
+    expect(variants.get('api')?.color).toBe(VARIANT_ACCENT[0])
+    expect(variants.get('db')?.color).toBe(VARIANT_ACCENT[0])
+  })
+
+  it('cycles successive same-type-pool nodes through the palette', () => {
+    const variants = assignNodeVariants([
+      { id: 'svc-a', type: 'service' },
+      { id: 'svc-b', type: 'service' },
+      { id: 'svc-c', type: 'service' },
+    ])
+    expect(variants.get('svc-a')?.color).toBe(VARIANT_ACCENT[0])
+    expect(variants.get('svc-b')?.color).toBe(VARIANT_ACCENT[1])
+    expect(variants.get('svc-c')?.color).toBe(VARIANT_ACCENT[2])
+  })
+
+  it('shares a counter between service and custom (they fall back to the same sprite)', () => {
+    const variants = assignNodeVariants([
+      { id: 'svc', type: 'service' },
+      { id: 'cust', type: 'custom' },
+    ])
+    expect(variants.get('svc')?.color).toBe(VARIANT_ACCENT[0])
+    expect(variants.get('cust')?.color).toBe(VARIANT_ACCENT[1])
+  })
+
+  it('first variant has no filter, subsequent variants get a hue-rotate filter', () => {
+    const variants = assignNodeVariants([
+      { id: 'a', type: 'service' },
+      { id: 'b', type: 'service' },
+    ])
+    expect(variants.get('a')?.filter).toBeUndefined()
+    expect(variants.get('b')?.filter).toBeTruthy()
+  })
+})
+
+describe('multiDataPixelColor', () => {
+  it('returns palette[index] and wraps around at the end', () => {
+    expect(multiDataPixelColor(0)).toBe(VARIANT_ACCENT[0])
+    expect(multiDataPixelColor(1)).toBe(VARIANT_ACCENT[1])
+    expect(multiDataPixelColor(VARIANT_ACCENT.length)).toBe(VARIANT_ACCENT[0])
+  })
+})

--- a/packages/web/__tests__/pixel-palette.test.ts
+++ b/packages/web/__tests__/pixel-palette.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { VARIANT_ACCENT, assignNodeVariants, multiDataPixelColor } from '../src/lib/pixel-palette'
+import {
+  VARIANT_ACCENT,
+  assignNodeVariants,
+  multiDataPixelColor,
+  multiDataPixelFilter,
+} from '../src/lib/pixel-palette'
 
 describe('assignNodeVariants', () => {
   it('gives the first node of each independent type the original (orange) accent', () => {
@@ -46,5 +51,16 @@ describe('multiDataPixelColor', () => {
     expect(multiDataPixelColor(0)).toBe(VARIANT_ACCENT[0])
     expect(multiDataPixelColor(1)).toBe(VARIANT_ACCENT[1])
     expect(multiDataPixelColor(VARIANT_ACCENT.length)).toBe(VARIANT_ACCENT[0])
+  })
+})
+
+describe('multiDataPixelFilter', () => {
+  it('returns undefined for index 0 (the original orange sprite, no filter)', () => {
+    expect(multiDataPixelFilter(0)).toBeUndefined()
+  })
+
+  it('returns a hue-rotate filter for subsequent indices', () => {
+    expect(multiDataPixelFilter(1)).toMatch(/hue-rotate/)
+    expect(multiDataPixelFilter(2)).toMatch(/hue-rotate/)
   })
 })

--- a/packages/web/__tests__/pixel-palette.test.ts
+++ b/packages/web/__tests__/pixel-palette.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   VARIANT_ACCENT,
   assignNodeVariants,
+  resolvePixelStyle,
   stepPixelColor,
   stepPixelFilter,
 } from '../src/lib/pixel-palette'
@@ -62,5 +63,30 @@ describe('stepPixelFilter', () => {
   it('returns a hue-rotate filter for subsequent indices', () => {
     expect(stepPixelFilter(1)).toMatch(/hue-rotate/)
     expect(stepPixelFilter(2)).toMatch(/hue-rotate/)
+  })
+})
+
+describe('resolvePixelStyle', () => {
+  it('cycles palette per pixel when the step has 2+ carrots and no explicit data color', () => {
+    expect(resolvePixelStyle(true, 0)).toEqual({
+      pixelColor: VARIANT_ACCENT[0],
+      pixelFilter: undefined,
+    })
+    expect(resolvePixelStyle(true, 1).pixelColor).toBe(VARIANT_ACCENT[1])
+    expect(resolvePixelStyle(true, 1).pixelFilter).toMatch(/hue-rotate/)
+  })
+
+  it('returns no overrides for single-carrot steps so DataPixel falls back to the variant color', () => {
+    expect(resolvePixelStyle(false, 0)).toEqual({
+      pixelColor: undefined,
+      pixelFilter: undefined,
+    })
+  })
+
+  it('respects an explicit data.color and suppresses the sprite filter', () => {
+    expect(resolvePixelStyle(true, 1, '#123456')).toEqual({
+      pixelColor: '#123456',
+      pixelFilter: undefined,
+    })
   })
 })

--- a/packages/web/src/components/DataPixel.tsx
+++ b/packages/web/src/components/DataPixel.tsx
@@ -25,6 +25,10 @@ interface DataPixelProps {
   /** Per-pixel override (multi-data palette cycling, or explicit
    *  data.color). Wins over sourceNodeColor and the type fallback. */
   pixelColor?: string
+  /** Optional CSS filter applied to the carrot sprite itself (e.g.
+   *  hue-rotate) so the visible carrot color matches its drop-shadow.
+   *  Used for multi-data palette cycling. */
+  pixelFilter?: string
   step: FlowStep
   containerRef: React.RefObject<HTMLDivElement | null>
   isManual?: boolean
@@ -44,6 +48,7 @@ export function DataPixel({
   sourceNodeType,
   sourceNodeColor,
   pixelColor,
+  pixelFilter,
   step,
   containerRef,
   isManual,
@@ -192,7 +197,10 @@ export function DataPixel({
         <div
           className="data-pixel-sprite"
           style={{
-            filter: `drop-shadow(0 0 6px ${color})`,
+            // Stack the optional hue-rotate sprite filter (multi-data palette
+            // cycling) with the drop-shadow so the carrot itself takes on the
+            // pixel's hue, not just its glow.
+            filter: [pixelFilter, `drop-shadow(0 0 6px ${color})`].filter(Boolean).join(' '),
           }}
         >
           <img

--- a/packages/web/src/components/DataPixel.tsx
+++ b/packages/web/src/components/DataPixel.tsx
@@ -1,33 +1,22 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import type { FlowStep, FlowData } from '../types'
 import { DataTooltip } from './DataTooltip'
-const CARROT_SPRITE = '/sprites/carrot_pixels.svg'
 
-/** Node type colors — must match FlowNode.tsx NODE_STYLES */
-const NODE_COLORS: Record<string, string> = {
-  actor: '#4a9eff',
-  endpoint: '#4a9eff',
-  transform: '#b47aff',
-  database: '#4aff7a',
-  external: '#ff8a4a',
-  cache: '#4affee',
-  queue: '#4aeeff',
-  service: '#888',
-}
+const CARROT_SPRITE = '/sprites/carrot_pixels.svg'
+const DEFAULT_PIXEL_COLOR = '#ff8a4a' // VARIANT_ACCENT[0] — sprite's original orange.
 
 interface DataPixelProps {
   edgeId: string
   reverse?: boolean
-  sourceNodeType: string
-  /** Source node's variant color — drives the pixel drop-shadow when
-   *  pixelColor is not set. */
+  /** Source node's variant color from topology — drives the pixel
+   *  drop-shadow when pixelColor isn't set. */
   sourceNodeColor?: string
-  /** Per-pixel override (multi-data palette cycling, or explicit
-   *  data.color). Wins over sourceNodeColor and the type fallback. */
+  /** Per-pixel color override (palette cycling, or explicit data.color).
+   *  Wins over sourceNodeColor. */
   pixelColor?: string
-  /** Optional CSS filter applied to the carrot sprite itself (e.g.
-   *  hue-rotate) so the visible carrot color matches its drop-shadow.
-   *  Used for multi-data palette cycling. */
+  /** Optional CSS hue-rotate applied to the carrot sprite so its body
+   *  recolors to match pixelColor — without it, the orange sprite
+   *  visually dominates the colored drop-shadow. */
   pixelFilter?: string
   step: FlowStep
   containerRef: React.RefObject<HTMLDivElement | null>
@@ -45,7 +34,6 @@ const ANIMATION_DURATION_BASE = 1800
 export function DataPixel({
   edgeId,
   reverse = false,
-  sourceNodeType,
   sourceNodeColor,
   pixelColor,
   pixelFilter,
@@ -67,12 +55,9 @@ export function DataPixel({
   }, [onAnimationComplete])
   const [hovered, setHovered] = useState(false)
   const [position, setPosition] = useState<{ x: number; y: number } | null>(null)
-  // Pixel drop-shadow color resolution order:
-  //   1. explicit pixelColor (multi-data palette cycling, or data.color)
-  //   2. sourceNodeColor (variant color computed from topology — keeps the
-  //      shadow in lockstep with the sprite hue)
-  //   3. legacy NODE_COLORS by type, kept as a fallback
-  const color = pixelColor ?? sourceNodeColor ?? NODE_COLORS[sourceNodeType] ?? '#888'
+  // pixelColor (palette cycling / data.color) > sourceNodeColor (variant
+  // color from topology, keeps shadow in lockstep with sprite hue) > orange.
+  const color = pixelColor ?? sourceNodeColor ?? DEFAULT_PIXEL_COLOR
 
   const dataLabel = dataOverride
     ? dataOverride.label

--- a/packages/web/src/components/DataPixel.tsx
+++ b/packages/web/src/components/DataPixel.tsx
@@ -197,10 +197,7 @@ export function DataPixel({
         <div
           className="data-pixel-sprite"
           style={{
-            // Stack the optional hue-rotate sprite filter (multi-data palette
-            // cycling) with the drop-shadow so the carrot itself takes on the
-            // pixel's hue, not just its glow.
-            filter: [pixelFilter, `drop-shadow(0 0 6px ${color})`].filter(Boolean).join(' '),
+            filter: `drop-shadow(0 0 6px ${color})`,
           }}
         >
           <img
@@ -211,6 +208,10 @@ export function DataPixel({
               height: '100%',
               imageRendering: 'pixelated',
               display: 'block',
+              // Hue-rotate is applied directly to the <img> so the carrot's
+              // own pixel colors shift (the wrapper's drop-shadow then reads
+              // from the rotated alpha, keeping the glow in sync).
+              filter: pixelFilter,
             }}
           />
         </div>

--- a/packages/web/src/components/DataPixel.tsx
+++ b/packages/web/src/components/DataPixel.tsx
@@ -19,7 +19,12 @@ interface DataPixelProps {
   edgeId: string
   reverse?: boolean
   sourceNodeType: string
+  /** Source node's variant color — drives the pixel drop-shadow when
+   *  pixelColor is not set. */
   sourceNodeColor?: string
+  /** Per-pixel override (multi-data palette cycling, or explicit
+   *  data.color). Wins over sourceNodeColor and the type fallback. */
+  pixelColor?: string
   step: FlowStep
   containerRef: React.RefObject<HTMLDivElement | null>
   isManual?: boolean
@@ -38,6 +43,7 @@ export function DataPixel({
   reverse = false,
   sourceNodeType,
   sourceNodeColor,
+  pixelColor,
   step,
   containerRef,
   isManual,
@@ -56,11 +62,12 @@ export function DataPixel({
   }, [onAnimationComplete])
   const [hovered, setHovered] = useState(false)
   const [position, setPosition] = useState<{ x: number; y: number } | null>(null)
-  // Determine pixel color from source node type
-  const color =
-    sourceNodeType === 'custom' && sourceNodeColor
-      ? sourceNodeColor
-      : (NODE_COLORS[sourceNodeType] ?? '#888')
+  // Pixel drop-shadow color resolution order:
+  //   1. explicit pixelColor (multi-data palette cycling, or data.color)
+  //   2. sourceNodeColor (variant color computed from topology — keeps the
+  //      shadow in lockstep with the sprite hue)
+  //   3. legacy NODE_COLORS by type, kept as a fallback
+  const color = pixelColor ?? sourceNodeColor ?? NODE_COLORS[sourceNodeType] ?? '#888'
 
   const dataLabel = dataOverride
     ? dataOverride.label

--- a/packages/web/src/components/FlowCanvas.tsx
+++ b/packages/web/src/components/FlowCanvas.tsx
@@ -19,6 +19,8 @@ import { useFlowAnimation, type EdgeFlowRef, type StepEdgeMapping } from '../hoo
 import { useFlowGraphLayout } from '../hooks/useFlowGraphLayout'
 import { DataPixel } from './DataPixel'
 import { DataPopup } from './DataPopup'
+import { buildFlowTopology } from '../lib/flow-layout'
+import { multiDataPixelColor } from '../lib/pixel-palette'
 import type { Flow, FlowStep } from '../types'
 
 const nodeTypes: NodeTypes = {
@@ -226,11 +228,22 @@ function FlowCanvasInner({
     [pinnedEdge, edgeStepsById]
   )
 
-  // Build a map from node id to node type for pixel coloring
+  // Build a map from node id to type and shadow color for animated pixels.
+  // The shadow color comes from the topology's variant assignment so it
+  // stays in lockstep with the sprite filter cycle in flow-layout — same
+  // sprite hue → same pixel shadow.
   const nodeTypeMap = useMemo(() => {
+    const topology = buildFlowTopology(flow)
     const map = new Map<string, { type: string; color?: string }>()
     for (const n of flow.flow.nodes) {
-      map.set(n.id, { type: n.type ?? 'service', color: n.color })
+      // A `custom`-typed node with an explicit hex color keeps that color
+      // (it already drives the sprite tint via FlowNode). Other nodes use
+      // the variant accent color from the shared palette.
+      const explicit = n.type === 'custom' && n.color ? n.color : undefined
+      map.set(n.id, {
+        type: n.type ?? 'service',
+        color: explicit ?? topology.nodeVariants.get(n.id)?.color,
+      })
     }
     return map
   }, [flow])
@@ -600,7 +613,9 @@ function FlowCanvasInner({
           }
           const edgeStep = edgeFlow.step ?? animState.activeStep!
 
-          // If the step has array data, render one pixel per data object with stagger
+          // Multi-data: render one pixel per data object with stagger AND a
+          // distinct shadow hue cycling through the variant palette. An
+          // explicit `data[i].color` always wins.
           if (Array.isArray(edgeStep.data)) {
             return edgeStep.data.map((dataObj, dataIndex) => (
               <DataPixel
@@ -609,6 +624,7 @@ function FlowCanvasInner({
                 reverse={edgeFlow.reverse}
                 sourceNodeType={sourceInfo.type}
                 sourceNodeColor={sourceInfo.color}
+                pixelColor={dataObj.color ?? multiDataPixelColor(dataIndex)}
                 step={edgeStep}
                 containerRef={containerRef}
                 onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}
@@ -618,6 +634,13 @@ function FlowCanvasInner({
             ))
           }
 
+          // Single-object data: respect explicit `data.color`; otherwise the
+          // pixel falls back to the source node's variant color via the
+          // sourceNodeColor pipe.
+          const singleColor =
+            edgeStep.data && typeof edgeStep.data === 'object' && !Array.isArray(edgeStep.data)
+              ? edgeStep.data.color
+              : undefined
           return (
             <DataPixel
               key={`${edgeFlow.edgeId}-${edgeFlow.reverse ? 'r' : 'f'}-${edgeFlowIndex}`}
@@ -625,6 +648,7 @@ function FlowCanvasInner({
               reverse={edgeFlow.reverse}
               sourceNodeType={sourceInfo.type}
               sourceNodeColor={sourceInfo.color}
+              pixelColor={singleColor}
               step={edgeStep}
               containerRef={containerRef}
               onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}

--- a/packages/web/src/components/FlowCanvas.tsx
+++ b/packages/web/src/components/FlowCanvas.tsx
@@ -277,18 +277,22 @@ function FlowCanvasInner({
   // Build a map from node id to type and shadow color for animated pixels.
   // The shadow color comes from the topology's variant assignment so it
   // stays in lockstep with the sprite filter cycle in flow-layout — same
-  // sprite hue → same pixel shadow.
+  // sprite hue → same pixel shadow. Iterating topology.nodeSnapshots
+  // (rather than just flow.flow.nodes) also covers dynamic nodes spawned
+  // by `create:` steps so their pixels get a real variant color too.
   const nodeTypeMap = useMemo(() => {
     const topology = buildFlowTopology(flow)
-    const map = new Map<string, { type: string; color?: string }>()
+    const explicitColors = new Map<string, string>()
     for (const n of flow.flow.nodes) {
       // A `custom`-typed node with an explicit hex color keeps that color
-      // (it already drives the sprite tint via FlowNode). Other nodes use
-      // the variant accent color from the shared palette.
-      const explicit = n.type === 'custom' && n.color ? n.color : undefined
-      map.set(n.id, {
-        type: n.type ?? 'service',
-        color: explicit ?? topology.nodeVariants.get(n.id)?.color,
+      // (it already drives the sprite tint via FlowNode).
+      if (n.type === 'custom' && n.color) explicitColors.set(n.id, n.color)
+    }
+    const map = new Map<string, { type: string; color?: string }>()
+    for (const [id, snapshot] of topology.nodeSnapshots) {
+      map.set(id, {
+        type: snapshot.nodeType,
+        color: explicitColors.get(id) ?? topology.nodeVariants.get(id)?.color,
       })
     }
     return map

--- a/packages/web/src/components/FlowCanvas.tsx
+++ b/packages/web/src/components/FlowCanvas.tsx
@@ -20,7 +20,7 @@ import { useFlowGraphLayout } from '../hooks/useFlowGraphLayout'
 import { DataPixel } from './DataPixel'
 import { DataPopup } from './DataPopup'
 import { buildFlowTopology } from '../lib/flow-layout'
-import { multiDataPixelColor } from '../lib/pixel-palette'
+import { multiDataPixelColor, multiDataPixelFilter } from '../lib/pixel-palette'
 import type { Flow, FlowStep } from '../types'
 
 const nodeTypes: NodeTypes = {
@@ -625,6 +625,7 @@ function FlowCanvasInner({
                 sourceNodeType={sourceInfo.type}
                 sourceNodeColor={sourceInfo.color}
                 pixelColor={dataObj.color ?? multiDataPixelColor(dataIndex)}
+                pixelFilter={dataObj.color ? undefined : multiDataPixelFilter(dataIndex)}
                 step={edgeStep}
                 containerRef={containerRef}
                 onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}

--- a/packages/web/src/components/FlowCanvas.tsx
+++ b/packages/web/src/components/FlowCanvas.tsx
@@ -629,7 +629,10 @@ function FlowCanvasInner({
                 step={edgeStep}
                 containerRef={containerRef}
                 onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}
-                delayMs={dataIndex * 120}
+                // 280ms stagger keeps successive pixels far enough apart on
+                // the path that distinct hues are visible even on short
+                // self-loop ears (~100px); shorter stagger overlapped them.
+                delayMs={dataIndex * 280}
                 dataOverride={dataObj}
               />
             ))

--- a/packages/web/src/components/FlowCanvas.tsx
+++ b/packages/web/src/components/FlowCanvas.tsx
@@ -20,7 +20,7 @@ import { useFlowGraphLayout } from '../hooks/useFlowGraphLayout'
 import { DataPixel } from './DataPixel'
 import { DataPopup } from './DataPopup'
 import { buildFlowTopology } from '../lib/flow-layout'
-import { multiDataPixelColor, multiDataPixelFilter } from '../lib/pixel-palette'
+import { stepPixelColor, stepPixelFilter } from '../lib/pixel-palette'
 import type { Flow, FlowStep } from '../types'
 
 const nodeTypes: NodeTypes = {
@@ -422,17 +422,55 @@ function FlowCanvasInner({
         return // no pixel to fire
       }
 
-      // Fire a pixel for EACH edge flow in this logical step (broadcast = multiple edges)
+      // Fire a pixel for EACH edge flow in this logical step. A multi-data
+      // step expands one edgeFlow into N pixels (one per data entry). The
+      // total pixel count drives whether colors cycle through the variant
+      // palette: 2+ → cycle so each carrot is visually distinct; 1 → keep
+      // the source node's variant color.
+      const totalPixels = entry.edgeFlows.reduce((sum, ef) => {
+        const s = ef.step ?? entry.step
+        return sum + (Array.isArray(s.data) ? s.data.length : 1)
+      }, 0)
+      const cycle = totalPixels >= 2
+      let pixelIdx = 0
       for (const edgeFlow of entry.edgeFlows) {
-        fireManualPixel({
-          edgeId: edgeFlow.edgeId,
-          reverse: edgeFlow.reverse,
-          step: edgeFlow.step,
-          sourceNodeId: nodeId,
-          sourceStepIndex: currentProg,
-          sourceNodeType: sourceInfo.type,
-          sourceNodeColor: sourceInfo.color,
-        })
+        const stepData = (edgeFlow.step ?? entry.step).data
+        if (Array.isArray(stepData)) {
+          for (let i = 0; i < stepData.length; i++) {
+            const dataObj = stepData[i]
+            const idx = pixelIdx++
+            fireManualPixel({
+              edgeId: edgeFlow.edgeId,
+              reverse: edgeFlow.reverse,
+              step: edgeFlow.step,
+              sourceNodeId: nodeId,
+              sourceStepIndex: currentProg,
+              sourceNodeType: sourceInfo.type,
+              sourceNodeColor: sourceInfo.color,
+              pixelColor: dataObj.color ?? (cycle ? stepPixelColor(idx) : undefined),
+              pixelFilter: dataObj.color || !cycle ? undefined : stepPixelFilter(idx),
+              dataOverride: dataObj,
+              delayMs: i * 280,
+            })
+          }
+        } else {
+          const singleColor =
+            stepData && typeof stepData === 'object' && !Array.isArray(stepData)
+              ? stepData.color
+              : undefined
+          const idx = pixelIdx++
+          fireManualPixel({
+            edgeId: edgeFlow.edgeId,
+            reverse: edgeFlow.reverse,
+            step: edgeFlow.step,
+            sourceNodeId: nodeId,
+            sourceStepIndex: currentProg,
+            sourceNodeType: sourceInfo.type,
+            sourceNodeColor: sourceInfo.color,
+            pixelColor: singleColor ?? (cycle ? stepPixelColor(idx) : undefined),
+            pixelFilter: singleColor || !cycle ? undefined : stepPixelFilter(idx),
+          })
+        }
       }
     },
     [
@@ -605,60 +643,66 @@ function FlowCanvasInner({
         />
       </ReactFlow>
 
-      {/* Data pixel overlay — automatic */}
+      {/* Data pixel overlay — automatic. When a step emits 2+ pixels (multi-
+          data on one edge, a broadcast across several edges, or a parallel
+          step combining both), every carrot gets a distinct hue from the
+          variant palette indexed across the WHOLE step. Single-pixel steps
+          keep the source node's variant color. */}
       {animState.activeStep &&
-        activeEdgeFlows.flatMap((edgeFlow, edgeFlowIndex) => {
-          const sourceInfo = nodeTypeMap.get(edgeFlow.fromId) ?? {
-            type: 'service',
-          }
-          const edgeStep = edgeFlow.step ?? animState.activeStep!
+        (() => {
+          const totalPixels = activeEdgeFlows.reduce((sum, ef) => {
+            const s = ef.step ?? animState.activeStep!
+            return sum + (Array.isArray(s.data) ? s.data.length : 1)
+          }, 0)
+          const cycle = totalPixels >= 2
+          let pixelIdx = 0
+          return activeEdgeFlows.flatMap((edgeFlow, edgeFlowIndex) => {
+            const sourceInfo = nodeTypeMap.get(edgeFlow.fromId) ?? { type: 'service' }
+            const edgeStep = edgeFlow.step ?? animState.activeStep!
 
-          // Multi-data: render one pixel per data object with stagger AND a
-          // distinct shadow hue cycling through the variant palette. An
-          // explicit `data[i].color` always wins.
-          if (Array.isArray(edgeStep.data)) {
-            return edgeStep.data.map((dataObj, dataIndex) => (
+            if (Array.isArray(edgeStep.data)) {
+              return edgeStep.data.map((dataObj, dataIndex) => {
+                const idx = pixelIdx++
+                return (
+                  <DataPixel
+                    key={`${edgeFlow.edgeId}-${edgeFlow.reverse ? 'r' : 'f'}-${edgeFlowIndex}-${dataIndex}`}
+                    edgeId={edgeFlow.edgeId}
+                    reverse={edgeFlow.reverse}
+                    sourceNodeType={sourceInfo.type}
+                    sourceNodeColor={sourceInfo.color}
+                    pixelColor={dataObj.color ?? (cycle ? stepPixelColor(idx) : undefined)}
+                    pixelFilter={dataObj.color || !cycle ? undefined : stepPixelFilter(idx)}
+                    step={edgeStep}
+                    containerRef={containerRef}
+                    onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}
+                    delayMs={dataIndex * 280}
+                    dataOverride={dataObj}
+                  />
+                )
+              })
+            }
+
+            const singleColor =
+              edgeStep.data && typeof edgeStep.data === 'object' && !Array.isArray(edgeStep.data)
+                ? edgeStep.data.color
+                : undefined
+            const idx = pixelIdx++
+            return (
               <DataPixel
-                key={`${edgeFlow.edgeId}-${edgeFlow.reverse ? 'r' : 'f'}-${edgeFlowIndex}-${dataIndex}`}
+                key={`${edgeFlow.edgeId}-${edgeFlow.reverse ? 'r' : 'f'}-${edgeFlowIndex}`}
                 edgeId={edgeFlow.edgeId}
                 reverse={edgeFlow.reverse}
                 sourceNodeType={sourceInfo.type}
                 sourceNodeColor={sourceInfo.color}
-                pixelColor={dataObj.color ?? multiDataPixelColor(dataIndex)}
-                pixelFilter={dataObj.color ? undefined : multiDataPixelFilter(dataIndex)}
+                pixelColor={singleColor ?? (cycle ? stepPixelColor(idx) : undefined)}
+                pixelFilter={singleColor || !cycle ? undefined : stepPixelFilter(idx)}
                 step={edgeStep}
                 containerRef={containerRef}
                 onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}
-                // 280ms stagger keeps successive pixels far enough apart on
-                // the path that distinct hues are visible even on short
-                // self-loop ears (~100px); shorter stagger overlapped them.
-                delayMs={dataIndex * 280}
-                dataOverride={dataObj}
               />
-            ))
-          }
-
-          // Single-object data: respect explicit `data.color`; otherwise the
-          // pixel falls back to the source node's variant color via the
-          // sourceNodeColor pipe.
-          const singleColor =
-            edgeStep.data && typeof edgeStep.data === 'object' && !Array.isArray(edgeStep.data)
-              ? edgeStep.data.color
-              : undefined
-          return (
-            <DataPixel
-              key={`${edgeFlow.edgeId}-${edgeFlow.reverse ? 'r' : 'f'}-${edgeFlowIndex}`}
-              edgeId={edgeFlow.edgeId}
-              reverse={edgeFlow.reverse}
-              sourceNodeType={sourceInfo.type}
-              sourceNodeColor={sourceInfo.color}
-              pixelColor={singleColor}
-              step={edgeStep}
-              containerRef={containerRef}
-              onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}
-            />
-          )
-        })}
+            )
+          })
+        })()}
 
       {/* Data pixel overlay — manual (click-to-fire) */}
       {manualPixels.map((mp) => (
@@ -668,6 +712,10 @@ function FlowCanvasInner({
           reverse={mp.reverse}
           sourceNodeType={mp.sourceNodeType}
           sourceNodeColor={mp.sourceNodeColor}
+          pixelColor={mp.pixelColor}
+          pixelFilter={mp.pixelFilter}
+          dataOverride={mp.dataOverride}
+          delayMs={mp.delayMs}
           step={mp.step}
           containerRef={containerRef}
           isManual

--- a/packages/web/src/components/FlowCanvas.tsx
+++ b/packages/web/src/components/FlowCanvas.tsx
@@ -20,8 +20,54 @@ import { useFlowGraphLayout } from '../hooks/useFlowGraphLayout'
 import { DataPixel } from './DataPixel'
 import { DataPopup } from './DataPopup'
 import { buildFlowTopology } from '../lib/flow-layout'
-import { stepPixelColor, stepPixelFilter } from '../lib/pixel-palette'
-import type { Flow, FlowStep } from '../types'
+import { resolvePixelStyle, type ResolvedStepPixel } from '../lib/pixel-palette'
+import type { Flow, FlowStep, FlowData } from '../types'
+
+/** One carrot to render for a step. `dataObj` is set only for multi-data
+ *  steps (one item per data entry). Cycling is applied across the WHOLE
+ *  step so multi-data + broadcast + parallel carrots share one global
+ *  index — any 2+ carrots in a step render distinct hues. */
+interface StepPixelPlan extends ResolvedStepPixel {
+  edgeFlow: EdgeFlowRef
+  edgeFlowIndex: number
+  dataObj?: FlowData
+  dataIndex?: number
+  delayMs: number
+}
+
+function planStepPixels(edgeFlows: EdgeFlowRef[], fallbackStep?: FlowStep): StepPixelPlan[] {
+  const totalPixels = edgeFlows.reduce((sum, ef) => {
+    const data = (ef.step ?? fallbackStep)?.data
+    return sum + (Array.isArray(data) ? data.length : 1)
+  }, 0)
+  const cycle = totalPixels >= 2
+  const plans: StepPixelPlan[] = []
+  let pixelIdx = 0
+  edgeFlows.forEach((edgeFlow, edgeFlowIndex) => {
+    const data = (edgeFlow.step ?? fallbackStep)?.data
+    if (Array.isArray(data)) {
+      data.forEach((dataObj, dataIndex) => {
+        plans.push({
+          edgeFlow,
+          edgeFlowIndex,
+          dataObj,
+          dataIndex,
+          delayMs: dataIndex * 280,
+          ...resolvePixelStyle(cycle, pixelIdx++, dataObj.color),
+        })
+      })
+    } else {
+      const singleColor = data && typeof data === 'object' ? data.color : undefined
+      plans.push({
+        edgeFlow,
+        edgeFlowIndex,
+        delayMs: 0,
+        ...resolvePixelStyle(cycle, pixelIdx++, singleColor),
+      })
+    }
+  })
+  return plans
+}
 
 const nodeTypes: NodeTypes = {
   flowNode: FlowNodeComponent,
@@ -422,55 +468,21 @@ function FlowCanvasInner({
         return // no pixel to fire
       }
 
-      // Fire a pixel for EACH edge flow in this logical step. A multi-data
-      // step expands one edgeFlow into N pixels (one per data entry). The
-      // total pixel count drives whether colors cycle through the variant
-      // palette: 2+ → cycle so each carrot is visually distinct; 1 → keep
-      // the source node's variant color.
-      const totalPixels = entry.edgeFlows.reduce((sum, ef) => {
-        const s = ef.step ?? entry.step
-        return sum + (Array.isArray(s.data) ? s.data.length : 1)
-      }, 0)
-      const cycle = totalPixels >= 2
-      let pixelIdx = 0
-      for (const edgeFlow of entry.edgeFlows) {
-        const stepData = (edgeFlow.step ?? entry.step).data
-        if (Array.isArray(stepData)) {
-          for (let i = 0; i < stepData.length; i++) {
-            const dataObj = stepData[i]
-            const idx = pixelIdx++
-            fireManualPixel({
-              edgeId: edgeFlow.edgeId,
-              reverse: edgeFlow.reverse,
-              step: edgeFlow.step,
-              sourceNodeId: nodeId,
-              sourceStepIndex: currentProg,
-              sourceNodeType: sourceInfo.type,
-              sourceNodeColor: sourceInfo.color,
-              pixelColor: dataObj.color ?? (cycle ? stepPixelColor(idx) : undefined),
-              pixelFilter: dataObj.color || !cycle ? undefined : stepPixelFilter(idx),
-              dataOverride: dataObj,
-              delayMs: i * 280,
-            })
-          }
-        } else {
-          const singleColor =
-            stepData && typeof stepData === 'object' && !Array.isArray(stepData)
-              ? stepData.color
-              : undefined
-          const idx = pixelIdx++
-          fireManualPixel({
-            edgeId: edgeFlow.edgeId,
-            reverse: edgeFlow.reverse,
-            step: edgeFlow.step,
-            sourceNodeId: nodeId,
-            sourceStepIndex: currentProg,
-            sourceNodeType: sourceInfo.type,
-            sourceNodeColor: sourceInfo.color,
-            pixelColor: singleColor ?? (cycle ? stepPixelColor(idx) : undefined),
-            pixelFilter: singleColor || !cycle ? undefined : stepPixelFilter(idx),
-          })
-        }
+      // Click-to-fire uses the same plan as autoplay so manual pixels get
+      // the same multi-data expansion + palette cycling.
+      for (const plan of planStepPixels(entry.edgeFlows, entry.step)) {
+        fireManualPixel({
+          edgeId: plan.edgeFlow.edgeId,
+          reverse: plan.edgeFlow.reverse,
+          step: plan.edgeFlow.step,
+          sourceNodeId: nodeId,
+          sourceStepIndex: currentProg,
+          sourceNodeColor: sourceInfo.color,
+          pixelColor: plan.pixelColor,
+          pixelFilter: plan.pixelFilter,
+          dataOverride: plan.dataObj,
+          delayMs: plan.delayMs || undefined,
+        })
       }
     },
     [
@@ -643,66 +655,35 @@ function FlowCanvasInner({
         />
       </ReactFlow>
 
-      {/* Data pixel overlay — automatic. When a step emits 2+ pixels (multi-
-          data on one edge, a broadcast across several edges, or a parallel
-          step combining both), every carrot gets a distinct hue from the
-          variant palette indexed across the WHOLE step. Single-pixel steps
-          keep the source node's variant color. */}
+      {/* Data pixel overlay — automatic. planStepPixels handles the cycling
+          rule: any step emitting 2+ carrots (multi-data, broadcast, or
+          parallel) cycles the variant palette across the whole set so each
+          one is distinct; single-carrot steps keep the source node's
+          variant color via DataPixel's sourceNodeColor fallback. */}
       {animState.activeStep &&
-        (() => {
-          const totalPixels = activeEdgeFlows.reduce((sum, ef) => {
-            const s = ef.step ?? animState.activeStep!
-            return sum + (Array.isArray(s.data) ? s.data.length : 1)
-          }, 0)
-          const cycle = totalPixels >= 2
-          let pixelIdx = 0
-          return activeEdgeFlows.flatMap((edgeFlow, edgeFlowIndex) => {
-            const sourceInfo = nodeTypeMap.get(edgeFlow.fromId) ?? { type: 'service' }
-            const edgeStep = edgeFlow.step ?? animState.activeStep!
-
-            if (Array.isArray(edgeStep.data)) {
-              return edgeStep.data.map((dataObj, dataIndex) => {
-                const idx = pixelIdx++
-                return (
-                  <DataPixel
-                    key={`${edgeFlow.edgeId}-${edgeFlow.reverse ? 'r' : 'f'}-${edgeFlowIndex}-${dataIndex}`}
-                    edgeId={edgeFlow.edgeId}
-                    reverse={edgeFlow.reverse}
-                    sourceNodeType={sourceInfo.type}
-                    sourceNodeColor={sourceInfo.color}
-                    pixelColor={dataObj.color ?? (cycle ? stepPixelColor(idx) : undefined)}
-                    pixelFilter={dataObj.color || !cycle ? undefined : stepPixelFilter(idx)}
-                    step={edgeStep}
-                    containerRef={containerRef}
-                    onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}
-                    delayMs={dataIndex * 280}
-                    dataOverride={dataObj}
-                  />
-                )
-              })
-            }
-
-            const singleColor =
-              edgeStep.data && typeof edgeStep.data === 'object' && !Array.isArray(edgeStep.data)
-                ? edgeStep.data.color
-                : undefined
-            const idx = pixelIdx++
-            return (
-              <DataPixel
-                key={`${edgeFlow.edgeId}-${edgeFlow.reverse ? 'r' : 'f'}-${edgeFlowIndex}`}
-                edgeId={edgeFlow.edgeId}
-                reverse={edgeFlow.reverse}
-                sourceNodeType={sourceInfo.type}
-                sourceNodeColor={sourceInfo.color}
-                pixelColor={singleColor ?? (cycle ? stepPixelColor(idx) : undefined)}
-                pixelFilter={singleColor || !cycle ? undefined : stepPixelFilter(idx)}
-                step={edgeStep}
-                containerRef={containerRef}
-                onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}
-              />
-            )
-          })
-        })()}
+        planStepPixels(activeEdgeFlows, animState.activeStep).map((plan) => {
+          const { edgeFlow, edgeFlowIndex, dataObj, dataIndex } = plan
+          const sourceInfo = nodeTypeMap.get(edgeFlow.fromId) ?? { type: 'service' }
+          const edgeStep = edgeFlow.step ?? animState.activeStep!
+          const key =
+            `${edgeFlow.edgeId}-${edgeFlow.reverse ? 'r' : 'f'}-${edgeFlowIndex}` +
+            (dataIndex !== undefined ? `-${dataIndex}` : '')
+          return (
+            <DataPixel
+              key={key}
+              edgeId={edgeFlow.edgeId}
+              reverse={edgeFlow.reverse}
+              sourceNodeColor={sourceInfo.color}
+              pixelColor={plan.pixelColor}
+              pixelFilter={plan.pixelFilter}
+              step={edgeStep}
+              containerRef={containerRef}
+              onPixelClick={(s, pos) => handlePinPopup(s, pos, edgeFlow.edgeId)}
+              delayMs={plan.delayMs || undefined}
+              dataOverride={dataObj}
+            />
+          )
+        })}
 
       {/* Data pixel overlay — manual (click-to-fire) */}
       {manualPixels.map((mp) => (
@@ -710,7 +691,6 @@ function FlowCanvasInner({
           key={mp.id}
           edgeId={mp.edgeId}
           reverse={mp.reverse}
-          sourceNodeType={mp.sourceNodeType}
           sourceNodeColor={mp.sourceNodeColor}
           pixelColor={mp.pixelColor}
           pixelFilter={mp.pixelFilter}

--- a/packages/web/src/hooks/useFlowAnimation.ts
+++ b/packages/web/src/hooks/useFlowAnimation.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import type { FlowStep } from '../types'
+import type { FlowStep, FlowData } from '../types'
 
 export interface EdgeFlowRef {
   edgeId: string
@@ -18,6 +18,17 @@ export interface ManualPixel {
   sourceStepIndex: number
   sourceNodeType: string
   sourceNodeColor?: string
+  /** Per-pixel color override (used when expanding a multi-data step into
+   *  one pixel per data entry, so each click-to-fire carrot gets a distinct
+   *  hue from the variant palette). */
+  pixelColor?: string
+  /** CSS filter to stack on the sprite <img>, paired with pixelColor. */
+  pixelFilter?: string
+  /** Single data object to render this pixel for (set when expanding a
+   *  multi-data step). */
+  dataOverride?: FlowData
+  /** Render delay in ms — used to stagger multi-data carrots. */
+  delayMs?: number
 }
 
 export interface AnimationState {

--- a/packages/web/src/hooks/useFlowAnimation.ts
+++ b/packages/web/src/hooks/useFlowAnimation.ts
@@ -16,7 +16,6 @@ export interface ManualPixel {
   step: FlowStep
   sourceNodeId: string
   sourceStepIndex: number
-  sourceNodeType: string
   sourceNodeColor?: string
   /** Per-pixel color override (used when expanding a multi-data step into
    *  one pixel per data entry, so each click-to-fire carrot gets a distinct

--- a/packages/web/src/lib/flow-layout.ts
+++ b/packages/web/src/lib/flow-layout.ts
@@ -2,6 +2,7 @@ import ELK from 'elkjs'
 import type { Edge, Node } from '@xyflow/react'
 import type { Flow } from '../types'
 import type { FlowNodeData } from '../components/nodes/FlowNode'
+import { assignNodeVariants, type NodeVariant } from './pixel-palette'
 
 const elk = new ELK()
 
@@ -37,6 +38,9 @@ export type FlowTopology = {
   nodeSnapshots: Map<string, NodeSnapshot>
   displayEdges: DisplayEdgeSpec[]
   layoutEdges: Array<[string, string]>
+  /** Per-node sprite + accent variant. Computed once over orderedIds so any
+   *  consumer (sprite filter, animated pixel shadow) lands on the same hue. */
+  nodeVariants: Map<string, NodeVariant>
 }
 
 export type ElKLayoutResult = {
@@ -246,11 +250,16 @@ export function buildFlowTopology(flow: Flow): FlowTopology {
     layoutNodeIds.add(source)
   }
 
+  const nodeVariants = assignNodeVariants(
+    ordered.map((id) => ({ id, type: nodeSnapshots.get(id)?.nodeType ?? 'service' }))
+  )
+
   return {
     orderedIds: ordered,
     nodeSnapshots,
     displayEdges,
     layoutEdges,
+    nodeVariants,
   }
 }
 
@@ -710,44 +719,16 @@ export function buildReactFlowGraph(
     incomingByTarget.set(edge.target, incoming)
   }
 
-  // Color-variant cycle: when several nodes share the same sprite and have no
-  // custom icon, each successive one gets a different CSS filter so viewers
-  // can tell them apart at a glance. The accent palette parallels the sprite
-  // filter so the label, drop-shadow, and progress bar match the sprite's
-  // visible hue.
-  const VARIANT_CYCLE: string[] = [
-    '', // original (orange)
-    'hue-rotate(210deg)', // purple
-    'hue-rotate(90deg)', // green
-    'hue-rotate(140deg)', // blue
-    'hue-rotate(320deg)', // red
-    'hue-rotate(60deg) saturate(1.2)', // yellow (was grey)
-  ]
-  const VARIANT_ACCENT: string[] = [
-    '#ff8a4a', // orange
-    '#b47aff', // purple
-    '#4aff7a', // green
-    '#4a9eff', // blue
-    '#ff6b6b', // red
-    '#ffd84a', // yellow
-  ]
-  const spriteVariantCounters = new Map<string, number>()
-
-  // Nodes that fall back to the service sprite (e.g. `custom`) share the same
-  // variant counter, so five `custom` + five `service` nodes cycle through
-  // the six colors as a single pool instead of restarting per type.
-  const FALLBACK_SPRITE_KEY = 'service'
-  const TYPES_SHARING_SERVICE_SPRITE = new Set(['service', 'custom'])
-
+  // Per-node variant: precomputed once on the topology so the sprite filter
+  // here and the data-pixel drop-shadow in FlowCanvas read from the same
+  // palette index.
   const nodes: Node<FlowNodeData>[] = topology.orderedIds.map((id) => {
     const snapshot = topology.nodeSnapshots.get(id)
     const position = positionMap.get(id) ?? defaultPosition()
     const nodeType = snapshot?.nodeType ?? 'service'
-    const counterKey = TYPES_SHARING_SERVICE_SPRITE.has(nodeType) ? FALLBACK_SPRITE_KEY : nodeType
-    const n = spriteVariantCounters.get(counterKey) ?? 0
-    const variantFilter = VARIANT_CYCLE[n % VARIANT_CYCLE.length] || undefined
-    const variantColor = VARIANT_ACCENT[n % VARIANT_ACCENT.length]
-    spriteVariantCounters.set(counterKey, n + 1)
+    const variant = topology.nodeVariants.get(id)
+    const variantFilter = variant?.filter
+    const variantColor = variant?.color ?? '#ff8a4a'
 
     return {
       id,

--- a/packages/web/src/lib/pixel-palette.ts
+++ b/packages/web/src/lib/pixel-palette.ts
@@ -12,7 +12,6 @@ export const VARIANT_FILTER: readonly string[] = [
   'hue-rotate(90deg)', // green
   'hue-rotate(140deg)', // blue
   'hue-rotate(320deg)', // red
-  'hue-rotate(60deg) saturate(1.2)', // yellow
 ]
 
 export const VARIANT_ACCENT: readonly string[] = [
@@ -21,7 +20,6 @@ export const VARIANT_ACCENT: readonly string[] = [
   '#4aff7a', // green
   '#4a9eff', // blue
   '#ff6b6b', // red
-  '#ffd84a', // yellow
 ]
 
 const FALLBACK_SPRITE_KEY = 'service'

--- a/packages/web/src/lib/pixel-palette.ts
+++ b/packages/web/src/lib/pixel-palette.ts
@@ -73,8 +73,35 @@ export function stepPixelFilter(index: number): string | undefined {
 }
 
 /**
- * Back-compat aliases. The original API was named after multi-data steps,
- * but the same cycling now applies to broadcast and parallel pixels too.
+ * Resolved per-carrot styling for one pixel within a step.
+ * `pixelColor`/`pixelFilter` are undefined when the step emits a single
+ * carrot (the source node's variant color is used instead) or when the
+ * data entry has its own explicit `color` (the filter is suppressed so
+ * the user's color isn't tinted further).
  */
-export const multiDataPixelColor = stepPixelColor
-export const multiDataPixelFilter = stepPixelFilter
+export interface ResolvedStepPixel {
+  pixelColor: string | undefined
+  pixelFilter: string | undefined
+}
+
+/**
+ * Resolve the carrot styling for one pixel given its global index in the
+ * step and the data entry it represents (if any).
+ *
+ * - When `cycle` is true (the step emits 2+ carrots) and the data entry
+ *   has no explicit color, both pixelColor and pixelFilter come from the
+ *   variant palette so each carrot in the step looks distinct.
+ * - An explicit `data.color` always wins; the sprite filter is dropped
+ *   so we don't tint over the user-chosen color.
+ * - When `cycle` is false (single-carrot step) we leave both undefined,
+ *   so DataPixel falls back to the source node's variant color.
+ */
+export function resolvePixelStyle(
+  cycle: boolean,
+  index: number,
+  dataColor?: string
+): ResolvedStepPixel {
+  if (dataColor) return { pixelColor: dataColor, pixelFilter: undefined }
+  if (!cycle) return { pixelColor: undefined, pixelFilter: undefined }
+  return { pixelColor: stepPixelColor(index), pixelFilter: stepPixelFilter(index) }
+}

--- a/packages/web/src/lib/pixel-palette.ts
+++ b/packages/web/src/lib/pixel-palette.ts
@@ -56,20 +56,27 @@ export function assignNodeVariants(
 }
 
 /**
- * Default color for the index-th pixel in a multi-data step. Each pixel
- * cycles through VARIANT_ACCENT so multi-payload steps render with
- * distinguishable shadows.
+ * Default color for the index-th pixel when a step emits multiple carrots
+ * (multi-data, broadcast, or parallel). Each pixel cycles through
+ * VARIANT_ACCENT so they render with distinguishable shadows.
  */
-export function multiDataPixelColor(index: number): string {
+export function stepPixelColor(index: number): string {
   return VARIANT_ACCENT[index % VARIANT_ACCENT.length]
 }
 
 /**
- * Sprite-hue filter that pairs with `multiDataPixelColor(index)`. Apply
- * this to the carrot <img> so the visible sprite tint matches its
- * drop-shadow — without it, all multi-data carrots stay orange (the
- * sprite's original hue) and only the surrounding glow cycles.
+ * Sprite-hue filter that pairs with `stepPixelColor(index)`. Apply this to
+ * the carrot <img> so the visible sprite tint matches its drop-shadow —
+ * without it, all carrots stay orange (the sprite's original hue) and only
+ * the surrounding glow cycles.
  */
-export function multiDataPixelFilter(index: number): string | undefined {
+export function stepPixelFilter(index: number): string | undefined {
   return VARIANT_FILTER[index % VARIANT_FILTER.length] || undefined
 }
+
+/**
+ * Back-compat aliases. The original API was named after multi-data steps,
+ * but the same cycling now applies to broadcast and parallel pixels too.
+ */
+export const multiDataPixelColor = stepPixelColor
+export const multiDataPixelFilter = stepPixelFilter

--- a/packages/web/src/lib/pixel-palette.ts
+++ b/packages/web/src/lib/pixel-palette.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared color-variant palette for sprite filters and animated pixel shadows.
+ * When several nodes resolve to the same fallback sprite, each successive
+ * one cycles to a different hue — both the node's CSS filter (sprite tint)
+ * and the data pixel's drop-shadow read from this palette so they always
+ * agree.
+ */
+
+export const VARIANT_FILTER: readonly string[] = [
+  '', // original (orange)
+  'hue-rotate(210deg)', // purple
+  'hue-rotate(90deg)', // green
+  'hue-rotate(140deg)', // blue
+  'hue-rotate(320deg)', // red
+  'hue-rotate(60deg) saturate(1.2)', // yellow
+]
+
+export const VARIANT_ACCENT: readonly string[] = [
+  '#ff8a4a', // orange
+  '#b47aff', // purple
+  '#4aff7a', // green
+  '#4a9eff', // blue
+  '#ff6b6b', // red
+  '#ffd84a', // yellow
+]
+
+const FALLBACK_SPRITE_KEY = 'service'
+const TYPES_SHARING_SERVICE_SPRITE = new Set(['service', 'custom'])
+
+export interface NodeVariant {
+  filter: string | undefined
+  color: string
+}
+
+/**
+ * Compute per-node variant assignments. `nodes` MUST be passed in the same
+ * canonical order across all callers (this is what `topology.orderedIds`
+ * provides) so flow-layout's sprite filter and FlowCanvas's pixel shadow
+ * land on the same palette index for the same node.
+ */
+export function assignNodeVariants(
+  nodes: ReadonlyArray<{ id: string; type: string }>
+): Map<string, NodeVariant> {
+  const counters = new Map<string, number>()
+  const out = new Map<string, NodeVariant>()
+  for (const node of nodes) {
+    const counterKey = TYPES_SHARING_SERVICE_SPRITE.has(node.type) ? FALLBACK_SPRITE_KEY : node.type
+    const n = counters.get(counterKey) ?? 0
+    counters.set(counterKey, n + 1)
+    out.set(node.id, {
+      filter: VARIANT_FILTER[n % VARIANT_FILTER.length] || undefined,
+      color: VARIANT_ACCENT[n % VARIANT_ACCENT.length],
+    })
+  }
+  return out
+}
+
+/**
+ * Default color for the index-th pixel in a multi-data step. Each pixel
+ * cycles through VARIANT_ACCENT so multi-payload steps render with
+ * distinguishable shadows.
+ */
+export function multiDataPixelColor(index: number): string {
+  return VARIANT_ACCENT[index % VARIANT_ACCENT.length]
+}

--- a/packages/web/src/lib/pixel-palette.ts
+++ b/packages/web/src/lib/pixel-palette.ts
@@ -63,3 +63,13 @@ export function assignNodeVariants(
 export function multiDataPixelColor(index: number): string {
   return VARIANT_ACCENT[index % VARIANT_ACCENT.length]
 }
+
+/**
+ * Sprite-hue filter that pairs with `multiDataPixelColor(index)`. Apply
+ * this to the carrot <img> so the visible sprite tint matches its
+ * drop-shadow — without it, all multi-data carrots stay orange (the
+ * sprite's original hue) and only the surrounding glow cycles.
+ */
+export function multiDataPixelFilter(index: number): string | undefined {
+  return VARIANT_FILTER[index % VARIANT_FILTER.length] || undefined
+}


### PR DESCRIPTION
## Summary

Two related fixes for animated pixel ("carrot") drop-shadows:

### 1. Same-sprite nodes now have matching pixel drop-shadows

\`DataPixel\` resolved its color from a hard-coded \`NODE_COLORS\` map keyed on raw node type, so two nodes that share a sprite hue (e.g. \`api\` typed \`endpoint\` and \`worker\` typed \`service\` — both render with the orange sprite) emitted shadows in different colors (blue vs grey).

Now: per-node variant assignment is computed **once** on the topology (\`topology.nodeVariants\`) via the shared \`lib/pixel-palette\` module. The sprite filter (in \`flow-layout.ts\`) and the pixel drop-shadow (in \`FlowCanvas\`'s \`nodeTypeMap\`) read from the **same** map, so they stay in lockstep. Same orange sprite → same orange drop-shadow.

Threading variants through the topology (instead of recomputing per call site) also fixes a subtle ordering bug where \`flow.flow.nodes\` order and \`topology.orderedIds\` could disagree and assign a node different palette indices in different files.

### 2. Multi-data steps cycle the palette per pixel

When \`step.data\` is an array, multiple pixels travel on one edge with a 120 ms stagger but previously shared a single color. Each pixel now gets a distinct hue from \`VARIANT_ACCENT\` by index (\`multiDataPixelColor(i)\`). Explicit \`data[i].color\` always wins.

### Color resolution order on \`DataPixel\`
1. Explicit \`pixelColor\` prop (multi-data palette cycling, or single \`data.color\`)
2. \`sourceNodeColor\` (variant color from topology — mirrors sprite hue)
3. Legacy \`NODE_COLORS[type]\` (final fallback)

## Test plan
- [x] New unit tests in \`packages/web/__tests__/pixel-palette.test.ts\` (5 cases) verify palette cycling and same-pool aliasing.
- [x] New \`buildFlowTopology\` test asserts that two first-pool nodes (\`api\` endpoint, \`order-service\` service) share the **same** accent color — directly verifies the user-reported bug.
- [x] All 17 web tests pass; \`npx tsc --noEmit\` clean; prettier clean.
- [ ] Visual: \`examples/self-loops.yaml\` — \`api\` and \`worker\` (both rendered with the orange sprite) should now emit pixels with the same orange drop-shadow.
- [ ] Visual: api → api self-loop's multi-data step should show 3 pixels in 3 different colors cycling through the palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional pixelColor and pixelFilter props for finer control of data-pixel appearance

* **Improvements**
  * Stable per-node accent and filter assignment for consistent sprite coloring
  * Pixel visuals: resolved colors appear in drop-shadows and tooltips; first variant omits filter, later variants use hue-rotate
  * Multi-item pixel cycling with wraparound and increased per-item stagger delay

* **Tests**
  * Unit tests covering variant assignment, pixel color cycling, and filter behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->