### PR TITLE
feat: bundle server+web into npm package; add openhop demo (closes B3, B9, W6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,28 +53,19 @@ between components on a pixel-art canvas. Click any node to drill into its sub-f
 ## Try it in 60 seconds
 
 ```bash
-git clone https://github.com/naorsabag/OpenHop.git
-cd OpenHop
-npm install           # installs deps and builds the CLI bundle
-cd packages/cli && npm link && cd ../..
-npm run dev           # API :8787 + web UI :8788
+npx openhop demo
 ```
 
-In another terminal:
-
-```bash
-openhop push examples/auth-flow.yaml
-# → prints a URL. Open it.
-```
+That's it. The CLI starts the API + web UI on `localhost:8787` / `:8788`, posts a starter flow, and opens your browser. Press Ctrl-C to stop.
 
 ## Install
 
-| Scenario                     | Command                                                   |
-| ---------------------------- | --------------------------------------------------------- |
-| **Try locally (no install)** | Clone this repo, `npm install`, `npm run dev`. See above. |
-| **Use the CLI globally**     | After `npm install`, `cd packages/cli && npm link`        |
-
-> npm, plugin-registry, and `npx openhop init` install paths are in progress — track [#18–#37](https://github.com/naorsabag/OpenHop/issues) for launch-readiness.
+| Scenario                           | Command                                                                         |
+| ---------------------------------- | ------------------------------------------------------------------------------- |
+| **One-shot demo**                  | `npx openhop demo` — boots everything and opens the browser                     |
+| **Long-lived local server**        | `npm install -g openhop && openhop serve` — API + web UI, no starter flow       |
+| **Install the agent skill**        | `npx openhop init` — copies `SKILL.md` into every detected AI client            |
+| **Run from source (contributors)** | `git clone … && npm install && npm run dev` — see [Contributing](#contributing) |
 
 ## Give your agent the skill
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ That's it. The CLI starts the API + web UI on `localhost:8787` / `:8788`, posts 
 
 ## Install
 
-| Scenario                           | Command                                                                         |
-| ---------------------------------- | ------------------------------------------------------------------------------- |
-| **One-shot demo**                  | `npx openhop demo` — boots everything and opens the browser                     |
-| **Long-lived local server**        | `npm install -g openhop && openhop serve` — API + web UI, no starter flow       |
-| **Install the agent skill**        | `npx openhop init` — copies `SKILL.md` into every detected AI client            |
-| **Run from source (contributors)** | `git clone … && npm install && npm run dev` — see [Contributing](#contributing) |
+| Scenario                           | Command                                                                                                                                  |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **One-shot demo**                  | `npx openhop demo` — boots everything and opens the browser                                                                              |
+| **Long-lived local server**        | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
+| **Install the agent skill**        | `npx openhop init` — copies `SKILL.md` into every detected AI client                                                                     |
+| **Run from source (contributors)** | `git clone … && npm install && npm run dev` — see [Contributing](#contributing)                                                          |
 
 ## Give your agent the skill
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,11 @@
+# Contributor-only convenience. End users should run `npx openhop demo`
+# (or `openhop serve`) instead — the npm package ships a self-contained
+# server + web UI and does not need a repo checkout.
+#
+# This compose file mounts the source tree, runs `npm install` inside a
+# Node container, and starts the workspace dev script. Use it when you
+# want to hack on OpenHop in an isolated container without installing
+# Node locally.
 services:
   openhop:
     image: node:22-alpine

--- a/package-lock.json
+++ b/package-lock.json
@@ -262,6 +262,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
@@ -272,6 +273,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -281,6 +283,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -293,11 +296,13 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -309,11 +314,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -325,11 +332,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -341,11 +350,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -357,11 +368,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -373,11 +386,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -389,11 +404,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -405,11 +422,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -421,11 +440,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -437,11 +458,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -453,11 +476,13 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -469,11 +494,13 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -485,11 +512,13 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -501,11 +530,13 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -517,11 +548,13 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -533,11 +566,13 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -549,11 +584,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -565,11 +602,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -581,11 +620,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -597,11 +638,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -613,11 +656,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -629,11 +674,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -645,11 +692,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -661,11 +710,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -677,11 +728,13 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -693,11 +746,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1157,6 +1212,14 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
@@ -1183,6 +1246,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1192,6 +1256,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1201,6 +1266,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1208,12 +1274,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1232,6 +1300,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.1"
@@ -1261,6 +1330,7 @@
       "version": "0.127.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
       "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -1278,6 +1348,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1293,6 +1364,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1308,6 +1380,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1323,6 +1396,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -1338,6 +1412,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1353,6 +1428,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1368,6 +1444,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1383,6 +1460,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1398,6 +1476,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1413,6 +1492,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1428,6 +1508,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1443,6 +1524,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openharmony"
@@ -1458,6 +1540,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
@@ -1475,6 +1558,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1490,6 +1574,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1865,6 +1950,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
       "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
@@ -1880,6 +1966,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
       "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -1906,6 +1993,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1922,6 +2010,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1938,6 +2027,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1954,6 +2044,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1970,6 +2061,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1986,6 +2078,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2002,6 +2095,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2018,6 +2112,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2034,6 +2129,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2058,6 +2154,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2074,6 +2171,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
       "version": "1.8.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2084,6 +2182,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.8.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2093,6 +2192,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2102,6 +2202,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2117,6 +2218,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2126,6 +2228,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
       "version": "2.8.1",
+      "dev": true,
       "inBundle": true,
       "license": "0BSD",
       "optional": true
@@ -2137,6 +2240,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2153,6 +2257,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2166,6 +2271,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
       "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/node": "4.2.4",
@@ -2180,6 +2286,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -2188,12 +2295,14 @@
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true
     },
     "node_modules/@types/d3-drag": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
       "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
       "dependencies": {
         "@types/d3-selection": "*"
       }
@@ -2202,6 +2311,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
       "dependencies": {
         "@types/d3-color": "*"
       }
@@ -2209,12 +2319,14 @@
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true
     },
     "node_modules/@types/d3-transition": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
       "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
       "dependencies": {
         "@types/d3-selection": "*"
       }
@@ -2223,6 +2335,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
       "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
       "dependencies": {
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
@@ -2244,7 +2357,7 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2253,7 +2366,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2721,6 +2834,7 @@
       "version": "12.10.2",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
       "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "dev": true,
       "dependencies": {
         "@xyflow/system": "0.0.76",
         "classcat": "^5.0.3",
@@ -2735,6 +2849,7 @@
       "version": "0.0.76",
       "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
       "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "dev": true,
       "dependencies": {
         "@types/d3-drag": "^3.0.7",
         "@types/d3-interpolate": "^3.0.4",
@@ -3053,7 +3168,8 @@
     "node_modules/classcat": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
-      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3130,7 +3246,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3144,12 +3259,13 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -3158,6 +3274,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
       "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -3166,6 +3283,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
       "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -3178,6 +3296,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -3186,6 +3305,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -3197,6 +3317,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -3205,6 +3326,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -3213,6 +3335,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
       "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -3231,6 +3354,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
       "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -3299,6 +3423,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3323,12 +3448,14 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
       "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "dev": true,
       "license": "EPL-2.0"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
       "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -3342,6 +3469,7 @@
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3781,6 +3909,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -3854,6 +3983,21 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3864,6 +4008,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -3909,6 +4054,7 @@
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
       "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -3995,6 +4141,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -4154,8 +4301,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4207,10 +4353,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -4374,6 +4535,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -4405,6 +4567,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4424,6 +4587,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -4443,6 +4607,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -4462,6 +4627,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -4481,6 +4647,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4500,6 +4667,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4519,6 +4687,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4538,6 +4707,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4557,6 +4727,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4576,6 +4747,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -4595,6 +4767,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -4668,6 +4841,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -4800,6 +4974,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4951,6 +5126,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4985,7 +5165,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5033,12 +5212,14 @@
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -5106,6 +5287,7 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5216,6 +5398,7 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5224,6 +5407,7 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "dev": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5269,6 +5453,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -5303,6 +5488,7 @@
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
       "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
       "dependencies": {
         "@oxc-project/types": "=0.127.0",
         "@rolldown/pluginutils": "1.0.0-rc.17"
@@ -5334,7 +5520,8 @@
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true
     },
     "node_modules/rollup": {
       "version": "4.60.1",
@@ -5381,6 +5568,25 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-regex2": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.0.tgz",
@@ -5415,7 +5621,8 @@
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -5458,7 +5665,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -5470,7 +5676,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5486,7 +5691,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -5508,6 +5712,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5605,12 +5810,14 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5678,6 +5885,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
@@ -5744,12 +5952,14 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -5835,7 +6045,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -5880,6 +6090,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -5888,6 +6099,7 @@
       "version": "8.0.10",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7032,7 +7244,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -7142,6 +7353,7 @@
       "version": "4.5.7",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
       "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "dev": true,
       "dependencies": {
         "use-sync-external-store": "^1.2.2"
       },
@@ -7170,7 +7382,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@fastify/static": "^8.0.0",
+        "@openhop/server": "0.1.0",
+        "@openhop/web": "0.1.0",
         "commander": "^12.0.0",
+        "fastify": "^5.0.0",
         "yaml": "^2.8.4",
         "zod": "^4.4.2"
       },
@@ -7605,6 +7821,59 @@
         "node": ">=18"
       }
     },
+    "packages/cli/node_modules/@fastify/static": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-8.3.0.tgz",
+      "integrity": "sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/send": "^4.0.0",
+        "content-disposition": "^0.5.4",
+        "fastify-plugin": "^5.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^11.0.0"
+      }
+    },
+    "packages/cli/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/cli/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "packages/cli/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "packages/cli/node_modules/esbuild": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
@@ -7646,26 +7915,524 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
+    "packages/cli/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/cli/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.0.1",
+      "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
         "@fastify/swagger": "^9.0.0",
         "@fastify/swagger-ui": "^5.2.6",
-        "@openhop/shared": "*",
         "fastify": "^5.0.0",
         "nanoid": "^5.1.11",
-        "tsx": "^4.0.0",
-        "yaml": "^2.8.4"
+        "yaml": "^2.8.4",
+        "zod": "^4.4.2",
+        "zod-to-json-schema": "^3.24.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@openhop/shared": "*",
         "@types/node": "^24.12.2",
+        "esbuild": "^0.28.0",
         "eslint": "^9.39.4",
         "globals": "^17.6.0",
+        "tsx": "^4.0.0",
         "typescript-eslint": "^8.59.1",
         "vitest": "^1.6.1"
+      }
+    },
+    "packages/server/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/server/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "packages/server/node_modules/nanoid": {
@@ -7706,27 +8473,26 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.0.0",
-      "dependencies": {
-        "@openhop/shared": "*",
-        "@tailwindcss/vite": "^4.2.4",
-        "@xyflow/react": "^12.10.2",
-        "elkjs": "^0.11.1",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "tailwindcss": "^4.2.2"
-      },
+      "version": "0.1.0",
+      "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@openhop/shared": "*",
+        "@tailwindcss/vite": "^4.2.4",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^1.6.1",
+        "@xyflow/react": "^12.10.2",
+        "elkjs": "^0.11.1",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "tailwindcss": "^4.2.2",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.59.1",
         "vite": "^8.0.10",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,12 +36,16 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:cli-contract": "vitest run __tests__/contract.test.ts",
-    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=esm --external:commander --external:yaml --external:zod --outfile=dist/index.js --banner:js='#!/usr/bin/env node'",
+    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=esm --external:commander --external:yaml --external:zod --external:@openhop/server --external:@openhop/web --external:fastify --external:@fastify/static --outfile=dist/index.js --banner:js='#!/usr/bin/env node'",
     "prepack": "rm -rf skills && cp -r ../../skills ./skills",
     "prepare": "npm run build"
   },
   "dependencies": {
+    "@fastify/static": "^8.0.0",
+    "@openhop/server": "0.1.0",
+    "@openhop/web": "0.1.0",
     "commander": "^12.0.0",
+    "fastify": "^5.0.0",
     "yaml": "^2.8.4",
     "zod": "^4.4.2"
   },

--- a/packages/cli/src/demo.ts
+++ b/packages/cli/src/demo.ts
@@ -1,0 +1,200 @@
+/**
+ * `openhop demo` — one-command bootstrap for first-time users.
+ *
+ * Boots the API + web UI in-process, posts a starter flow, opens the user's
+ * browser at the rendered URL, and stays running until SIGINT.
+ *
+ * Substitute for the hosted-playground "Try it live" link (the playground
+ * is deferred to post-launch per openhop-launch/02-hosted-playground.md:3).
+ * Closes the abort criterion in 01-repo-readiness.md:37.
+ */
+
+import { spawn } from 'node:child_process'
+import type { Command } from 'commander'
+import { errorMessage, errStderr, logStderr, dim, red, green, cyan, bold } from './utils.js'
+import { ExitCode } from './exit-codes.js'
+
+/**
+ * The bundled starter flow. Inlined here (rather than read from disk at
+ * runtime) so the CLI tarball doesn't need to ship `examples/`. esbuild
+ * keeps this as a single string literal in dist/index.js — ~2 KB.
+ */
+const STARTER_FLOW_YAML = `meta:
+  title: Authentication Flow
+  path: examples/auth
+  description: OAuth2 login with JWT tokens
+
+flow:
+  nodes:
+    - id: browser
+      label: Browser
+      type: actor
+    - id: app
+      label: App Server
+      type: endpoint
+    - id: oauth
+      label: Google OAuth
+      type: external
+      icon: "logos:google-icon"
+    - id: db
+      label: User DB
+      type: database
+    - id: cache
+      label: Session Cache
+      type: cache
+
+  steps:
+    - from: browser
+      to: app
+      data: GET /login
+    - from: app
+      to: oauth
+      data: Redirect to Google
+    - from: oauth
+      to: app
+      data:
+        label: OAuth callback
+        fields:
+          - name: code
+            type: string
+          - name: state
+            type: string
+    - from: app
+      to: oauth
+      data: Exchange code for token
+    - from: oauth
+      to: app
+      data:
+        label: Token response
+        fields:
+          - name: access_token
+          - name: id_token
+          - name: email
+            added: true
+    - from: app
+      to: [db, cache]
+      data: Store user + session
+    - parallel:
+        - from: db
+          to: app
+          data: user_id
+        - from: cache
+          to: app
+          data: session_id
+    - from: app
+      to: browser
+      data:
+        label: Set cookie + redirect
+        fields:
+          - name: session_id
+          - name: redirect_to
+            type: string
+`
+
+/** Cross-platform browser launcher. Avoids adding a runtime dependency. */
+function openInBrowser(url: string): void {
+  const platform = process.platform
+  const cmd = platform === 'darwin' ? 'open' : platform === 'win32' ? 'start' : 'xdg-open'
+  const child = spawn(cmd, [url], {
+    detached: true,
+    stdio: 'ignore',
+    shell: platform === 'win32',
+  })
+  child.on('error', () => {
+    // Browser couldn't be opened (headless box, no $DISPLAY, etc.) — the URL
+    // still gets printed below, so the user can copy-paste.
+  })
+  child.unref()
+}
+
+export function registerDemo(program: Command): void {
+  program
+    .command('demo')
+    .description('One-shot bootstrap: start API + web UI, push a starter flow, open the browser')
+    .option('-p, --port <port>', 'API port', '8787')
+    .option('--web-port <port>', 'Web UI port', '8788')
+    .option('--no-open', "Don't open the browser (print the URL only)")
+    .action(async (opts) => {
+      const apiPort = Number.parseInt(opts.port, 10)
+      const webPort = Number.parseInt(opts.webPort, 10)
+
+      logStderr(dim(`Starting OpenHop API on port ${apiPort}...`))
+      const { startServer } = await import('@openhop/server')
+      let api: { url: string; close: () => Promise<void> }
+      try {
+        api = await startServer({ port: apiPort, logger: false })
+      } catch (err) {
+        errStderr(red(`✗ Failed to start API: ${errorMessage(err)}`))
+        process.exit(ExitCode.GENERIC)
+      }
+
+      logStderr(dim(`Starting OpenHop web UI on port ${webPort}...`))
+      let web: { url: string; close: () => Promise<void> }
+      try {
+        const { startWebServer } = await import('./web-server.js')
+        web = await startWebServer({ port: webPort })
+      } catch (err) {
+        errStderr(red(`✗ Failed to start web UI: ${errorMessage(err)}`))
+        await api.close()
+        process.exit(ExitCode.GENERIC)
+      }
+
+      // Push the starter flow.
+      logStderr(dim('Pushing starter flow...'))
+      const pushUrl = `${api.url}/api/flows`
+      let flowId: string
+      try {
+        const res = await fetch(pushUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'text/yaml' },
+          body: STARTER_FLOW_YAML,
+        })
+        if (!res.ok) {
+          const body = await res.text()
+          errStderr(red(`✗ Server rejected starter flow (${res.status}): ${body}`))
+          await api.close()
+          await web.close()
+          process.exit(ExitCode.GENERIC)
+        }
+        const data = (await res.json()) as { id: string }
+        flowId = data.id
+      } catch (err) {
+        errStderr(red(`✗ Failed to push starter flow: ${errorMessage(err)}`))
+        await api.close()
+        await web.close()
+        process.exit(ExitCode.NETWORK)
+      }
+
+      const flowUrl = `${web.url}/flow/${flowId}`
+      logStderr(green('✓ OpenHop demo ready'))
+      logStderr(`  ${bold('API:')}  ${api.url}`)
+      logStderr(`  ${bold('Web:')}  ${web.url}`)
+      logStderr(`  ${bold('Flow:')} ${cyan(flowUrl)}`)
+      logStderr(dim('  Press Ctrl-C to stop.'))
+
+      if (opts.open !== false) {
+        openInBrowser(flowUrl)
+      }
+
+      // Keep the process alive until SIGINT/SIGTERM.
+      const shutdown = async (): Promise<never> => {
+        logStderr(dim('Shutting down...'))
+        try {
+          await api.close()
+        } catch {
+          /* ignore */
+        }
+        try {
+          await web.close()
+        } catch {
+          /* ignore */
+        }
+        process.exit(ExitCode.SUCCESS)
+      }
+      process.on('SIGINT', () => void shutdown())
+      process.on('SIGTERM', () => void shutdown())
+
+      // Stable, machine-parseable ready line on stdout (same shape as serve).
+      process.stdout.write(`openhop: ready api=${api.url} web=${web.url} flow=${flowUrl}\n`)
+    })
+}

--- a/packages/cli/src/help-json.ts
+++ b/packages/cli/src/help-json.ts
@@ -67,7 +67,11 @@ function positionalType(name: string): 'string' | 'path-or-dash' {
 const COMMAND_META: Record<string, { exitCodes: number[]; examples: string[] }> = {
   serve: {
     exitCodes: [ExitCode.SUCCESS, ExitCode.GENERIC],
-    examples: ['openhop serve', 'openhop serve --port 8800'],
+    examples: ['openhop serve', 'openhop serve --port 8800', 'openhop serve --no-web'],
+  },
+  demo: {
+    exitCodes: [ExitCode.SUCCESS, ExitCode.GENERIC, ExitCode.NETWORK],
+    examples: ['openhop demo', 'openhop demo --no-open', 'openhop demo --port 9000'],
   },
   push: {
     exitCodes: [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,4 @@
 import { Command } from 'commander'
-import { spawn } from 'node:child_process'
-import { resolve } from 'node:path'
 import YAML from 'yaml'
 import { parseFlowYaml } from '@openhop/shared'
 import type { FlowTreeNode, FlowSummary } from '@openhop/shared'
@@ -22,6 +20,7 @@ import { registerGet } from './get.js'
 import { registerValidate } from './validate.js'
 import { registerHelpJson } from './help-json.js'
 import { registerInit } from './init.js'
+import { registerDemo } from './demo.js'
 
 const DEFAULT_SERVER = 'http://localhost:8787'
 
@@ -55,105 +54,72 @@ program.name('openhop').description('OpenHop — Data Flow Visualization CLI').v
 
 // --- serve ---
 //
-// Starts both the API server (Fastify on :8787) and the web UI dev server
-// (Vite on :8788). The URL printed by `push` points at the web UI port, so
-// without the web running the user lands on a 404 — that's what a fresh
-// agent's cold-start test surfaced. Use --no-web to opt out (CI, headless).
-//
-// Note: this command only works inside a from-source checkout of the
-// monorepo, because the server and web entries are looked up relative to
-// the CLI bundle's dirname. The published `npm i -g openhop` package
-// doesn't ship the server/web sources — for production deployments use
-// docker-compose or clone the repo. Tracked for v0.2 with a separate
-// `@openhop/server` package.
+// Starts both the API server (Fastify on :8787) and the web UI server
+// (Fastify-static of @openhop/web's prebuilt assets on :8788). Both run
+// in-process; the server entry comes from `@openhop/server` and the web
+// assets come from `@openhop/web/dist/`, both resolved through the consumer's
+// node_modules. The URL printed by `push` points at the web UI port, so
+// without the web running the user lands on a 404 — use --no-web to opt out
+// (CI, headless).
 program
   .command('serve')
   .description('Start the OpenHop API server (:8787) and web UI (:8788)')
   .option('-p, --port <port>', 'API port', '8787')
-  .option('--no-web', 'Start API only, skip the web UI dev server')
-  .option('--no-wait-ready', "Don't probe /health and don't print the ready line on stdout")
-  .option('--ready-timeout <seconds>', 'How long to wait for readiness before giving up', '60')
+  .option('--web-port <port>', 'Web UI port', '8788')
+  .option('--no-web', 'Start API only, skip the web UI')
+  .option('--no-wait-ready', "Don't print the ready line on stdout")
   .action(async (opts) => {
-    const cliDir = resolve(import.meta.dirname, '..', '..')
-    const serverEntry = resolve(cliDir, 'server', 'src', 'index.ts')
-    const webDir = resolve(cliDir, 'web')
+    const apiPort = Number.parseInt(opts.port, 10)
+    const webPort = Number.parseInt(opts.webPort, 10)
 
-    logStderr(dim(`Starting OpenHop API on port ${opts.port}...`))
-    // Pipe child stdout/stderr to OUR stderr — the CLI contract says stdout
-    // is for data only. Without this, Fastify's pino logs and Vite's dev
-    // banner would pollute parent stdout and break agents that pipe
-    // `serve` output through jq.
-    const api = spawn('npx', ['tsx', serverEntry], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, PORT: opts.port },
-    })
-    api.stdout?.pipe(process.stderr)
-    api.stderr?.pipe(process.stderr)
+    logStderr(dim(`Starting OpenHop API on port ${apiPort}...`))
+    const { startServer } = await import('@openhop/server')
+    let api
+    try {
+      api = await startServer({ port: apiPort, logger: false })
+    } catch (err) {
+      errStderr(red(`✗ Failed to start API: ${errorMessage(err)}`))
+      process.exit(ExitCode.GENERIC)
+    }
 
-    let web: ReturnType<typeof spawn> | null = null
+    let web: { url: string; close: () => Promise<void> } | null = null
     if (opts.web !== false) {
-      logStderr(dim('Starting OpenHop web UI on port 8788...'))
-      web = spawn('npm', ['run', 'dev'], {
-        cwd: webDir,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        env: { ...process.env },
-      })
-      web.stdout?.pipe(process.stderr)
-      web.stderr?.pipe(process.stderr)
-      web.on('error', (err) => {
+      logStderr(dim(`Starting OpenHop web UI on port ${webPort}...`))
+      try {
+        const { startWebServer } = await import('./web-server.js')
+        web = await startWebServer({ port: webPort })
+      } catch (err) {
         errStderr(red(`Failed to start web UI: ${errorMessage(err)}`))
         // Web failure is non-fatal — API can still run for headless agents.
-      })
+      }
     }
 
-    const shutdown = () => {
-      api.kill('SIGTERM')
-      web?.kill('SIGTERM')
+    const shutdown = async (): Promise<never> => {
+      try {
+        await api.close()
+      } catch {
+        /* ignore */
+      }
+      try {
+        await web?.close()
+      } catch {
+        /* ignore */
+      }
+      process.exit(ExitCode.SUCCESS)
     }
-    process.on('SIGINT', shutdown)
-    process.on('SIGTERM', shutdown)
+    process.on('SIGINT', () => void shutdown())
+    process.on('SIGTERM', () => void shutdown())
 
-    api.on('error', (err) => {
-      errStderr(red(`Failed to start API: ${errorMessage(err)}`))
-      web?.kill('SIGTERM')
-      process.exit(ExitCode.GENERIC)
-    })
-    api.on('exit', (code) => {
-      web?.kill('SIGTERM')
-      process.exit(code ?? ExitCode.SUCCESS)
-    })
-
-    // Readiness probe. Default-on: poll /health until it returns 200, then
-    // emit a stable, machine-parseable line on stdout. This is the only
-    // thing `serve` puts on stdout, so callers can do:
-    //   openhop serve & wait_for=$(grep -m1 '^openhop: ready ' fd 1)
-    // Without --no-wait-ready, downstream scripts have to poll /health
-    // themselves to know when they can push.
+    // Stable, machine-parseable ready line on stdout. By the time startServer
+    // resolves, Fastify's listen() has bound the socket and all routes are
+    // registered, so /health is reachable — no need to poll.
     if (opts.waitReady !== false) {
-      const timeoutSec = Number.parseInt(opts.readyTimeout, 10) || 60
-      const apiUrl = `http://localhost:${opts.port}`
-      const webPart = opts.web !== false ? ` web=http://localhost:8788` : ''
-      const t0 = Date.now()
-      const deadline = t0 + timeoutSec * 1000
-      while (Date.now() < deadline) {
-        try {
-          const r = await fetch(`${apiUrl}/health`)
-          if (r.ok) {
-            const elapsed = Math.round((Date.now() - t0) / 100) / 10
-            process.stdout.write(`openhop: ready api=${apiUrl}${webPart} elapsed=${elapsed}s\n`)
-            break
-          }
-        } catch {
-          // Not ready yet — back off and retry.
-        }
-        await new Promise((r) => setTimeout(r, 500))
-      }
-      if (Date.now() >= deadline) {
-        errStderr(red(`✗ API did not become ready within ${timeoutSec}s. Check logs above.`))
-        // Don't exit — the children may still come up. Just warn.
-      }
+      const webPart = web ? ` web=${web.url}` : ''
+      process.stdout.write(`openhop: ready api=${api.url}${webPart} elapsed=0s\n`)
     }
   })
+
+registerDemo(program)
 
 // --- push ---
 program

--- a/packages/cli/src/web-server.ts
+++ b/packages/cli/src/web-server.ts
@@ -1,0 +1,59 @@
+/**
+ * Static web-UI server. Serves the prebuilt assets from `@openhop/web/dist/`
+ * on port 8788 (the URL contract the CLI's `push` command points clients at).
+ *
+ * Resolved via createRequire so it works whether the CLI is installed
+ * globally, locally, or invoked through `npx`. The web package ships only
+ * `dist/` (per its `files:[dist]` whitelist) — its build-time deps are not
+ * pulled in at install time.
+ */
+
+import { dirname, join } from 'node:path'
+import { createRequire } from 'node:module'
+import Fastify, { type FastifyInstance } from 'fastify'
+import fastifyStatic from '@fastify/static'
+
+export interface StartWebOptions {
+  /** TCP port. Default: 8788 (matches the URL the CLI's `push` returns). */
+  port?: number
+  /** Bind host. Default: 127.0.0.1. */
+  host?: string
+}
+
+export interface RunningWeb {
+  app: FastifyInstance
+  url: string
+  port: number
+  host: string
+  close(): Promise<void>
+}
+
+export async function startWebServer(opts: StartWebOptions = {}): Promise<RunningWeb> {
+  const port = opts.port ?? 8788
+  const host = opts.host ?? '127.0.0.1'
+
+  const require = createRequire(import.meta.url)
+  const webPkgPath = require.resolve('@openhop/web/package.json')
+  const webDistRoot = join(dirname(webPkgPath), 'dist')
+
+  const app = Fastify({ logger: false })
+  await app.register(fastifyStatic, {
+    root: webDistRoot,
+    prefix: '/',
+  })
+  // SPA fallback — `/flow/<id>` and other client-routed paths return the
+  // app shell so the web router can pick them up.
+  app.setNotFoundHandler((_req, reply) => {
+    return reply.sendFile('index.html')
+  })
+
+  await app.listen({ port, host })
+  const url = `http://${host}:${port}`
+  return {
+    app,
+    url,
+    port,
+    host,
+    close: () => app.close(),
+  }
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,32 +1,58 @@
 {
   "name": "@openhop/server",
-  "version": "0.0.1",
-  "private": true,
+  "version": "0.1.0",
+  "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/naorsabag/OpenHop.git",
+    "directory": "packages/server"
+  },
+  "homepage": "https://github.com/naorsabag/OpenHop#readme",
+  "bugs": {
+    "url": "https://github.com/naorsabag/OpenHop/issues"
+  },
+  "license": "MIT",
+  "author": "Naor Sabag (https://github.com/naorsabag)",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "dist/server.js",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/server.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/server.js --external:fastify --external:@fastify/cors --external:@fastify/swagger --external:@fastify/swagger-ui --external:nanoid --external:yaml --external:zod --external:zod-to-json-schema",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@fastify/cors": "^10.0.0",
     "@fastify/swagger": "^9.0.0",
     "@fastify/swagger-ui": "^5.2.6",
-    "@openhop/shared": "*",
     "fastify": "^5.0.0",
     "nanoid": "^5.1.11",
-    "tsx": "^4.0.0",
-    "yaml": "^2.8.4"
+    "yaml": "^2.8.4",
+    "zod": "^4.4.2",
+    "zod-to-json-schema": "^3.24.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@openhop/shared": "*",
     "@types/node": "^24.12.2",
+    "esbuild": "^0.28.0",
     "eslint": "^9.39.4",
     "globals": "^17.6.0",
+    "tsx": "^4.0.0",
     "typescript-eslint": "^8.59.1",
     "vitest": "^1.6.1"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,10 +15,10 @@
   "author": "Naor Sabag (https://github.com/naorsabag)",
   "type": "module",
   "main": "dist/server.js",
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/server.js"
     }
   },
@@ -32,8 +32,9 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/server.js --external:fastify --external:@fastify/cors --external:@fastify/swagger --external:@fastify/swagger-ui --external:nanoid --external:yaml --external:zod --external:zod-to-json-schema",
-    "prepack": "npm run build"
+    "build": "tsc -p tsconfig.build.json --emitDeclarationOnly && esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/server.js --external:fastify --external:@fastify/cors --external:@fastify/swagger --external:@fastify/swagger-ui --external:nanoid --external:yaml --external:zod --external:zod-to-json-schema",
+    "prepack": "npm run build",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@fastify/cors": "^10.0.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,59 +1,103 @@
-import Fastify from 'fastify'
+import { fileURLToPath } from 'node:url'
+import Fastify, { type FastifyInstance } from 'fastify'
 import cors from '@fastify/cors'
 import { sharedJsonSchemas } from '@openhop/shared'
 import { flowRoutes } from './routes.js'
 import { FlowStore } from './store.js'
 import { syncExampleOrderFlow } from './seed-example.js'
 
-const app = Fastify({ logger: true })
-
-// Register shared schemas once so routes can reference them by $id.
-// (Required because `flowJsonSchema` is recursive — inlining it re-binds
-// its internal `$ref: "#"` to whatever parent schema is compiling.)
-for (const schema of sharedJsonSchemas) {
-  app.addSchema(schema)
+export interface StartServerOptions {
+  /** TCP port. Default: process.env.PORT ?? 8787 */
+  port?: number
+  /** Bind host. Default: 127.0.0.1 (HOST env var overrides). */
+  host?: string
+  /** Pass through to Fastify. Default: true */
+  logger?: boolean
 }
 
-await app.register(cors, { origin: true })
-
-// Register Swagger
-try {
-  const swagger = await import('@fastify/swagger')
-  const swaggerUi = await import('@fastify/swagger-ui')
-  await app.register(swagger.default, {
-    openapi: {
-      info: {
-        title: 'OpenHop API',
-        description:
-          'Data flow visualization platform. AI tools POST flow definitions (YAML/JSON) and OpenHop renders them as animated diagrams.',
-        version: '0.1.0',
-      },
-    },
-  })
-  await app.register(swaggerUi.default, { routePrefix: '/docs' })
-} catch {
-  // Swagger deps not available, skip
+export interface RunningServer {
+  app: FastifyInstance
+  url: string
+  port: number
+  host: string
+  close(): Promise<void>
 }
 
-await app.register(flowRoutes)
+/** Build a Fastify app with OpenHop's routes registered. Does not call listen. */
+export async function buildApp(opts: { logger?: boolean } = {}): Promise<FastifyInstance> {
+  const app = Fastify({ logger: opts.logger ?? true })
 
-// Keep the built-in example flow synced with examples/order-flow.yaml.
-const store = new FlowStore()
-try {
-  const syncResult = await syncExampleOrderFlow(store)
-  if (syncResult === 'created') {
-    console.log('Seeded example flow: example-order-flow')
-  } else if (syncResult === 'updated') {
-    console.log('Updated example flow: example-order-flow')
+  // Register shared schemas once so routes can reference them by $id.
+  // (Required because `flowJsonSchema` is recursive — inlining it re-binds
+  // its internal `$ref: "#"` to whatever parent schema is compiling.)
+  for (const schema of sharedJsonSchemas) {
+    app.addSchema(schema)
   }
-} catch {
-  // No example flow available, that's fine for local development.
+
+  await app.register(cors, { origin: true })
+
+  try {
+    const swagger = await import('@fastify/swagger')
+    const swaggerUi = await import('@fastify/swagger-ui')
+    await app.register(swagger.default, {
+      openapi: {
+        info: {
+          title: 'OpenHop API',
+          description:
+            'Data flow visualization platform. AI tools POST flow definitions (YAML/JSON) and OpenHop renders them as animated diagrams.',
+          version: '0.1.0',
+        },
+      },
+    })
+    await app.register(swaggerUi.default, { routePrefix: '/docs' })
+  } catch {
+    // Swagger deps not available, skip.
+  }
+
+  await app.register(flowRoutes)
+
+  // Seed the bundled example flow into the disk-backed store, if available.
+  // FlowStore is disk-backed (~/.openhop/flows by default), so the seed write
+  // becomes visible to the routes' own FlowStore instance via the shared dir.
+  const store = new FlowStore()
+  try {
+    const syncResult = await syncExampleOrderFlow(store)
+    if (syncResult === 'created') {
+      app.log.info('Seeded example flow: example-order-flow')
+    } else if (syncResult === 'updated') {
+      app.log.info('Updated example flow: example-order-flow')
+    }
+  } catch {
+    // No example flow available, that's fine for the published package.
+  }
+
+  return app
 }
 
-const port = parseInt(process.env.PORT ?? '8787')
-// Default to loopback so a casual `npm run dev` is not exposed to the LAN.
-// Containers / docker-compose set HOST=0.0.0.0 to bind every interface.
-const host = process.env.HOST ?? '127.0.0.1'
-await app.listen({ port, host })
-console.log(`OpenHop server running on http://localhost:${port} (bound to ${host})`)
-console.log(`Swagger docs at http://localhost:${port}/docs`)
+/** Build the app and start listening. Returns a handle for in-process callers. */
+export async function startServer(opts: StartServerOptions = {}): Promise<RunningServer> {
+  const port = opts.port ?? Number.parseInt(process.env.PORT ?? '8787', 10)
+  // Default to loopback so a casual `npm run dev` is not exposed to the LAN.
+  // Containers / docker-compose set HOST=0.0.0.0 to bind every interface.
+  const host = opts.host ?? process.env.HOST ?? '127.0.0.1'
+  const app = await buildApp({ logger: opts.logger })
+  await app.listen({ port, host })
+  const url = `http://${host}:${port}`
+  return {
+    app,
+    url,
+    port,
+    host,
+    close: () => app.close(),
+  }
+}
+
+// Run as a script when this file is the program entry point. Works both for
+// `node dist/server.js` (published) and `npx tsx src/index.ts` (dev). When
+// imported as a library (CLI's `serve` and `demo` commands), the consumer
+// calls startServer() themselves and this branch is skipped.
+if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
+  const running = await startServer()
+  console.log(`OpenHop server running on ${running.url} (bound to ${running.host})`)
+  console.log(`Swagger docs at ${running.url}/docs`)
+}

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,8 +1,22 @@
 {
   "name": "@openhop/web",
-  "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
+  "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/naorsabag/OpenHop.git",
+    "directory": "packages/web"
+  },
+  "homepage": "https://github.com/naorsabag/OpenHop#readme",
+  "bugs": {
+    "url": "https://github.com/naorsabag/OpenHop/issues"
+  },
+  "license": "MIT",
+  "author": "Naor Sabag (https://github.com/naorsabag)",
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc -b --noEmit",
@@ -10,28 +24,27 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "preview": "vite preview"
-  },
-  "dependencies": {
-    "@openhop/shared": "*",
-    "@tailwindcss/vite": "^4.2.4",
-    "@xyflow/react": "^12.10.2",
-    "elkjs": "^0.11.1",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "tailwindcss": "^4.2.2"
+    "preview": "vite preview",
+    "prepack": "npm run build"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@openhop/shared": "*",
+    "@tailwindcss/vite": "^4.2.4",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^1.6.1",
+    "@xyflow/react": "^12.10.2",
+    "elkjs": "^0.11.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tailwindcss": "^4.2.2",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.1",
     "vite": "^8.0.10",

--- a/skills/openhop/SKILL.md
+++ b/skills/openhop/SKILL.md
@@ -61,13 +61,15 @@ curl -s http://localhost:8787/health
 
 If it returns `{"status":"ok"}`, OpenHop is ready.
 
-If not running, follow the install and run instructions in the repo README at `~/openhop/README.md`. If the repo doesn't exist yet, clone it first:
+If not running, start OpenHop with one command — both the API and the web UI come from the npm package:
 
 ```bash
-git clone https://github.com/naorsabag/OpenHop.git ~/openhop
+npx openhop demo    # one-shot: starts API + web UI, posts a starter flow, opens the browser
+# or
+npx openhop serve   # long-lived: starts API + web UI, no starter flow, no browser
 ```
 
-Then follow the README's Install and Run sections. After starting, open http://localhost:8788.
+Once `curl -s http://localhost:8787/health` returns `{"status":"ok"}`, the web UI is at http://localhost:8788.
 
 ## How to Work: Sketch → Detail → Polish
 


### PR DESCRIPTION
## Summary

- Closes the load-bearing v0.1 launch blockers from `openhop-launch/READINESS-AUDIT.md`: **B3** (`openhop demo` command) and **B9** (server+web were monorepo-only) plus all 6 of B9's "don't miss" sub-tasks (B9.1–B9.6) and **W6** (closed `#18–#37` README link).
- After this lands, `npx openhop` is a runnable tool, not a config-shipper. The published tarball (or, more precisely, the published `openhop` + `@openhop/server` + `@openhop/web` set) is everything a fresh machine needs to render a flow — no clone, no docker.

## Design choices

Followed the **Storybook / Remotion** shape (Option A from the audit): three independent npm packages with `openhop` as the user-facing one, depending on `@openhop/server` and `@openhop/web`.

- **`@openhop/server`** — exports `buildApp()` and `startServer({ port, host, logger })` returning a `RunningServer` handle. Still auto-starts when invoked as a script (`node dist/server.js` or `npx tsx src/index.ts`) via an `import.meta.url === fileURLToPath(process.argv[1])` guard, so the dev experience is unchanged.
- **`@openhop/web`** — ships the prebuilt Vite output as a static-assets-only package; build-time deps (react, elkjs, tailwind, vite) all moved to devDependencies so consumer installs don't pay for them.
- **`openhop` CLI** — replaces the old `spawn('npx tsx ../../server/src/index.ts')` + `spawn('npm run dev')` pair with an in-process `startServer()` call plus a tiny static server (`@fastify/static` over `@openhop/web/dist/` with SPA fallback for `/flow/<id>`).
- **`openhop demo`** — new subcommand: pick ports, boot both servers in-process, POST a bundled starter flow, open the browser via `xdg-open`/`open`/`start` (no runtime dep on the `open` package). Closes the abort criterion in `01-repo-readiness.md:37`.

## Verification

| Check | Result |
|---|---|
| `npm test --workspaces` | shared 93/93 · server 19/19 · CLI 83/83 — all pass |
| `npm run lint` | exit 0 (12 pre-existing warnings in `useFlowPolling.ts`, none from this PR) |
| `npm run format:check` | clean |
| `npm pack` per workspace | server 9.8 KB · web 880 KB · CLI 20 KB |
| Install all three tarballs in a clean `/tmp` dir + `./node_modules/.bin/openhop demo --no-open --port 18787 --web-port 18788` | `openhop: ready api=… web=… flow=…` on stdout, `/health` returns `{"status":"ok"}`, SPA fallback `/flow/<id>` returns `index.html`, SIGTERM shuts down cleanly |

This is the v0.1 acceptance gate the audit asks for — proves what `npm publish` *would* deliver, without actually publishing.

## Test plan

- [ ] CI green on Node 20 + 22 (lint, format:check, typecheck, build, test, coverage, audit, gitleaks)
- [ ] Reviewer runs `npm pack` for all three packages, installs in a clean dir, runs `npx openhop demo`, confirms the browser opens at the printed `/flow/<id>` URL
- [ ] Reviewer confirms `npx openhop serve` (the unchanged-from-user-POV command) still works the same way it did before this PR
- [ ] Reviewer eyeballs the README "Try it in 60 seconds" rewrite and the new install table
- [ ] Reviewer confirms `skills/openhop/SKILL.md` no longer tells agents to `git clone`

## Out of scope (deliberately deferred)

- `npm publish` of any of the three packages — the audit's B4 blocker, gated on this landing first
- `git tag v0.1.0` + GitHub Release notes (B5)
- B1 homepage clear, B2 social preview, B7 hero GIF, B8 PVR toggle — repo-settings work, separate PR(s)
- W11 README contact email, W12 Sentry, W13 name squatting — separate procurement track

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `npx openhop demo` (starts API + web UI, opens browser by default) and improved `serve` CLI with in-process API/web startup, configurable ports, and options like `--no-open` and `--no-web`.

* **Documentation**
  * Updated README quickstart/install and SKILL.md to recommend the new demo/serve workflows and simplified startup scenarios.
  * Added explanatory notes in docker-compose for demo/serve usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->