### PR TITLE
chore: bump publishable packages to 0.1.0-beta.0 for npm pre-release dogfood

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7299,12 +7299,12 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.1.0",
+      "version": "0.1.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/static": "^9.1.3",
-        "@openhop/server": "0.1.0",
-        "@openhop/web": "0.1.0",
+        "@openhop/server": "0.1.0-beta.0",
+        "@openhop/web": "0.1.0-beta.0",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
         "yaml": "^2.8.4",
@@ -7784,7 +7784,7 @@
     },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.1.0",
+      "version": "0.1.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
@@ -8303,7 +8303,7 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.1.0",
+      "version": "0.1.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.0",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -42,8 +42,8 @@
   },
   "dependencies": {
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.1.0",
-    "@openhop/web": "0.1.0",
+    "@openhop/server": "0.1.0-beta.0",
+    "@openhop/web": "0.1.0-beta.0",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ if (process.argv.includes('--api-version')) {
 
 const program = new Command()
 
-program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0')
+program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.0')
 
 // --- serve ---
 //

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.0",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -45,7 +45,7 @@ export async function buildApp(opts: { logger?: boolean } = {}): Promise<Fastify
           title: 'OpenHop API',
           description:
             'Data flow visualization platform. AI tools POST flow definitions (YAML/JSON) and OpenHop renders them as animated diagrams.',
-          version: '0.1.0',
+          version: '0.1.0-beta.0',
         },
       },
     })

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -58,14 +58,14 @@ export async function flowRoutes(app: FastifyInstance): Promise<void> {
             type: 'object',
             properties: {
               status: { type: 'string', example: 'ok' },
-              version: { type: 'string', example: '0.1.0' },
+              version: { type: 'string', example: '0.1.0-beta.0' },
             },
           },
         },
       },
     },
     async (_req, reply) => {
-      return reply.send({ status: 'ok', version: '0.1.0' })
+      return reply.send({ status: 'ok', version: '0.1.0-beta.0' })
     }
   )
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.0",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Bumps the three publishable packages to a semver pre-release version so we can dogfood the real `npx openhop` install path without burning the launch-day v0.1.0 narrative.

- `openhop` (CLI), `@openhop/server`, `@openhop/web` → `0.1.0-beta.0`
- CLI's deps block pins both internal packages exactly (`@openhop/server: 0.1.0-beta.0`, `@openhop/web: 0.1.0-beta.0`).
- Three hardcoded version strings updated to match: CLI's `program.version()`, server's OpenAPI `info.version`, and server's `GET /health` response body.
- `openhop-monorepo` (root) and `@openhop/shared` left at their current versions — both `private: true`, never published.

## Why

We haven't actually exercised the published `npx openhop demo` cold-start path on a fresh machine yet. Once we publish, every bug we find will normally cost us a version bump. If we publish as `0.1.0` straight off, by launch day we're at `0.1.4` or whatever and the HN/PH narrative ("v0.1.0 is out") is gone.

Pre-release tags solve this cleanly:

- **`npm publish --tag beta`** (per package, run interactively after this merges) puts the artifact on npm under the `beta` dist-tag, **not** `latest`.
- `npx openhop demo` from a random user (which resolves `latest` by default) still fetches nothing — perfect, the repo is private and we don't want strangers landing on a half-baked pre-release.
- The dogfood loop becomes `npx openhop@beta demo`. One asterisk to remember.
- Bug fixes during dogfood are `beta.0` → `beta.1` → `beta.2`. The clean `0.1.0` slot stays reserved for launch day.
- Semver pre-release ordering is correct: `0.1.0-beta.0 < 0.1.0-beta.1 < 0.1.0`. So when we eventually publish `0.1.0` to `latest`, anyone on `@beta` gets nothing weird.

## Launch-day flow (after this lands)

1. Bump three `package.json`s back to `0.1.0`.
2. Same three hardcoded strings → `0.1.0`.
3. `npm publish` per package (defaults to `--tag latest`).
4. `git tag v0.1.0 && git push --tags`, `gh release create v0.1.0` — closes B5.

## Test plan
- [x] `npm install` → lockfile updated (server + web pinned to `0.1.0-beta.0`).
- [x] All workspaces' tests pass: shared 93/93, server 19/19, cli 83/83, web 22/22 = **217/217**.
- [x] `npm run lint --workspaces`, `npm run typecheck --workspaces`, `npm run format:check`, `npm run build --workspaces` — all clean.
- [x] Both audit gates green: `--omit=dev --audit-level=moderate` exit 0, `--audit-level=high` exit 0.
- [x] `node packages/cli/dist/index.js --version` → `0.1.0-beta.0`.

## Not in this PR
- The actual `npm publish --tag beta` calls. Three `npm publish` runs are interactive (need 2FA / `npm login` state) so they belong outside CI; you'll run them per package after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version updated from 0.1.0 to 0.1.0-beta.0 across CLI, server, and web packages.
  * CLI metadata/version displayed to users updated to 0.1.0-beta.0.
  * Server health endpoint and API documentation now report the new 0.1.0-beta.0 version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->