### PR TITLE
fix(skills): quote SKILL.md description so YAML frontmatter parses

### DIFF
--- a/skills/openhop/SKILL.md
+++ b/skills/openhop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openhop
-description: Data flow visualization. Use when the user asks to visualize, explain, or diagram how data flows through their code, APIs, services, or architecture. Triggers: "show me the data flow", "visualize the architecture", "how does data move through", "diagram the flow", "show me how X works".
+description: 'Data flow visualization. Use when the user asks to visualize, explain, or diagram how data flows through their code, APIs, services, or architecture. Triggers: "show me the data flow", "visualize the architecture", "how does data move through", "diagram the flow", "show me how X works".'
 allowed-tools: Bash(openhop:*), Bash(npx tsx:*)
 ---
 


### PR DESCRIPTION
## Summary

GitHub (and any strict YAML parser) rejects `skills/openhop/SKILL.md` with:

> Error in user YAML: (\<unknown\>): mapping values are not allowed in this context at line 2 column 172

The `description:` scalar contained `Triggers: "..."` — the unquoted \`: \` sequence was being parsed as a nested mapping. Wrapping the whole value in single quotes fixes it without having to escape the embedded double quotes.

## Test plan

- [x] Verified with `yaml.parse()` (the same lib used in the rest of the repo) — frontmatter parses to `{ name, description, allowed-tools }` with the description preserved as a single string
- [x] No content/trigger phrases changed — `description` text is byte-identical save for the surrounding quotes
- [x] `packages/cli/skills/openhop/SKILL.md` is gitignored (regenerated from canonical at prepack time per `packages/cli/package.json:40`), so it'll pick up the fix on next publish — no separate change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenHop skill metadata description formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->