### PR TITLE
ci: tighten prod-tree audit gate to moderate; enable Dependabot security PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,12 @@ updates:
       production-dependencies:
         dependency-type: production
     ignore:
-      # Avoid noisy major-version PRs; bump these manually after evaluating breakage.
+      # Suppress noisy major-version PRs from regular version-update runs —
+      # bump these manually after evaluating breakage.
+      # Dependabot **security updates** (Settings → Code security → Dependabot
+      # security updates) bypass this filter by default, so CVEs that need a
+      # major bump still produce a PR. Don't tighten this without checking
+      # that the security-update path stays open.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           path: packages/*/coverage/
 
   audit:
-    name: npm audit (high+critical)
+    name: npm audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -59,7 +59,13 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npm audit --audit-level=high
+      # Production tree: stricter — anything moderate+ ships to end users.
+      - name: prod tree (moderate+)
+        run: npm audit --omit=dev --audit-level=moderate
+      # Full tree (incl. dev): looser — dev-only advisories don't reach
+      # users, so block only on high+critical to avoid noise.
+      - name: full tree (high+)
+        run: npm audit --audit-level=high
 
   gitleaks:
     name: gitleaks (secrets scan)


### PR DESCRIPTION
## Summary

- Splits the single `npm audit --audit-level=high` step into two:
  - **Prod tree** (`--omit=dev --audit-level=moderate`) — anything moderate+ that ships to end users blocks the merge.
  - **Full tree** (`--audit-level=high`) — dev-only advisories don't reach users, so block on high+critical only to avoid noise.
- Annotates `dependabot.yml`'s major-version ignore so future tightening doesn't accidentally close the security-update bypass path.

Rebased onto master after #68 merged, so the branch now contains only the CI/dependabot doc changes — the `@fastify/static` bump that closed the active CVE is already in master via #68. Dependabot auto-closed #70 for the same reason.

**Side effects already applied on the repo (via `gh api`, in scope of this audit cleanup):** Dependabot vulnerability alerts and automated security fixes are now on. `automated-security-fixes` returns `{"enabled":true,"paused":false}` (was `false`); `vulnerability-alerts` returns 204 (was 404). Security PRs bypass `dependabot.yml`'s major-version ignore, so future CVEs that need a major bump still produce a PR — closing the gap that let `GHSA-pr96-94w5-mx2h` linger between #66 and #68.

**Why now:** the W7 readiness-audit finding root-caused to two missing controls: (1) the audit gate was too lenient at `--audit-level=high`; (2) Dependabot security updates were off. Both fixed here.

**No auto-merge, no `npm i` major-bump escalation.** This PR only changes the *gate* (CI fails earlier) and the *signal* (a security PR shows up in your inbox); merging stays manual, and `package.json` ranges stay caret-pinned so `npm i` never crosses a major.

## Test plan
- [x] On master pre-#68: `npm audit --omit=dev --audit-level=moderate` exits **1** — the new gate would have caught the regression.
- [x] On master post-#68 (current rebased base): both audit gates exit 0.
- [x] All workspaces' tests pass; coverage thresholds intact.
- [x] `gh api repos/naorsabag/OpenHop/automated-security-fixes` returns `{"enabled":true,"paused":false}` (was `false`).
- [x] `gh api repos/naorsabag/OpenHop/vulnerability-alerts` returns 204 (was 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration documentation for security update handling.
  * Enhanced CI workflow to perform more comprehensive dependency audits with separate checks for production and development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->