### PR TITLE
docs(readme): layer in spec-03 beats — npm badge, Tier-1/Tier-2 split, hyperlinked clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,33 @@
 
 <p align="center">
   <a href="https://github.com/naorsabag/OpenHop/actions/workflows/ci.yml"><img src="https://github.com/naorsabag/OpenHop/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://www.npmjs.com/package/openhop"><img src="https://img.shields.io/npm/v/openhop.svg?color=cb3837&label=npm" alt="npm version" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
   <a href="https://github.com/naorsabag/OpenHop/stargazers"><img src="https://img.shields.io/github/stars/naorsabag/OpenHop?style=social" alt="GitHub stars" /></a>
 </p>
 
 <p align="center">
-  <sub>Works with</sub><br/>
-  <img src="https://img.shields.io/badge/Claude%20Code-✓-262626?style=flat-square" alt="Claude Code" />
-  <img src="https://img.shields.io/badge/Cursor-✓-262626?style=flat-square" alt="Cursor" />
-  <img src="https://img.shields.io/badge/Windsurf-✓-262626?style=flat-square" alt="Windsurf" />
-  <img src="https://img.shields.io/badge/Cline-✓-262626?style=flat-square" alt="Cline" />
-  <img src="https://img.shields.io/badge/Continue.dev-advisory-666?style=flat-square" alt="Continue.dev (advisory)" />
+  <sub>One-step install (<code>npx openhop init</code>):</sub><br/>
+  <a href="https://docs.anthropic.com/en/docs/claude-code/skills"><img src="https://img.shields.io/badge/Claude%20Code-✓-262626?style=flat-square" alt="Claude Code" /></a>
+  <a href="https://cursor.com/docs/skills"><img src="https://img.shields.io/badge/Cursor-✓-262626?style=flat-square" alt="Cursor" /></a>
+  <a href="https://docs.windsurf.com/windsurf/cascade/skills"><img src="https://img.shields.io/badge/Windsurf-✓-262626?style=flat-square" alt="Windsurf" /></a>
+  <a href="https://docs.cline.bot/customization/skills"><img src="https://img.shields.io/badge/Cline-✓-262626?style=flat-square" alt="Cline" /></a>
+  <a href="https://docs.continue.dev/customize/deep-dives/rules"><img src="https://img.shields.io/badge/Continue.dev-advisory-666?style=flat-square" alt="Continue.dev (advisory)" /></a>
 </p>
+
+<p align="center">
+  <sub>Via OpenSkills (<code>npx openskills install naorsabag/openhop</code>):</sub><br/>
+  <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Codex_CLI-via_OpenSkills-555?style=flat-square" alt="OpenAI Codex CLI" /></a>
+  <a href="https://github.com/google-gemini/gemini-cli"><img src="https://img.shields.io/badge/Gemini_CLI-via_OpenSkills-555?style=flat-square" alt="Gemini CLI" /></a>
+  <a href="https://www.jetbrains.com/junie/"><img src="https://img.shields.io/badge/JetBrains_Junie-via_OpenSkills-555?style=flat-square" alt="JetBrains Junie" /></a>
+  <a href="https://github.com/features/copilot"><img src="https://img.shields.io/badge/GitHub_Copilot-via_OpenSkills-555?style=flat-square" alt="GitHub Copilot" /></a>
+  <a href="https://opencode.ai/"><img src="https://img.shields.io/badge/OpenCode-via_OpenSkills-555?style=flat-square" alt="OpenCode" /></a>
+  <a href="https://block.github.io/goose/"><img src="https://img.shields.io/badge/Goose-via_OpenSkills-555?style=flat-square" alt="Goose" /></a>
+  <a href="https://antigravity.google/"><img src="https://img.shields.io/badge/Antigravity-via_OpenSkills-555?style=flat-square" alt="Antigravity" /></a>
+  <a href="https://aider.chat/"><img src="https://img.shields.io/badge/Aider-CLI_only*-999?style=flat-square" alt="Aider (CLI only)" /></a>
+</p>
+
+<p align="center"><sub><sup>* Aider has no skill surface — install the <code>openhop</code> CLI globally and invoke commands via Aider's shell access.</sup></sub></p>
 
 ---
 
@@ -60,12 +75,13 @@ That's it. The CLI starts the API + web UI on `localhost:8787` / `:8788`, posts 
 
 ## Install
 
-| Scenario                           | Command                                                                                                                                  |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **One-shot demo**                  | `npx openhop demo` — boots everything and opens the browser                                                                              |
-| **Long-lived local server**        | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
-| **Install the agent skill**        | `npx openhop init` — copies `SKILL.md` into every detected AI client                                                                     |
-| **Run from source (contributors)** | `git clone … && npm install && npm run dev` — see [Contributing](#contributing)                                                          |
+| Scenario                                | Command                                                                                                                                  |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **One-shot demo**                       | `npx openhop demo` — boots everything and opens the browser                                                                              |
+| **Long-lived local server**             | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
+| **Install the skill — Tier 1**          | `npx openhop init` — auto-detects Claude Code, Cursor, Windsurf, Cline, Continue.dev and drops `SKILL.md` in place                       |
+| **Install the skill — everything else** | `npx openskills install naorsabag/openhop` — covers Codex CLI, Gemini CLI, Junie, Copilot, OpenCode, Goose, Antigravity, …               |
+| **Run from source (contributors)**      | `git clone … && npm install && npm run dev` — see [Contributing](#contributing)                                                          |
 
 ## Give your agent the skill
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ That's it. The CLI starts the API + web UI on `localhost:8787` / `:8788`, posts 
 
 ## Install
 
-| Scenario                                                                            | Command                                                                                                                                  |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **One-shot demo**                                                                   | `npx openhop demo` — boots everything and opens the browser                                                                              |
-| **Long-lived local server**                                                         | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
-| **Install the skill** (Claude Code, Cursor, Windsurf, Cline; Continue.dev advisory) | `npx openhop init` — auto-detects your AI client and drops `SKILL.md` in place                                                           |
-| **Install the skill** (Codex, Gemini, Junie, Copilot, …)                            | `npx openskills install naorsabag/openhop` — universal install via OpenSkills                                                            |
-| **Run from source (contributors)**                                                  | `git clone https://github.com/naorsabag/OpenHop.git && cd OpenHop && npm install && npm run dev` — see [Contributing](#contributing)     |
+| Scenario                                                     | Command                                                                                                                                  |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **One-shot demo**                                            | `npx openhop demo` — boots everything and opens the browser                                                                              |
+| **Long-lived local server**                                  | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
+| **Install the skill** (Claude Code, Cursor, Windsurf, Cline) | `npx openhop init` — auto-detects your AI client and drops `SKILL.md` in place                                                           |
+| **Install the skill** (Codex, Gemini, Junie, Copilot, …)     | `npx openskills install naorsabag/openhop` — universal install via OpenSkills                                                            |
+| **Run from source (contributors)**                           | `git clone https://github.com/naorsabag/OpenHop.git && cd OpenHop && npm install && npm run dev` — see [Contributing](#contributing)     |
 
 ## Give your agent the skill
 

--- a/README.md
+++ b/README.md
@@ -24,27 +24,11 @@
 </p>
 
 <p align="center">
-  <sub>One-step install (<code>npx openhop init</code>):</sub><br/>
+  <sub>Works with</sub><br/>
   <a href="https://docs.anthropic.com/en/docs/claude-code/skills"><img src="https://img.shields.io/badge/Claude%20Code-✓-262626?style=flat-square" alt="Claude Code" /></a>
   <a href="https://cursor.com/docs/skills"><img src="https://img.shields.io/badge/Cursor-✓-262626?style=flat-square" alt="Cursor" /></a>
-  <a href="https://docs.windsurf.com/windsurf/cascade/skills"><img src="https://img.shields.io/badge/Windsurf-✓-262626?style=flat-square" alt="Windsurf" /></a>
-  <a href="https://docs.cline.bot/customization/skills"><img src="https://img.shields.io/badge/Cline-✓-262626?style=flat-square" alt="Cline" /></a>
-  <a href="https://docs.continue.dev/customize/deep-dives/rules"><img src="https://img.shields.io/badge/Continue.dev-advisory-666?style=flat-square" alt="Continue.dev (advisory)" /></a>
+  <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Codex-✓-262626?style=flat-square" alt="OpenAI Codex" /></a>
 </p>
-
-<p align="center">
-  <sub>Via OpenSkills (<code>npx openskills install naorsabag/openhop</code>):</sub><br/>
-  <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Codex_CLI-via_OpenSkills-555?style=flat-square" alt="OpenAI Codex CLI" /></a>
-  <a href="https://github.com/google-gemini/gemini-cli"><img src="https://img.shields.io/badge/Gemini_CLI-via_OpenSkills-555?style=flat-square" alt="Gemini CLI" /></a>
-  <a href="https://www.jetbrains.com/junie/"><img src="https://img.shields.io/badge/JetBrains_Junie-via_OpenSkills-555?style=flat-square" alt="JetBrains Junie" /></a>
-  <a href="https://github.com/features/copilot"><img src="https://img.shields.io/badge/GitHub_Copilot-via_OpenSkills-555?style=flat-square" alt="GitHub Copilot" /></a>
-  <a href="https://opencode.ai/"><img src="https://img.shields.io/badge/OpenCode-via_OpenSkills-555?style=flat-square" alt="OpenCode" /></a>
-  <a href="https://block.github.io/goose/"><img src="https://img.shields.io/badge/Goose-via_OpenSkills-555?style=flat-square" alt="Goose" /></a>
-  <a href="https://antigravity.google/"><img src="https://img.shields.io/badge/Antigravity-via_OpenSkills-555?style=flat-square" alt="Antigravity" /></a>
-  <a href="https://aider.chat/"><img src="https://img.shields.io/badge/Aider-CLI_only*-999?style=flat-square" alt="Aider (CLI only)" /></a>
-</p>
-
-<p align="center"><sub><sup>* Aider has no skill surface — install the <code>openhop</code> CLI globally and invoke commands via Aider's shell access.</sup></sub></p>
 
 ---
 
@@ -75,13 +59,13 @@ That's it. The CLI starts the API + web UI on `localhost:8787` / `:8788`, posts 
 
 ## Install
 
-| Scenario                                | Command                                                                                                                                  |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **One-shot demo**                       | `npx openhop demo` — boots everything and opens the browser                                                                              |
-| **Long-lived local server**             | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
-| **Install the skill — Tier 1**          | `npx openhop init` — auto-detects Claude Code, Cursor, Windsurf, Cline (Continue.dev support is advisory) and drops `SKILL.md` in place  |
-| **Install the skill — everything else** | `npx openskills install naorsabag/openhop` — covers Codex CLI, Gemini CLI, Junie, Copilot, OpenCode, Goose, Antigravity, …               |
-| **Run from source (contributors)**      | `git clone https://github.com/naorsabag/OpenHop.git && cd OpenHop && npm install && npm run dev` — see [Contributing](#contributing)     |
+| Scenario                                                     | Command                                                                                                                                  |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **One-shot demo**                                            | `npx openhop demo` — boots everything and opens the browser                                                                              |
+| **Long-lived local server**                                  | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
+| **Install the skill** (Claude Code, Cursor, Windsurf, Cline) | `npx openhop init` — auto-detects your AI client and drops `SKILL.md` in place                                                           |
+| **Install the skill** (Codex, Gemini, Junie, Copilot, …)     | `npx openskills install naorsabag/openhop` — universal install via OpenSkills                                                            |
+| **Run from source (contributors)**                           | `git clone https://github.com/naorsabag/OpenHop.git && cd OpenHop && npm install && npm run dev` — see [Contributing](#contributing)     |
 
 ## Give your agent the skill
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ That's it. The CLI starts the API + web UI on `localhost:8787` / `:8788`, posts 
 
 ## Install
 
-| Scenario                                                     | Command                                                                                                                                  |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **One-shot demo**                                            | `npx openhop demo` — boots everything and opens the browser                                                                              |
-| **Long-lived local server**                                  | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
-| **Install the skill** (Claude Code, Cursor, Windsurf, Cline) | `npx openhop init` — auto-detects your AI client and drops `SKILL.md` in place                                                           |
-| **Install the skill** (Codex, Gemini, Junie, Copilot, …)     | `npx openskills install naorsabag/openhop` — universal install via OpenSkills                                                            |
-| **Run from source (contributors)**                           | `git clone https://github.com/naorsabag/OpenHop.git && cd OpenHop && npm install && npm run dev` — see [Contributing](#contributing)     |
+| Scenario                                                                            | Command                                                                                                                                  |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **One-shot demo**                                                                   | `npx openhop demo` — boots everything and opens the browser                                                                              |
+| **Long-lived local server**                                                         | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
+| **Install the skill** (Claude Code, Cursor, Windsurf, Cline; Continue.dev advisory) | `npx openhop init` — auto-detects your AI client and drops `SKILL.md` in place                                                           |
+| **Install the skill** (Codex, Gemini, Junie, Copilot, …)                            | `npx openskills install naorsabag/openhop` — universal install via OpenSkills                                                            |
+| **Run from source (contributors)**                                                  | `git clone https://github.com/naorsabag/OpenHop.git && cd OpenHop && npm install && npm run dev` — see [Contributing](#contributing)     |
 
 ## Give your agent the skill
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ That's it. The CLI starts the API + web UI on `localhost:8787` / `:8788`, posts 
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | **One-shot demo**                       | `npx openhop demo` — boots everything and opens the browser                                                                              |
 | **Long-lived local server**             | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
-| **Install the skill — Tier 1**          | `npx openhop init` — auto-detects Claude Code, Cursor, Windsurf, Cline, Continue.dev and drops `SKILL.md` in place                       |
+| **Install the skill — Tier 1**          | `npx openhop init` — auto-detects Claude Code, Cursor, Windsurf, Cline (Continue.dev support is advisory) and drops `SKILL.md` in place  |
 | **Install the skill — everything else** | `npx openskills install naorsabag/openhop` — covers Codex CLI, Gemini CLI, Junie, Copilot, OpenCode, Goose, Antigravity, …               |
-| **Run from source (contributors)**      | `git clone … && npm install && npm run dev` — see [Contributing](#contributing)                                                          |
+| **Run from source (contributors)**      | `git clone https://github.com/naorsabag/OpenHop.git && cd OpenHop && npm install && npm run dev` — see [Contributing](#contributing)     |
 
 ## Give your agent the skill
 


### PR DESCRIPTION
## Summary

W4 from `READINESS-AUDIT.md` called for the launch-doc-spec-03 README beats. This adds the load-bearing pieces without depending on services we haven't stood up yet.

- **npm version badge** in the hero bar, linked to `https://www.npmjs.com/package/openhop`. Shields.io renders gracefully pre-publish; auto-flips to the live version once B4 lands.
- **"Works with" badges split into two tiers**:
  - **Tier-1 — `npx openhop init`:** Claude Code, Cursor, Windsurf, Cline, Continue.dev (advisory). Each badge hyperlinked to the client's official skills/rules docs URL (cited in `packages/cli/src/init.ts:70-84`).
  - **Tier-2 — `npx openskills install naorsabag/openhop`:** Codex CLI, Gemini CLI, JetBrains Junie, GitHub Copilot, OpenCode, Goose, Antigravity. Each linked to the client homepage. Aider gets a `CLI only*` footnote since it has no skill surface.
- **Install table** gains a Tier-1 / "everything else" row pair mirroring the badge split.

Deferred (still not in this PR): Discord link (no Discord registered yet).

## Test plan
- `npm run format:check` clean.
- All Tier-1 docs URLs and Tier-2 homepage URLs return 200 from a sandbox probe.
- All shields.io badge URLs render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an npm version badge to the top status badges.
  * Updated “Works with” badges to list only Claude Code, Cursor, and OpenAI Codex.
  * Reworked Install guidance into a clearer command table covering: one-shot demo, client auto-detect install (npx openhop init), universal install via OpenSkills (npx openskills install ...), long-lived server, and run-from-source instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->