### PR TITLE
chore: address readiness-audit warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ npx tsc --noEmit -p packages/cli
 npm run build -w @openhop/cli
 ```
 
-There is **no** CI lint or formatter enforced — don't try to run one.
+CI runs `npm run lint` and `npm run format:check` (see `.github/workflows/ci.yml`). Run them locally before pushing if you're touching a lot of files.
 
 ## Tests
 
@@ -66,7 +66,7 @@ npm test -w @openhop/shared     # vitest, fast
 npm test -w @openhop/server     # vitest, touches the in-memory store
 ```
 
-Known pre-existing failures in `packages/shared/__tests__/patch.test.ts` — it references old singular op names (`add-node`) that were renamed to plural (`add-nodes`). Don't waste time on those unless fixing them is your ticket.
+The shared test suite is fully passing. The previous `patch.test.ts` "old singular op names" caveat no longer applies — it has been updated to the plural ops.
 
 ## Authoring flows
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@
   <a href="https://github.com/naorsabag/OpenHop/stargazers"><img src="https://img.shields.io/github/stars/naorsabag/OpenHop?style=social" alt="GitHub stars" /></a>
 </p>
 
+<p align="center">
+  <sub>Works with</sub><br/>
+  <img src="https://img.shields.io/badge/Claude%20Code-✓-262626?style=flat-square" alt="Claude Code" />
+  <img src="https://img.shields.io/badge/Cursor-✓-262626?style=flat-square" alt="Cursor" />
+  <img src="https://img.shields.io/badge/Windsurf-✓-262626?style=flat-square" alt="Windsurf" />
+  <img src="https://img.shields.io/badge/Cline-✓-262626?style=flat-square" alt="Cline" />
+  <img src="https://img.shields.io/badge/Continue.dev-advisory-666?style=flat-square" alt="Continue.dev (advisory)" />
+</p>
+
 ---
 
 ## Why
@@ -37,7 +46,9 @@ between components on a pixel-art canvas. Click any node to drill into its sub-f
 - 🔍 **Multi-level drill-down.** Click a node to zoom into its sub-flow. Infinite depth.
 - ⚡ **Live re-render.** `openhop patch` applies incremental changes without a full reload.
 - 🧠 **Strict schema + fuzzy typo hints.** Invalid YAML fails loudly with helpful suggestions.
-- 🐚 **CLI + HTTP API + web UI.** Script it, hit it from tools, or browse at <http://localhost:8788>.
+- 🐚 **CLI + HTTP API + web UI.** Script it, hit it from tools, or browse at `http://localhost:8788`.
+- 🔒 **Local-first, no telemetry.** Runs entirely on your machine — no analytics, no phone-home, no account required.
+- ✂️ **Token-light.** A typical flow YAML is ~5–20× smaller than the equivalent prose explanation an agent would otherwise emit.
 
 ## Try it in 60 seconds
 
@@ -119,6 +130,7 @@ Pre-made flows under [`examples/`](examples/):
 - `order-flow.yaml` — e-commerce order pipeline
 - `simple-crud.yaml` — minimal CRUD example
 - `type-variants.yaml` — every node type in one flow
+- `self-loops.yaml` — same-node steps (internal work, retries) plus broadcasts and multi-data steps
 
 Push any of them:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
       - openhop-flows:/root/.openhop
     environment:
       - CHOKIDAR_USEPOLLING=true
+      # Inside the container we need to bind every interface so the host
+      # port-mapping above can reach the server. Outside docker the server
+      # defaults to 127.0.0.1.
+      - HOST=0.0.0.0
     restart: unless-stopped
 
 volumes:

--- a/packages/cli/src/help-json.ts
+++ b/packages/cli/src/help-json.ts
@@ -120,7 +120,13 @@ const COMMAND_META: Record<string, { exitCodes: number[]; examples: string[] }> 
     ],
   },
   init: {
-    exitCodes: [ExitCode.SUCCESS, ExitCode.GENERIC, ExitCode.USAGE],
+    exitCodes: [
+      ExitCode.SUCCESS,
+      ExitCode.GENERIC,
+      ExitCode.USAGE,
+      ExitCode.NOT_FOUND,
+      ExitCode.CONFLICT,
+    ],
     examples: [
       'openhop init',
       'openhop init --dry-run --json',

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -25,6 +25,8 @@ import { fileURLToPath } from 'node:url'
 const EXIT_OK = 0
 const EXIT_GENERIC = 1
 const EXIT_USAGE = 2
+const EXIT_NOT_FOUND = 4
+const EXIT_CONFLICT = 5
 
 /** A supported AI client and where it expects skills on this machine. */
 export interface ClientSpec {
@@ -305,9 +307,6 @@ export function registerInit(program: Command): void {
       const skipped = results.filter((r) => r.status === 'skipped' || r.status === 'advisory')
       const failed = results.filter((r) => r.status === 'failed')
       const wouldInstall = results.filter((r) => r.status === 'would-install')
-      const alreadyInstalled = results.filter(
-        (r) => r.status === 'skipped' && r.reason?.startsWith('already installed')
-      )
 
       if (opts.json) {
         const payload = {
@@ -327,14 +326,18 @@ export function registerInit(program: Command): void {
         }
       }
 
-      // Exit code policy: a converged machine — every detected client already
-      // has the skill — is success, not failure. Only fail when something
-      // actually went wrong (a `failed` result) or there was nothing to do
-      // at all (no detected clients).
-      if (failed.length > 0) process.exit(EXIT_GENERIC)
-      const anyOutcome =
-        installed.length > 0 || wouldInstall.length > 0 || alreadyInstalled.length > 0
-      if (!anyOutcome) process.exit(EXIT_GENERIC)
+      // Exit code policy:
+      //   CONFLICT (5)  — at least one install actually errored.
+      //   NOT_FOUND (4) — no clients were detected at all (every result is
+      //                   `skipped: not detected`); nothing to do.
+      //   SUCCESS (0)   — anything else, including a converged machine where
+      //                   every detected client is `already installed`, and
+      //                   advisory-only detections (e.g. Continue.dev).
+      if (failed.length > 0) process.exit(EXIT_CONFLICT)
+      const detectedCount = results.filter(
+        (r) => !(r.status === 'skipped' && r.reason === 'not detected')
+      ).length
+      if (detectedCount === 0) process.exit(EXIT_NOT_FOUND)
       process.exit(EXIT_OK)
     })
 }

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -305,6 +305,9 @@ export function registerInit(program: Command): void {
       const skipped = results.filter((r) => r.status === 'skipped' || r.status === 'advisory')
       const failed = results.filter((r) => r.status === 'failed')
       const wouldInstall = results.filter((r) => r.status === 'would-install')
+      const alreadyInstalled = results.filter(
+        (r) => r.status === 'skipped' && r.reason?.startsWith('already installed')
+      )
 
       if (opts.json) {
         const payload = {
@@ -324,13 +327,14 @@ export function registerInit(program: Command): void {
         }
       }
 
-      // Exit code policy: success if anything was installed (or, in dry-run,
-      // would have been installed). Otherwise generic failure when nothing
-      // was actionable.
-      const anySuccess = installed.length > 0 || wouldInstall.length > 0
-      if (!anySuccess && installed.length === 0 && wouldInstall.length === 0) {
-        process.exit(EXIT_GENERIC)
-      }
+      // Exit code policy: a converged machine — every detected client already
+      // has the skill — is success, not failure. Only fail when something
+      // actually went wrong (a `failed` result) or there was nothing to do
+      // at all (no detected clients).
+      if (failed.length > 0) process.exit(EXIT_GENERIC)
+      const anyOutcome =
+        installed.length > 0 || wouldInstall.length > 0 || alreadyInstalled.length > 0
+      if (!anyOutcome) process.exit(EXIT_GENERIC)
       process.exit(EXIT_OK)
     })
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -51,6 +51,9 @@ try {
 }
 
 const port = parseInt(process.env.PORT ?? '8787')
-await app.listen({ port, host: '0.0.0.0' })
-console.log(`OpenHop server running on http://localhost:${port}`)
+// Default to loopback so a casual `npm run dev` is not exposed to the LAN.
+// Containers / docker-compose set HOST=0.0.0.0 to bind every interface.
+const host = process.env.HOST ?? '127.0.0.1'
+await app.listen({ port, host })
+console.log(`OpenHop server running on http://localhost:${port} (bound to ${host})`)
 console.log(`Swagger docs at http://localhost:${port}/docs`)


### PR DESCRIPTION
## Summary

Local-only fixes from [`READINESS-AUDIT.md`](https://github.com/naorsabag/OpenHop/blob/master/../openhop-launch/READINESS-AUDIT.md) — every item that doesn't require publishing, force-pushes, or external services. Audit blockers (B1–B9) and external warnings (W1, W6, W7, W11, W12, W13, W14) are out of scope for this PR.

- **W5** `openhop init` is now idempotent. On a converged machine (every detected client already has the skill), both live and `--dry-run` modes exit 0. Only `failed` results or zero detected clients exit non-zero.
- **W10** Server defaults to `127.0.0.1`; `HOST=0.0.0.0` is set in `docker-compose.yml` so the in-container port mapping still works. Casual `npm run dev` is no longer LAN-exposed.
- **W3** README lists `examples/self-loops.yaml` under `## Examples`.
- **W4 (partial)** README adds the local-first/no-telemetry line, token-light claim, and platform-badge grid (Claude Code / Cursor / Windsurf / Cline / Continue). Deferred items: npm version badge (needs publish), Discord CTA (no Discord yet).
- **W8** `AGENTS.md` updated — CI lint/formatter ARE enforced; the stale `patch.test.ts` known-failure note is removed.
- **W9** Autolink `<http://localhost:8788>` wrapped in backticks (link-checker safe).

## Test plan

- [x] `npm test --workspaces --if-present` — cli 83/83, server 19/19, shared 93/93, web 22/22
- [x] `npm run lint` — 0 errors (12 pre-existing warnings)
- [x] `npm run format:check` — clean
- [ ] Manual: `openhop init` twice on a fresh machine → second run exits 0 with all clients marked "already installed"
- [ ] Manual: `npm run dev` outside docker → server visible on `127.0.0.1:8787`, not on LAN IP
- [ ] Manual: `docker compose up` → server reachable through host port mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support indicators for more AI agents and a new example workflow (`self-loops.yaml`).
  * README highlights: local-first, no-telemetry, and token-light messaging.

* **Bug Fixes**
  * Docker service configured so container ports are reachable from outside Docker.
  * CLI init command refined to return clearer exit codes for not-found and conflict cases.

* **Documentation**
  * CI/lint/format checks noted and shared test suite status updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->