### PR TITLE
feat(web): inline YAML editor — Add/Edit modal + Delete (closes #74, partial #12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,6 +207,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -258,6 +267,114 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "dev": true,
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
+      "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -302,6 +419,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -319,6 +437,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -336,6 +455,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -353,6 +473,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -370,6 +491,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -387,6 +509,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -404,6 +527,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -421,6 +545,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -438,6 +563,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -455,6 +581,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -472,6 +599,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -489,6 +617,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -506,6 +635,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -523,6 +653,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -540,6 +671,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -557,6 +689,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -574,6 +707,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -591,6 +725,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -608,6 +743,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -625,6 +761,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -642,6 +779,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -659,6 +797,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -676,6 +815,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -693,6 +833,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -710,6 +851,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -727,6 +869,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1253,6 +1396,41 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "dev": true
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -1261,6 +1439,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -2641,6 +2825,59 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.9.tgz",
+      "integrity": "sha512-QFAqr+pu6lDmNpAlecODcF49TlsrZ0bj15zPzfhiqSDl+Um3EsDLFLppixC7kFLn+rdDM2LTvVjn5CPvefpRgw==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.9.tgz",
+      "integrity": "sha512-HftqCBUYShAOH0pGi1CHP8vfm5L8fQ3+0j0VI6lQD6QpK+UBu3J7nxfEN5O/BXMilMNf9ZyFJRvRcuMMOLHMng==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.9",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -3137,6 +3374,21 @@
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "dev": true
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3207,6 +3459,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5713,6 +5971,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7159,6 +7423,12 @@
         }
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7216,7 +7486,6 @@
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
-      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -8306,12 +8575,14 @@
       "version": "0.1.0-beta.0",
       "license": "MIT",
       "devDependencies": {
+        "@codemirror/lang-yaml": "^6.1.3",
         "@eslint/js": "^9.39.4",
         "@openhop/shared": "*",
         "@tailwindcss/vite": "^4.2.4",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@uiw/react-codemirror": "^4.25.9",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^1.6.1",
         "@xyflow/react": "^12.10.2",
@@ -8326,7 +8597,8 @@
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.59.1",
         "vite": "^8.0.10",
-        "vitest": "^1.6.1"
+        "vitest": "^1.6.1",
+        "yaml": "^2.8.4"
       }
     }
   }

--- a/packages/web/__tests__/flow-mutations.test.ts
+++ b/packages/web/__tests__/flow-mutations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import YAML from 'yaml'
 import { parseFlowYaml } from '@openhop/shared'
+import { buildStarterYaml } from '../src/components/FlowEditorModal'
 
 const VALID_YAML = `meta:
   title: Test
@@ -95,5 +96,31 @@ flow:
 
   it('canned VALID_YAML is what the e2e fetch test would POST', () => {
     expect(parseFlowYaml(VALID_YAML).success).toBe(true)
+  })
+})
+
+describe('buildStarterYaml — path injection for the per-folder "+" menu', () => {
+  it('omits meta.path when no folder is provided (root creation)', () => {
+    const yamlText = buildStarterYaml()
+    const parsed = parseFlowYaml(yamlText)
+    expect(parsed.success).toBe(true)
+    const meta = (YAML.parse(yamlText) as { meta: { path?: string } }).meta
+    expect(meta.path).toBeUndefined()
+  })
+
+  it('injects meta.path when called with a folder path', () => {
+    const yamlText = buildStarterYaml('billing/payments')
+    const parsed = parseFlowYaml(yamlText)
+    expect(parsed.success).toBe(true)
+    const meta = (YAML.parse(yamlText) as { meta: { path?: string } }).meta
+    expect(meta.path).toBe('billing/payments')
+  })
+
+  it('preserves path through nested folder creation (folder-then-flow)', () => {
+    // Sidebar's handleCreateAt('folder', 'billing') prompts for a name, splices
+    // it onto the parent path, and calls buildStarterYaml('billing/<name>').
+    const yamlText = buildStarterYaml('billing/refunds')
+    const meta = (YAML.parse(yamlText) as { meta: { path?: string } }).meta
+    expect(meta.path).toBe('billing/refunds')
   })
 })

--- a/packages/web/__tests__/flow-mutations.test.ts
+++ b/packages/web/__tests__/flow-mutations.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import YAML from 'yaml'
 import { parseFlowYaml } from '@openhop/shared'
-import { buildStarterYaml } from '../src/components/FlowEditorModal'
+import { buildStarterYaml } from '../src/lib/starter-yaml'
 
 const VALID_YAML = `meta:
   title: Test
@@ -46,24 +46,35 @@ flow:
   })
 
   it('reports path + message + suggestion for an unknown step ref', () => {
+    // Use a typo close enough that the validator's findClosest() returns a
+    // suggestion (Levenshtein-bounded). Refer to "dbb" when "db" exists →
+    // "Did you mean \"db\"?". The earlier "nonexistent" pointed at no
+    // similar id and so the hint silently dropped, missing the contract.
     const bad = `meta:
   title: T
 flow:
   nodes:
-    - id: a
-      label: A
-      type: actor
+    - id: api
+      label: API
+      type: endpoint
+    - id: db
+      label: DB
+      type: database
   steps:
-    - from: a
-      to: nonexistent
+    - from: api
+      to: dbb
       data: x
 `
     const result = parseFlowYaml(bad)
     expect(result.success).toBe(false)
     expect(result.errors.length).toBeGreaterThan(0)
     const err = result.errors[0]
-    expect(err.path).toBeTruthy()
+    expect(err.path).toBe('flow.steps[0].to')
     expect(err.message.toLowerCase()).toContain('node')
+    // Lock the modal's "[path]: msg — hint" contract: dropping the
+    // suggestion would silently lose the typo hint.
+    expect(err.suggestion).toBeTruthy()
+    expect(err.suggestion?.toLowerCase()).toContain('did you mean')
   })
 
   it('returns a validation error when the YAML is malformed / empty', () => {

--- a/packages/web/__tests__/flow-mutations.test.ts
+++ b/packages/web/__tests__/flow-mutations.test.ts
@@ -99,6 +99,38 @@ flow:
   })
 })
 
+describe('handleDeleteFolder descendant match — what gets bulk-deleted', () => {
+  // Mirror the predicate in App.handleDeleteFolder: a flow is in the folder
+  // when its path equals the folder OR starts with `${folder}/`. Locking the
+  // semantics so "delete folder billing" doesn't accidentally take billing-x
+  // or x/billing.
+  const inFolder = (folderPath: string, flowPath: string | undefined): boolean =>
+    flowPath === folderPath || (flowPath ?? '').startsWith(`${folderPath}/`)
+
+  it('matches the folder itself', () => {
+    expect(inFolder('billing', 'billing')).toBe(true)
+  })
+
+  it('matches descendants of the folder', () => {
+    expect(inFolder('billing', 'billing/refunds')).toBe(true)
+    expect(inFolder('billing', 'billing/refunds/q1')).toBe(true)
+  })
+
+  it('does NOT match siblings with the folder name as a prefix', () => {
+    expect(inFolder('billing', 'billing-tax')).toBe(false)
+    expect(inFolder('billing', 'billing2')).toBe(false)
+  })
+
+  it('does NOT match unrelated paths or root flows', () => {
+    expect(inFolder('billing', 'orders')).toBe(false)
+    expect(inFolder('billing', undefined)).toBe(false) // a flow at the root
+  })
+
+  it('does NOT match folder appearing as a non-prefix segment', () => {
+    expect(inFolder('billing', 'eu/billing')).toBe(false)
+  })
+})
+
 describe('buildStarterYaml — path injection for the per-folder "+" menu', () => {
   it('omits meta.path when no folder is provided (root creation)', () => {
     const yamlText = buildStarterYaml()

--- a/packages/web/__tests__/flow-mutations.test.ts
+++ b/packages/web/__tests__/flow-mutations.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+import { parseFlowYaml } from '@openhop/shared'
+
+const VALID_YAML = `meta:
+  title: Test
+flow:
+  nodes:
+    - id: a
+      label: A
+      type: actor
+    - id: b
+      label: B
+      type: endpoint
+  steps:
+    - from: a
+      to: b
+      data: req
+`
+
+describe('FlowEditorModal validation handshake', () => {
+  it('passes parseFlowYaml on the canned starter YAML used for "+ New flow"', () => {
+    // Mirror the STARTER_YAML constant in FlowEditorModal so the green-on-open
+    // promise from #74 ("opens with valid starter YAML") doesn't regress.
+    const STARTER_YAML = `meta:
+  title: New flow
+flow:
+  nodes:
+    - id: browser
+      label: Browser
+      type: actor
+    - id: api
+      label: API
+      type: endpoint
+  steps:
+    - from: browser
+      to: api
+      data: request
+    - from: api
+      to: browser
+      data: response
+`
+    const result = parseFlowYaml(STARTER_YAML)
+    expect(result.success).toBe(true)
+  })
+
+  it('reports path + message + suggestion for an unknown step ref', () => {
+    const bad = `meta:
+  title: T
+flow:
+  nodes:
+    - id: a
+      label: A
+      type: actor
+  steps:
+    - from: a
+      to: nonexistent
+      data: x
+`
+    const result = parseFlowYaml(bad)
+    expect(result.success).toBe(false)
+    expect(result.errors.length).toBeGreaterThan(0)
+    const err = result.errors[0]
+    expect(err.path).toBeTruthy()
+    expect(err.message.toLowerCase()).toContain('node')
+  })
+
+  it('returns a validation error when the YAML is malformed / empty', () => {
+    const result = parseFlowYaml('::: not yaml')
+    expect(result.success).toBe(false)
+    expect(result.errors.length).toBeGreaterThan(0)
+  })
+
+  it('round-trips a stored flow through YAML.stringify → YAML.parse without lossy schema changes', () => {
+    // The Edit-mode pre-population uses YAML.stringify({ meta, flow }) on the
+    // server response. This test locks in that the round-trip preserves the
+    // shape parseFlowYaml accepts — i.e. the user's first keystroke in the
+    // editor doesn't fail validation just from the round-trip.
+    const stored = {
+      meta: { title: 'Round trip', description: 'A test' },
+      flow: {
+        nodes: [
+          { id: 'a', label: 'A', type: 'actor' as const },
+          { id: 'b', label: 'B', type: 'endpoint' as const },
+        ],
+        steps: [{ from: 'a', to: 'b', data: 'req' }],
+      },
+    }
+    const yamlText = YAML.stringify(stored)
+    const reparsed = parseFlowYaml(yamlText)
+    expect(reparsed.success).toBe(true)
+    expect(reparsed.data?.meta.title).toBe('Round trip')
+    expect(reparsed.data?.flow.nodes).toHaveLength(2)
+  })
+
+  it('canned VALID_YAML is what the e2e fetch test would POST', () => {
+    expect(parseFlowYaml(VALID_YAML).success).toBe(true)
+  })
+})

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,12 +28,14 @@
     "prepack": "npm run build"
   },
   "devDependencies": {
+    "@codemirror/lang-yaml": "^6.1.3",
     "@eslint/js": "^9.39.4",
     "@openhop/shared": "*",
     "@tailwindcss/vite": "^4.2.4",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@uiw/react-codemirror": "^4.25.9",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^1.6.1",
     "@xyflow/react": "^12.10.2",
@@ -48,6 +50,7 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.1",
     "vite": "^8.0.10",
-    "vitest": "^1.6.1"
+    "vitest": "^1.6.1",
+    "yaml": "^2.8.4"
   }
 }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -113,6 +113,46 @@ function App() {
     [flows, mutations, reloadFlows, selectedFlowId, selectFlow]
   )
 
+  // Delete every flow at-or-below the given folder path. The server has no
+  // bulk-delete endpoint (and folders are virtual — they exist only as a
+  // derived view of each flow's meta.path), so we iterate. Confirms with the
+  // count up-front; bails on the first failure.
+  const handleDeleteFolder = useCallback(
+    async (folderPath: string) => {
+      if (!folderPath) return // root is undeletable; UI should never call this
+      const targets = flows.filter(
+        (f) => f.path === folderPath || (f.path ?? '').startsWith(`${folderPath}/`)
+      )
+      if (targets.length === 0) {
+        window.alert(`Folder "${folderPath}" is empty already.`)
+        return
+      }
+      const msg =
+        targets.length === 1
+          ? `Delete folder "${folderPath}" and the 1 flow inside? This cannot be undone.`
+          : `Delete folder "${folderPath}" and all ${targets.length} flows inside? This cannot be undone.`
+      if (!window.confirm(msg)) return
+
+      let failed: string | null = null
+      for (const target of targets) {
+        const ok = await mutations.deleteFlow(target.id)
+        if (!ok) {
+          failed = target.title || target.id
+          break
+        }
+      }
+      reloadFlows()
+      if (failed) {
+        window.alert(
+          `Stopped after failing to delete "${failed}" — refresh to see what's left in the folder.`
+        )
+        return
+      }
+      if (selectedFlowId && targets.some((t) => t.id === selectedFlowId)) selectFlow(null)
+    },
+    [flows, mutations, reloadFlows, selectedFlowId, selectFlow]
+  )
+
   const handleEditorSave = useCallback(
     async (yamlText: string) => {
       const created = await mutations.createFlow(yamlText)
@@ -323,6 +363,7 @@ function App() {
           onCreateAt={handleCreateAt}
           onEditFlow={handleEditFlow}
           onDeleteFlow={handleDeleteFlow}
+          onDeleteFolder={handleDeleteFolder}
         />
 
         {/* Canvas + Inspector */}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -7,7 +7,7 @@ import {
   InspectorToggle,
   type DockSide,
 } from './components/DataInspectionPanel'
-import { FlowEditorModal } from './components/FlowEditorModal'
+import { FlowEditorModal, buildStarterYaml } from './components/FlowEditorModal'
 import { useFlowList, useFlowData } from './hooks/useFlowPolling'
 import { useFlowMutations } from './hooks/useFlowMutations'
 import type { FlowNode, FlowStep, Flow } from './types'
@@ -46,16 +46,36 @@ function App() {
   const { flows, loading: listLoading, reload: reloadFlows } = useFlowList()
   const { flow: apiFlow, loading: flowLoading } = useFlowData(selectedFlowId)
 
-  // Editor modal state. mode='new' opens a blank editor; mode='edit' pre-populates.
+  // Editor modal state. mode='new' opens with a (path-aware) starter YAML;
+  // mode='edit' pre-populates from the stored flow.
   const [editor, setEditor] = useState<
-    { mode: 'closed' } | { mode: 'new' } | { mode: 'edit'; flowId: string; initialYaml: string }
+    | { mode: 'closed' }
+    | { mode: 'new'; initialYaml: string }
+    | { mode: 'edit'; flowId: string; initialYaml: string }
   >({ mode: 'closed' })
   const mutations = useFlowMutations()
 
-  const handleNewFlow = useCallback(() => {
-    mutations.reset()
-    setEditor({ mode: 'new' })
-  }, [mutations])
+  // Sidebar's per-folder "+" menu calls this with kind='flow'|'folder' and the
+  // parent folder path ('' for root). For 'folder' we prompt for a name and
+  // splice it into the path, so the modal opens with `meta.path: <parent>/<name>`.
+  const handleCreateAt = useCallback(
+    (kind: 'flow' | 'folder', parentPath: string) => {
+      mutations.reset()
+      let path = parentPath
+      if (kind === 'folder') {
+        const raw = window.prompt('New folder name:')
+        if (!raw) return
+        const name = raw
+          .trim()
+          .replace(/^\/+|\/+$/g, '')
+          .replace(/\s+/g, '-')
+        if (!name) return
+        path = parentPath ? `${parentPath}/${name}` : name
+      }
+      setEditor({ mode: 'new', initialYaml: buildStarterYaml(path || undefined) })
+    },
+    [mutations]
+  )
 
   const handleEditFlow = useCallback(
     async (flowId: string) => {
@@ -300,7 +320,7 @@ function App() {
           loading={listLoading}
           selectedFlowId={selectedFlowId}
           onSelectFlow={selectFlow}
-          onNewFlow={handleNewFlow}
+          onCreateAt={handleCreateAt}
           onEditFlow={handleEditFlow}
           onDeleteFlow={handleDeleteFlow}
         />
@@ -423,7 +443,7 @@ function App() {
       <FlowEditorModal
         open={editor.mode !== 'closed'}
         title={editor.mode === 'edit' ? 'Edit flow' : 'New flow'}
-        initialYaml={editor.mode === 'edit' ? editor.initialYaml : ''}
+        initialYaml={editor.mode === 'closed' ? '' : editor.initialYaml}
         saving={mutations.inFlight}
         serverError={mutations.error}
         onSave={handleEditorSave}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
+import YAML from 'yaml'
 import { Sidebar } from './components/Sidebar'
 import { FlowCanvas } from './components/FlowCanvas'
 import {
@@ -6,7 +7,9 @@ import {
   InspectorToggle,
   type DockSide,
 } from './components/DataInspectionPanel'
+import { FlowEditorModal } from './components/FlowEditorModal'
 import { useFlowList, useFlowData } from './hooks/useFlowPolling'
+import { useFlowMutations } from './hooks/useFlowMutations'
 import type { FlowNode, FlowStep, Flow } from './types'
 
 interface FlowNavItem {
@@ -40,8 +43,73 @@ function App() {
     return () => window.removeEventListener('popstate', handler)
   }, [])
 
-  const { flows, loading: listLoading } = useFlowList()
+  const { flows, loading: listLoading, reload: reloadFlows } = useFlowList()
   const { flow: apiFlow, loading: flowLoading } = useFlowData(selectedFlowId)
+
+  // Editor modal state. mode='new' opens a blank editor; mode='edit' pre-populates.
+  const [editor, setEditor] = useState<
+    { mode: 'closed' } | { mode: 'new' } | { mode: 'edit'; flowId: string; initialYaml: string }
+  >({ mode: 'closed' })
+  const mutations = useFlowMutations()
+
+  const handleNewFlow = useCallback(() => {
+    mutations.reset()
+    setEditor({ mode: 'new' })
+  }, [mutations])
+
+  const handleEditFlow = useCallback(
+    async (flowId: string) => {
+      mutations.reset()
+      try {
+        const res = await fetch(`/api/flows/${flowId}`)
+        if (!res.ok) {
+          window.alert(`Could not load flow ${flowId} for editing (HTTP ${res.status}).`)
+          return
+        }
+        const data = (await res.json()) as { meta: unknown; flow: unknown }
+        const yamlText = YAML.stringify({ meta: data.meta, flow: data.flow })
+        setEditor({ mode: 'edit', flowId, initialYaml: yamlText })
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        window.alert(`Could not load flow ${flowId} for editing: ${message}`)
+      }
+    },
+    [mutations]
+  )
+
+  const handleDeleteFlow = useCallback(
+    async (flowId: string) => {
+      const target = flows.find((f) => f.id === flowId)
+      const label = target?.title ? `"${target.title}"` : flowId
+      if (!window.confirm(`Delete flow ${label}? This cannot be undone.`)) return
+      const ok = await mutations.deleteFlow(flowId)
+      if (!ok) {
+        window.alert(`Failed to delete flow: ${mutations.error?.message ?? 'unknown error'}`)
+        return
+      }
+      reloadFlows()
+      if (selectedFlowId === flowId) selectFlow(null)
+    },
+    [flows, mutations, reloadFlows, selectedFlowId, selectFlow]
+  )
+
+  const handleEditorSave = useCallback(
+    async (yamlText: string) => {
+      const created = await mutations.createFlow(yamlText)
+      if (!created) return // server error stays in mutations.error; modal renders it
+      reloadFlows()
+      // For both new + edit modes we POST; selecting the new id navigates to /flow/<id>.
+      // (For edit, this means a fresh id since the server creates a new flow on POST.
+      //  Patch-ops-based in-place edit is the CLI's `openhop patch` flow — out of scope per #74.)
+      selectFlow(created.id)
+      setEditor({ mode: 'closed' })
+    },
+    [mutations, reloadFlows, selectFlow]
+  )
+
+  const handleEditorCancel = useCallback(() => {
+    setEditor({ mode: 'closed' })
+  }, [])
 
   const [playing, setPlaying] = useState(false)
   const [flowStack, setFlowStack] = useState<FlowNavItem[]>([])
@@ -232,6 +300,9 @@ function App() {
           loading={listLoading}
           selectedFlowId={selectedFlowId}
           onSelectFlow={selectFlow}
+          onNewFlow={handleNewFlow}
+          onEditFlow={handleEditFlow}
+          onDeleteFlow={handleDeleteFlow}
         />
 
         {/* Canvas + Inspector */}
@@ -347,6 +418,17 @@ function App() {
           )}
         </div>
       </div>
+
+      {/* Editor modal — overlays everything when open */}
+      <FlowEditorModal
+        open={editor.mode !== 'closed'}
+        title={editor.mode === 'edit' ? 'Edit flow' : 'New flow'}
+        initialYaml={editor.mode === 'edit' ? editor.initialYaml : ''}
+        saving={mutations.inFlight}
+        serverError={mutations.error}
+        onSave={handleEditorSave}
+        onCancel={handleEditorCancel}
+      />
     </div>
   )
 }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -7,7 +7,8 @@ import {
   InspectorToggle,
   type DockSide,
 } from './components/DataInspectionPanel'
-import { FlowEditorModal, buildStarterYaml } from './components/FlowEditorModal'
+import { FlowEditorModal } from './components/FlowEditorModal'
+import { buildStarterYaml } from './lib/starter-yaml'
 import { useFlowList, useFlowData } from './hooks/useFlowPolling'
 import { useFlowMutations } from './hooks/useFlowMutations'
 import type { FlowNode, FlowStep, Flow } from './types'
@@ -102,9 +103,9 @@ function App() {
       const target = flows.find((f) => f.id === flowId)
       const label = target?.title ? `"${target.title}"` : flowId
       if (!window.confirm(`Delete flow ${label}? This cannot be undone.`)) return
-      const ok = await mutations.deleteFlow(flowId)
-      if (!ok) {
-        window.alert(`Failed to delete flow: ${mutations.error?.message ?? 'unknown error'}`)
+      const err = await mutations.deleteFlow(flowId)
+      if (err) {
+        window.alert(`Failed to delete flow: ${err.message}`)
         return
       }
       reloadFlows()
@@ -133,18 +134,18 @@ function App() {
           : `Delete folder "${folderPath}" and all ${targets.length} flows inside? This cannot be undone.`
       if (!window.confirm(msg)) return
 
-      let failed: string | null = null
+      let failure: { label: string; message: string } | null = null
       for (const target of targets) {
-        const ok = await mutations.deleteFlow(target.id)
-        if (!ok) {
-          failed = target.title || target.id
+        const err = await mutations.deleteFlow(target.id)
+        if (err) {
+          failure = { label: target.title || target.id, message: err.message }
           break
         }
       }
       reloadFlows()
-      if (failed) {
+      if (failure) {
         window.alert(
-          `Stopped after failing to delete "${failed}" — refresh to see what's left in the folder.`
+          `Stopped after failing to delete "${failure.label}" (${failure.message}) — refresh to see what's left in the folder.`
         )
         return
       }

--- a/packages/web/src/components/FlowEditorModal.tsx
+++ b/packages/web/src/components/FlowEditorModal.tsx
@@ -46,6 +46,9 @@ export function FlowEditorModal({
   // already gated via disabled={!canSave}; this ref carries the same gate
   // into the keyboard / backdrop / Cancel paths through the closure.
   const savingRef = useRef(saving)
+  // Refs for focus management — see the focus-trap effect below.
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     onSaveRef.current = onSave
@@ -61,11 +64,60 @@ export function FlowEditorModal({
 
   const localValidation = useMemo(() => parseFlowYaml(text), [text])
 
-  // Keyboard shortcuts: Cmd/Ctrl-Enter saves, Esc cancels. Both no-op while
-  // a save is in flight (see savingRef rationale above).
+  // Focus management: on open, save the previously-focused element and move
+  // focus into the dialog. On close, restore focus. Without this, keyboard
+  // users could Tab into the sidebar/header behind the overlay even though
+  // role="dialog" + aria-modal are set.
+  useEffect(() => {
+    if (!open) return
+    previouslyFocusedRef.current = (document.activeElement as HTMLElement | null) ?? null
+    // Defer to next frame so the dialog's children (CodeMirror, buttons) are
+    // mounted and focusable.
+    const t = window.setTimeout(() => {
+      const first = dialogRef.current?.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+      if (first) first.focus()
+      else dialogRef.current?.focus()
+    }, 0)
+    return () => {
+      window.clearTimeout(t)
+      previouslyFocusedRef.current?.focus?.()
+    }
+  }, [open])
+
+  // Keyboard handler — combines:
+  //   - Esc: cancel (no-op while saving)
+  //   - Cmd/Ctrl-Enter: save (no-op while saving / invalid)
+  //   - Tab / Shift-Tab: trap focus inside the dialog
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Tab' && dialogRef.current) {
+        const focusables = Array.from(
+          dialogRef.current.querySelectorAll<HTMLElement>(
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+          )
+        )
+        if (focusables.length === 0) return
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        const active = document.activeElement
+        // Edge cases: if focus is somehow outside the dialog, pull it back in.
+        if (active && !dialogRef.current.contains(active)) {
+          e.preventDefault()
+          ;(e.shiftKey ? last : first).focus()
+          return
+        }
+        if (e.shiftKey && active === first) {
+          e.preventDefault()
+          last.focus()
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault()
+          first.focus()
+        }
+        return
+      }
       if (savingRef.current) return
       if (e.key === 'Escape') {
         e.preventDefault()
@@ -88,10 +140,12 @@ export function FlowEditorModal({
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label={title}
       data-testid="flow-editor-modal"
+      tabIndex={-1}
       onClick={(e) => {
         // Backdrop click dismisses, but only when no save is in flight — see
         // savingRef rationale at the top of the component.

--- a/packages/web/src/components/FlowEditorModal.tsx
+++ b/packages/web/src/components/FlowEditorModal.tsx
@@ -5,6 +5,11 @@ import { parseFlowYaml } from '@openhop/shared'
 import type { ValidationError } from '@openhop/shared'
 import type { MutationError } from '../hooks/useFlowMutations'
 
+/**
+ * Default seed used when the parent doesn't supply an `initialYaml`.
+ * For path-aware "New flow" / "New folder" calls the parent should build a
+ * starter via `buildStarterYaml(path)` and pass it explicitly.
+ */
 const STARTER_YAML = `meta:
   title: New flow
 flow:
@@ -23,6 +28,16 @@ flow:
       to: browser
       data: response
 `
+
+/** Build the seed YAML for a "New flow" inside a given folder path. */
+export function buildStarterYaml(path?: string): string {
+  if (!path) return STARTER_YAML
+  // Inject `path:` under meta. Match the shape of STARTER_YAML literally.
+  return STARTER_YAML.replace(
+    /^meta:\n  title: New flow\n/,
+    `meta:\n  title: New flow\n  path: ${path}\n`
+  )
+}
 
 export interface FlowEditorModalProps {
   open: boolean

--- a/packages/web/src/components/FlowEditorModal.tsx
+++ b/packages/web/src/components/FlowEditorModal.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import CodeMirror from '@uiw/react-codemirror'
+import { yaml as yamlLang } from '@codemirror/lang-yaml'
+import { parseFlowYaml } from '@openhop/shared'
+import type { ValidationError } from '@openhop/shared'
+import type { MutationError } from '../hooks/useFlowMutations'
+
+const STARTER_YAML = `meta:
+  title: New flow
+flow:
+  nodes:
+    - id: browser
+      label: Browser
+      type: actor
+    - id: api
+      label: API
+      type: endpoint
+  steps:
+    - from: browser
+      to: api
+      data: request
+    - from: api
+      to: browser
+      data: response
+`
+
+export interface FlowEditorModalProps {
+  open: boolean
+  /** Pre-populated YAML for "edit" mode. Empty string ⇒ "new" mode (uses STARTER_YAML). */
+  initialYaml: string
+  /** Header label — "New flow" / "Edit flow". */
+  title: string
+  /** True while the parent's mutation is in flight. */
+  saving: boolean
+  /** Surfaced from the parent's useFlowMutations() — server errors after save. */
+  serverError: MutationError | null
+  onSave: (yamlText: string) => void
+  onCancel: () => void
+}
+
+/**
+ * YAML editor modal. Validates locally via parseFlowYaml() (sub-100ms) so the
+ * "Save" button is disabled until the schema passes. Server errors land in
+ * serverError; we render those distinctly because they may include path
+ * suggestions that local validation didn't catch (e.g. node-ref existence).
+ */
+export function FlowEditorModal({
+  open,
+  initialYaml,
+  title,
+  saving,
+  serverError,
+  onSave,
+  onCancel,
+}: FlowEditorModalProps) {
+  const [text, setText] = useState(initialYaml || STARTER_YAML)
+  const onSaveRef = useRef(onSave)
+  const onCancelRef = useRef(onCancel)
+  const textRef = useRef(text)
+
+  useEffect(() => {
+    onSaveRef.current = onSave
+    onCancelRef.current = onCancel
+    textRef.current = text
+  })
+
+  // Re-seed the editor whenever the modal opens with a new flow.
+  useEffect(() => {
+    if (open) setText(initialYaml || STARTER_YAML)
+  }, [open, initialYaml])
+
+  const localValidation = useMemo(() => parseFlowYaml(text), [text])
+
+  // Keyboard shortcuts: Cmd/Ctrl-Enter saves, Esc cancels.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onCancelRef.current()
+      } else if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault()
+        if (parseFlowYaml(textRef.current).success) {
+          onSaveRef.current(textRef.current)
+        }
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
+
+  if (!open) return null
+
+  const validationErrors: ValidationError[] = localValidation.success ? [] : localValidation.errors
+  const canSave = localValidation.success && !saving
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      data-testid="flow-editor-modal"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel()
+      }}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+      }}
+    >
+      <div
+        className="flex flex-col"
+        style={{
+          width: 'min(720px, 90vw)',
+          height: 'min(640px, 90vh)',
+          background: '#141428',
+          border: '2px solid #2a2a4a',
+          borderRadius: 4,
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-3 py-2 shrink-0"
+          style={{ borderBottom: '1px solid #2a2a4a', background: '#1a1a2e' }}
+        >
+          <h2 className="font-pixel text-accent" style={{ fontSize: 12 }}>
+            {title}
+          </h2>
+          <button
+            aria-label="Close"
+            onClick={onCancel}
+            className="font-pixel text-text/60 hover:text-text transition-colors"
+            style={{ fontSize: 12, background: 'none', border: 'none', cursor: 'pointer' }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Editor */}
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <CodeMirror
+            data-testid="flow-editor-textarea"
+            value={text}
+            onChange={(v) => setText(v)}
+            extensions={[yamlLang()]}
+            theme="dark"
+            height="100%"
+            style={{ height: '100%', fontSize: 13 }}
+            basicSetup={{ lineNumbers: true, foldGutter: false, highlightActiveLine: true }}
+          />
+        </div>
+
+        {/* Validation feedback */}
+        <div
+          className="shrink-0 px-3 py-2 font-terminal text-xs overflow-y-auto"
+          style={{
+            maxHeight: 120,
+            borderTop: '1px solid #2a2a4a',
+            background: '#0d0d1a',
+            color: validationErrors.length > 0 || serverError ? '#ff8a8a' : '#7df9ff',
+          }}
+          data-testid="flow-editor-validation"
+        >
+          {validationErrors.length === 0 && !serverError && '✓ Valid OpenHop flow'}
+          {validationErrors.map((err, i) => (
+            <div key={i}>
+              <span className="text-text/60">{err.path || '(root)'}:</span> {err.message}
+              {err.suggestion ? <span className="text-text/40"> — {err.suggestion}</span> : null}
+            </div>
+          ))}
+          {serverError &&
+            (serverError.details && serverError.details.length > 0 ? (
+              serverError.details.map((d, i) => (
+                <div key={`s-${i}`}>
+                  <span className="text-text/60">{d.path || '(root)'}:</span> {d.message}
+                  {d.suggestion ? <span className="text-text/40"> — {d.suggestion}</span> : null}
+                </div>
+              ))
+            ) : (
+              <div>
+                <span className="text-text/60">server:</span> {serverError.message}
+              </div>
+            ))}
+        </div>
+
+        {/* Footer */}
+        <div
+          className="flex items-center justify-end gap-2 px-3 py-2 shrink-0"
+          style={{ borderTop: '1px solid #2a2a4a', background: '#1a1a2e' }}
+        >
+          <span className="font-terminal text-xs text-text/40 mr-auto">
+            ⌘/Ctrl-Enter to save · Esc to cancel
+          </span>
+          <button
+            onClick={onCancel}
+            className="font-pixel text-xs px-3 py-1 border transition-colors"
+            style={{
+              fontSize: 10,
+              background: 'transparent',
+              borderColor: '#2a2a4a',
+              color: 'rgba(224, 224, 255, 0.7)',
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            disabled={!canSave}
+            onClick={() => canSave && onSave(text)}
+            className="font-pixel text-xs px-3 py-1 border transition-colors"
+            style={{
+              fontSize: 10,
+              background: canSave ? 'rgba(125, 249, 255, 0.12)' : 'transparent',
+              borderColor: canSave ? '#7df9ff' : '#2a2a4a',
+              color: canSave ? '#7df9ff' : 'rgba(224, 224, 255, 0.3)',
+              cursor: canSave ? 'pointer' : 'not-allowed',
+            }}
+            data-testid="flow-editor-save"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/FlowEditorModal.tsx
+++ b/packages/web/src/components/FlowEditorModal.tsx
@@ -4,40 +4,7 @@ import { yaml as yamlLang } from '@codemirror/lang-yaml'
 import { parseFlowYaml } from '@openhop/shared'
 import type { ValidationError } from '@openhop/shared'
 import type { MutationError } from '../hooks/useFlowMutations'
-
-/**
- * Default seed used when the parent doesn't supply an `initialYaml`.
- * For path-aware "New flow" / "New folder" calls the parent should build a
- * starter via `buildStarterYaml(path)` and pass it explicitly.
- */
-const STARTER_YAML = `meta:
-  title: New flow
-flow:
-  nodes:
-    - id: browser
-      label: Browser
-      type: actor
-    - id: api
-      label: API
-      type: endpoint
-  steps:
-    - from: browser
-      to: api
-      data: request
-    - from: api
-      to: browser
-      data: response
-`
-
-/** Build the seed YAML for a "New flow" inside a given folder path. */
-export function buildStarterYaml(path?: string): string {
-  if (!path) return STARTER_YAML
-  // Inject `path:` under meta. Match the shape of STARTER_YAML literally.
-  return STARTER_YAML.replace(
-    /^meta:\n  title: New flow\n/,
-    `meta:\n  title: New flow\n  path: ${path}\n`
-  )
-}
+import { STARTER_YAML } from '../lib/starter-yaml'
 
 export interface FlowEditorModalProps {
   open: boolean
@@ -72,11 +39,19 @@ export function FlowEditorModal({
   const onSaveRef = useRef(onSave)
   const onCancelRef = useRef(onCancel)
   const textRef = useRef(text)
+  // While `saving` is true we freeze every dismiss + save trigger:
+  // POST /api/flows is non-idempotent, so allowing Cmd+Enter to fire twice
+  // (or Esc/backdrop to "dismiss" while a save is mid-flight) would create
+  // duplicate flows or hidden background saves. The Save button itself is
+  // already gated via disabled={!canSave}; this ref carries the same gate
+  // into the keyboard / backdrop / Cancel paths through the closure.
+  const savingRef = useRef(saving)
 
   useEffect(() => {
     onSaveRef.current = onSave
     onCancelRef.current = onCancel
     textRef.current = text
+    savingRef.current = saving
   })
 
   // Re-seed the editor whenever the modal opens with a new flow.
@@ -86,10 +61,12 @@ export function FlowEditorModal({
 
   const localValidation = useMemo(() => parseFlowYaml(text), [text])
 
-  // Keyboard shortcuts: Cmd/Ctrl-Enter saves, Esc cancels.
+  // Keyboard shortcuts: Cmd/Ctrl-Enter saves, Esc cancels. Both no-op while
+  // a save is in flight (see savingRef rationale above).
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
+      if (savingRef.current) return
       if (e.key === 'Escape') {
         e.preventDefault()
         onCancelRef.current()
@@ -116,7 +93,9 @@ export function FlowEditorModal({
       aria-label={title}
       data-testid="flow-editor-modal"
       onClick={(e) => {
-        if (e.target === e.currentTarget) onCancel()
+        // Backdrop click dismisses, but only when no save is in flight — see
+        // savingRef rationale at the top of the component.
+        if (!saving && e.target === e.currentTarget) onCancel()
       }}
       style={{
         position: 'fixed',
@@ -150,7 +129,8 @@ export function FlowEditorModal({
           <button
             aria-label="Close"
             onClick={onCancel}
-            className="font-pixel text-text/60 hover:text-text transition-colors"
+            disabled={saving}
+            className="font-pixel text-text/60 hover:text-text transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ fontSize: 12, background: 'none', border: 'none', cursor: 'pointer' }}
           >
             ✕
@@ -214,7 +194,8 @@ export function FlowEditorModal({
           </span>
           <button
             onClick={onCancel}
-            className="font-pixel text-xs px-3 py-1 border transition-colors"
+            disabled={saving}
+            className="font-pixel text-xs px-3 py-1 border transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             style={{
               fontSize: 10,
               background: 'transparent',

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -166,8 +166,11 @@ interface TreeItemProps {
   onSelectFlow: (id: string) => void
   onEditFlow?: (id: string) => void
   onDeleteFlow?: (id: string) => void
+  onDeleteFolder?: (path: string) => void
   onCreateAt?: (kind: 'flow' | 'folder', parentPath: string) => void
   addMenu?: AddMenuState
+  /** Marks the synthetic top-level "/" row. Always expanded, no delete, no toggle caret. */
+  isRoot?: boolean
 }
 
 function TreeItem({
@@ -179,58 +182,112 @@ function TreeItem({
   onSelectFlow,
   onEditFlow,
   onDeleteFlow,
+  onDeleteFolder,
   onCreateAt,
   addMenu,
+  isRoot,
 }: TreeItemProps) {
   if (node.type === 'folder') {
-    const expanded = expandedFolders.has(node.path)
+    // Root is always expanded \u2014 collapsing the workspace serves no purpose
+    // and would just hide the entire tree.
+    const expanded = isRoot || expandedFolders.has(node.path)
     const showAddBtn = !!onCreateAt
+    const showDeleteBtn = !isRoot && !!onDeleteFolder
     const menuOpen = addMenu?.openForPath === node.path
     // Wrap the header in its own .group/folder.relative so hover and absolute
     // positioning scope to just the folder header row, not the entire expanded
     // subtree (which includes child <ul>). Without this, "top: 50%" on the
     // "+" button lands at the geometric center of the whole subtree, and
     // hovering a child flow row triggers the parent folder's group-hover.
+    const rowPaddingLeft = depth * 16 + 8
+    const headerLabel = isRoot ? '/' : node.name
     return (
-      <li role="treeitem" aria-expanded={expanded} data-testid={`folder-${node.path}`}>
+      <li
+        role="treeitem"
+        aria-expanded={expanded}
+        data-testid={isRoot ? 'folder-root' : `folder-${node.path}`}
+      >
         <div className="group/folder relative">
-          <button
-            onClick={() => toggleFolder(node.path)}
-            className="flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm text-text/70 hover:text-text transition-colors pr-7"
-            style={{ paddingLeft: depth * 16 + 8, cursor: 'pointer' }}
-          >
-            <span className="shrink-0 text-xs" style={{ width: 16, textAlign: 'center' }}>
-              {expanded ? '\u25BE' : '\u25B8'}
-            </span>
-            <span className="truncate">{node.name}</span>
-          </button>
-          {showAddBtn && (
-            <button
-              aria-label={`Add inside ${node.name}`}
-              data-testid={`sidebar-add-${node.path}`}
-              onClick={(e) => {
-                e.stopPropagation()
-                addMenu?.setOpenForPath(menuOpen ? null : node.path)
-              }}
-              title="Add (flow or folder)"
-              className={`absolute right-2 top-1/2 -translate-y-1/2 font-pixel transition-opacity ${
-                menuOpen
-                  ? 'opacity-100'
-                  : 'opacity-0 group-hover/folder:opacity-100 focus:opacity-100'
-              }`}
-              style={{
-                background: 'transparent',
-                border: 'none',
-                color: menuOpen ? '#7df9ff' : 'rgba(224, 224, 255, 0.7)',
-                cursor: 'pointer',
-                padding: '0 4px',
-                fontSize: 14,
-                lineHeight: 1,
-              }}
+          {isRoot ? (
+            // Root row \u2014 non-toggleable, slightly emphasized.
+            <div
+              className="flex items-center gap-1.5 w-full py-1 font-terminal text-sm text-text/80 pr-12"
+              style={{ paddingLeft: rowPaddingLeft }}
             >
-              {'+'}
+              <span
+                className="shrink-0 text-xs"
+                style={{ width: 16, textAlign: 'center', opacity: 0.5 }}
+              >
+                {'/'}
+              </span>
+              <span className="truncate text-text/90">{headerLabel}</span>
+            </div>
+          ) : (
+            <button
+              onClick={() => toggleFolder(node.path)}
+              className="flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm text-text/70 hover:text-text transition-colors pr-12"
+              style={{ paddingLeft: rowPaddingLeft, cursor: 'pointer' }}
+            >
+              <span className="shrink-0 text-xs" style={{ width: 16, textAlign: 'center' }}>
+                {expanded ? '\u25BE' : '\u25B8'}
+              </span>
+              <span className="truncate">{headerLabel}</span>
             </button>
           )}
+          <div
+            className={`absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 transition-opacity ${
+              menuOpen
+                ? 'opacity-100'
+                : 'opacity-0 group-hover/folder:opacity-100 focus-within:opacity-100'
+            }`}
+          >
+            {showAddBtn && (
+              <button
+                aria-label={`Add inside ${headerLabel}`}
+                data-testid={isRoot ? 'sidebar-add-root' : `sidebar-add-${node.path}`}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  addMenu?.setOpenForPath(menuOpen ? null : node.path)
+                }}
+                title="Add (flow or folder)"
+                className="font-pixel transition-colors"
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  color: menuOpen ? '#7df9ff' : 'rgba(224, 224, 255, 0.7)',
+                  cursor: 'pointer',
+                  padding: '0 4px',
+                  fontSize: 14,
+                  lineHeight: 1,
+                }}
+              >
+                {'+'}
+              </button>
+            )}
+            {showDeleteBtn && (
+              <button
+                aria-label={`Delete folder ${node.name}`}
+                data-testid={`sidebar-delete-folder-${node.path}`}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onDeleteFolder?.(node.path)
+                }}
+                title="Delete folder"
+                className="font-pixel text-xs hover:text-red-400 transition-colors"
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  color: 'rgba(224, 224, 255, 0.5)',
+                  cursor: 'pointer',
+                  padding: '0 4px',
+                  fontSize: 11,
+                  lineHeight: 1,
+                }}
+              >
+                {'\u2715'}
+              </button>
+            )}
+          </div>
           {menuOpen && onCreateAt && (
             <AddMenu
               parentPath={node.path}
@@ -252,6 +309,7 @@ function TreeItem({
                 onSelectFlow={onSelectFlow}
                 onEditFlow={onEditFlow}
                 onDeleteFlow={onDeleteFlow}
+                onDeleteFolder={onDeleteFolder}
                 onCreateAt={onCreateAt}
                 addMenu={addMenu}
               />
@@ -273,7 +331,9 @@ function TreeItem({
     >
       <button
         onClick={() => flowId && onSelectFlow(flowId)}
-        className="flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm transition-colors truncate pr-12"
+        className={`flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm transition-colors truncate pr-12 ${
+          isActive ? '' : 'hover:bg-white/5 hover:text-text'
+        }`}
         style={{
           paddingLeft: depth * 16 + 8,
           color: isActive ? '#7df9ff' : 'rgba(224, 224, 255, 0.6)',
@@ -350,6 +410,8 @@ interface SidebarProps {
   onCreateAt?: (kind: 'flow' | 'folder', parentPath: string) => void
   onEditFlow?: (id: string) => void
   onDeleteFlow?: (id: string) => void
+  /** Delete a folder and every flow whose meta.path is at-or-below it. Not callable on root. */
+  onDeleteFolder?: (path: string) => void
 }
 
 export function Sidebar({
@@ -360,6 +422,7 @@ export function Sidebar({
   onCreateAt,
   onEditFlow,
   onDeleteFlow,
+  onDeleteFolder,
 }: SidebarProps) {
   const [addMenuPath, setAddMenuPath] = useState<string | null>(null)
   const addMenu: AddMenuState = useMemo(
@@ -422,72 +485,44 @@ export function Sidebar({
       style={{ width: 260, background: '#141428', borderRight: '2px solid #2a2a4a' }}
       aria-label="File explorer"
     >
-      {/* Search + root-level "+" */}
-      <div
-        className="p-2 shrink-0 flex items-center gap-2 relative"
-        style={{ borderBottom: '1px solid #2a2a4a' }}
-      >
+      {/* Search */}
+      <div className="p-2 shrink-0" style={{ borderBottom: '1px solid #2a2a4a' }}>
         <input
           aria-label="Search flows"
           type="text"
           placeholder="Search..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="flex-1 px-2 py-1.5 rounded font-terminal text-xs text-text placeholder-text/30 outline-none focus:ring-1 focus:ring-accent"
+          className="w-full px-2 py-1.5 rounded font-terminal text-xs text-text placeholder-text/30 outline-none focus:ring-1 focus:ring-accent"
           style={{ background: '#1a1a2e', border: '1px solid #2a2a4a' }}
         />
-        {onCreateAt && (
-          <>
-            <button
-              aria-label="Add at root"
-              data-testid="sidebar-add-root"
-              onClick={() => setAddMenuPath(addMenuPath === '' ? null : '')}
-              title="Add (flow or folder)"
-              className="font-pixel text-sm transition-colors"
-              style={{
-                background: 'transparent',
-                border: '1px solid #2a2a4a',
-                borderRadius: 4,
-                color: addMenuPath === '' ? '#7df9ff' : 'rgba(224, 224, 255, 0.7)',
-                cursor: 'pointer',
-                padding: '2px 8px',
-                lineHeight: 1.2,
-              }}
-            >
-              {'+'}
-            </button>
-            {addMenuPath === '' && (
-              <AddMenu parentPath="" onClose={() => setAddMenuPath(null)} onCreateAt={onCreateAt} />
-            )}
-          </>
-        )}
       </div>
 
-      {/* Tree */}
+      {/* Tree — root row is synthetic and always present so users can add at "/" */}
       <div className="flex-1 overflow-y-auto py-1">
         {loading ? (
           <p className="text-text/40 font-terminal text-xs px-3 py-4">Loading...</p>
-        ) : displayTree.length === 0 ? (
-          <p className="text-text/40 font-terminal text-xs px-3 py-4">
-            {search ? 'No matches' : 'No flows yet'}
-          </p>
         ) : (
           <ul role="tree">
-            {displayTree.map((node, i) => (
-              <TreeItem
-                key={node.type === 'flow' ? node.flowId : `${node.path}-${i}`}
-                node={node}
-                depth={0}
-                selectedFlowId={selectedFlowId}
-                expandedFolders={expandedFolders}
-                toggleFolder={toggleFolder}
-                onSelectFlow={handleSelectFlow}
-                onEditFlow={onEditFlow}
-                onDeleteFlow={onDeleteFlow}
-                onCreateAt={onCreateAt}
-                addMenu={addMenu}
-              />
-            ))}
+            <TreeItem
+              node={{ name: '/', type: 'folder', path: '', children: displayTree }}
+              depth={0}
+              selectedFlowId={selectedFlowId}
+              expandedFolders={expandedFolders}
+              toggleFolder={toggleFolder}
+              onSelectFlow={handleSelectFlow}
+              onEditFlow={onEditFlow}
+              onDeleteFlow={onDeleteFlow}
+              onDeleteFolder={onDeleteFolder}
+              onCreateAt={onCreateAt}
+              addMenu={addMenu}
+              isRoot
+            />
+            {displayTree.length === 0 && (
+              <li className="text-text/40 font-terminal text-xs px-3 py-3" aria-live="polite">
+                {search ? 'No matches' : 'No flows yet — add one with the "+" above.'}
+              </li>
+            )}
           </ul>
         )}
       </div>

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -331,15 +331,12 @@ function TreeItem({
     >
       <button
         onClick={() => flowId && onSelectFlow(flowId)}
-        className={`flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm transition-colors truncate pr-12 ${
-          isActive ? '' : 'hover:bg-white/5 hover:text-text'
+        className={`flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm transition-colors truncate pr-12 cursor-pointer ${
+          isActive
+            ? 'text-[#7df9ff] bg-[rgba(125,249,255,0.08)]'
+            : 'text-text/60 hover:text-text hover:bg-white/5'
         }`}
-        style={{
-          paddingLeft: depth * 16 + 8,
-          color: isActive ? '#7df9ff' : 'rgba(224, 224, 255, 0.6)',
-          background: isActive ? 'rgba(125, 249, 255, 0.08)' : 'transparent',
-          cursor: 'pointer',
-        }}
+        style={{ paddingLeft: depth * 16 + 8 }}
       >
         <span className="shrink-0 text-xs" style={{ width: 16, textAlign: 'center', opacity: 0.5 }}>
           {'\u25C7'}

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -191,7 +191,7 @@ function TreeItem({
         role="treeitem"
         aria-expanded={expanded}
         data-testid={`folder-${node.path}`}
-        className="group relative"
+        className="group/folder relative"
       >
         <button
           onClick={() => toggleFolder(node.path)}
@@ -213,7 +213,9 @@ function TreeItem({
             }}
             title="Add (flow or folder)"
             className={`absolute right-2 top-1/2 -translate-y-1/2 font-pixel text-xs transition-opacity ${
-              menuOpen ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus:opacity-100'
+              menuOpen
+                ? 'opacity-100'
+                : 'opacity-0 group-hover/folder:opacity-100 focus:opacity-100'
             }`}
             style={{
               background: 'transparent',
@@ -264,7 +266,7 @@ function TreeItem({
       role="treeitem"
       aria-selected={isActive}
       data-testid={`sidebar-flow-${flowId}`}
-      className="group relative"
+      className="group/flow relative"
     >
       <button
         onClick={() => flowId && onSelectFlow(flowId)}
@@ -283,7 +285,7 @@ function TreeItem({
       </button>
       {flowId && (onEditFlow || onDeleteFlow) && (
         <div
-          className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
+          className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover/flow:opacity-100 focus-within:opacity-100 transition-opacity"
           style={{ pointerEvents: 'auto' }}
         >
           {onEditFlow && (

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -68,6 +68,95 @@ function filterTree(nodes: TreeNode[], query: string): TreeNode[] {
   return result
 }
 
+interface AddMenuState {
+  /** Full folder path for which the menu is open. `''` represents the root. `null` = closed. */
+  openForPath: string | null
+  setOpenForPath: (path: string | null) => void
+}
+
+interface AddMenuProps {
+  parentPath: string // '' for root
+  onClose: () => void
+  onCreateAt: (kind: 'flow' | 'folder', parentPath: string) => void
+}
+
+function AddMenu({ parentPath, onClose, onCreateAt }: AddMenuProps) {
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  // Close on outside click / Esc.
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    // Defer the click listener until next tick so the click that opened the
+    // menu (which bubbles up to document) doesn't immediately close it.
+    const t = setTimeout(() => document.addEventListener('mousedown', onDoc), 0)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      clearTimeout(t)
+      document.removeEventListener('mousedown', onDoc)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      data-testid={`add-menu-${parentPath}`}
+      className="absolute z-20 font-terminal text-xs flex flex-col"
+      style={{
+        right: 8,
+        top: 'calc(100% + 2px)',
+        background: '#1a1a2e',
+        border: '1px solid #2a2a4a',
+        borderRadius: 4,
+        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.4)',
+        minWidth: 130,
+      }}
+    >
+      <button
+        role="menuitem"
+        data-testid={`add-menu-${parentPath}-flow`}
+        onClick={() => {
+          onCreateAt('flow', parentPath)
+          onClose()
+        }}
+        className="text-left px-3 py-2 hover:bg-white/5 transition-colors"
+        style={{
+          background: 'none',
+          border: 'none',
+          color: 'rgba(224, 224, 255, 0.85)',
+          cursor: 'pointer',
+        }}
+      >
+        📄 New flow
+      </button>
+      <button
+        role="menuitem"
+        data-testid={`add-menu-${parentPath}-folder`}
+        onClick={() => {
+          onCreateAt('folder', parentPath)
+          onClose()
+        }}
+        className="text-left px-3 py-2 hover:bg-white/5 transition-colors"
+        style={{
+          background: 'none',
+          border: 'none',
+          color: 'rgba(224, 224, 255, 0.85)',
+          cursor: 'pointer',
+          borderTop: '1px solid #2a2a4a',
+        }}
+      >
+        📁 New folder
+      </button>
+    </div>
+  )
+}
+
 interface TreeItemProps {
   node: TreeNode
   depth: number
@@ -77,6 +166,8 @@ interface TreeItemProps {
   onSelectFlow: (id: string) => void
   onEditFlow?: (id: string) => void
   onDeleteFlow?: (id: string) => void
+  onCreateAt?: (kind: 'flow' | 'folder', parentPath: string) => void
+  addMenu?: AddMenuState
 }
 
 function TreeItem({
@@ -88,14 +179,23 @@ function TreeItem({
   onSelectFlow,
   onEditFlow,
   onDeleteFlow,
+  onCreateAt,
+  addMenu,
 }: TreeItemProps) {
   if (node.type === 'folder') {
     const expanded = expandedFolders.has(node.path)
+    const showAddBtn = !!onCreateAt
+    const menuOpen = addMenu?.openForPath === node.path
     return (
-      <li role="treeitem" aria-expanded={expanded} data-testid={`folder-${node.path}`}>
+      <li
+        role="treeitem"
+        aria-expanded={expanded}
+        data-testid={`folder-${node.path}`}
+        className="group relative"
+      >
         <button
           onClick={() => toggleFolder(node.path)}
-          className="flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm text-text/70 hover:text-text transition-colors"
+          className="flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm text-text/70 hover:text-text transition-colors pr-7"
           style={{ paddingLeft: depth * 16 + 8, cursor: 'pointer' }}
         >
           <span className="shrink-0 text-xs" style={{ width: 16, textAlign: 'center' }}>
@@ -103,6 +203,37 @@ function TreeItem({
           </span>
           <span className="truncate">{node.name}</span>
         </button>
+        {showAddBtn && (
+          <button
+            aria-label={`Add inside ${node.name}`}
+            data-testid={`sidebar-add-${node.path}`}
+            onClick={(e) => {
+              e.stopPropagation()
+              addMenu?.setOpenForPath(menuOpen ? null : node.path)
+            }}
+            title="Add (flow or folder)"
+            className={`absolute right-2 top-1/2 -translate-y-1/2 font-pixel text-xs transition-opacity ${
+              menuOpen ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus:opacity-100'
+            }`}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: menuOpen ? '#7df9ff' : 'rgba(224, 224, 255, 0.6)',
+              cursor: 'pointer',
+              padding: '0 4px',
+              fontSize: 12,
+            }}
+          >
+            {'+'}
+          </button>
+        )}
+        {menuOpen && onCreateAt && (
+          <AddMenu
+            parentPath={node.path}
+            onClose={() => addMenu?.setOpenForPath(null)}
+            onCreateAt={onCreateAt}
+          />
+        )}
         {expanded && (
           <ul role="group">
             {node.children.map((child, i) => (
@@ -116,6 +247,8 @@ function TreeItem({
                 onSelectFlow={onSelectFlow}
                 onEditFlow={onEditFlow}
                 onDeleteFlow={onDeleteFlow}
+                onCreateAt={onCreateAt}
+                addMenu={addMenu}
               />
             ))}
           </ul>
@@ -208,7 +341,8 @@ interface SidebarProps {
   loading: boolean
   selectedFlowId: string | null
   onSelectFlow: (id: string | null) => void
-  onNewFlow?: () => void
+  /** parentPath is `''` for root, or the folder path for nested creation. */
+  onCreateAt?: (kind: 'flow' | 'folder', parentPath: string) => void
   onEditFlow?: (id: string) => void
   onDeleteFlow?: (id: string) => void
 }
@@ -218,10 +352,15 @@ export function Sidebar({
   loading,
   selectedFlowId,
   onSelectFlow,
-  onNewFlow,
+  onCreateAt,
   onEditFlow,
   onDeleteFlow,
 }: SidebarProps) {
+  const [addMenuPath, setAddMenuPath] = useState<string | null>(null)
+  const addMenu: AddMenuState = useMemo(
+    () => ({ openForPath: addMenuPath, setOpenForPath: setAddMenuPath }),
+    [addMenuPath]
+  )
   const [search, setSearch] = useState('')
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set())
 
@@ -278,37 +417,45 @@ export function Sidebar({
       style={{ width: 260, background: '#141428', borderRight: '2px solid #2a2a4a' }}
       aria-label="File explorer"
     >
-      {/* New + Search */}
+      {/* Search + root-level "+" */}
       <div
-        className="p-2 shrink-0 flex flex-col gap-2"
+        className="p-2 shrink-0 flex items-center gap-2 relative"
         style={{ borderBottom: '1px solid #2a2a4a' }}
       >
-        {onNewFlow && (
-          <button
-            aria-label="New flow"
-            data-testid="sidebar-new-flow"
-            onClick={onNewFlow}
-            className="w-full font-pixel text-xs py-1.5 border transition-colors"
-            style={{
-              fontSize: 10,
-              background: 'rgba(125, 249, 255, 0.08)',
-              borderColor: '#7df9ff',
-              color: '#7df9ff',
-              cursor: 'pointer',
-            }}
-          >
-            + New flow
-          </button>
-        )}
         <input
           aria-label="Search flows"
           type="text"
           placeholder="Search..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-full px-2 py-1.5 rounded font-terminal text-xs text-text placeholder-text/30 outline-none focus:ring-1 focus:ring-accent"
+          className="flex-1 px-2 py-1.5 rounded font-terminal text-xs text-text placeholder-text/30 outline-none focus:ring-1 focus:ring-accent"
           style={{ background: '#1a1a2e', border: '1px solid #2a2a4a' }}
         />
+        {onCreateAt && (
+          <>
+            <button
+              aria-label="Add at root"
+              data-testid="sidebar-add-root"
+              onClick={() => setAddMenuPath(addMenuPath === '' ? null : '')}
+              title="Add (flow or folder)"
+              className="font-pixel text-sm transition-colors"
+              style={{
+                background: 'transparent',
+                border: '1px solid #2a2a4a',
+                borderRadius: 4,
+                color: addMenuPath === '' ? '#7df9ff' : 'rgba(224, 224, 255, 0.7)',
+                cursor: 'pointer',
+                padding: '2px 8px',
+                lineHeight: 1.2,
+              }}
+            >
+              {'+'}
+            </button>
+            {addMenuPath === '' && (
+              <AddMenu parentPath="" onClose={() => setAddMenuPath(null)} onCreateAt={onCreateAt} />
+            )}
+          </>
+        )}
       </div>
 
       {/* Tree */}
@@ -332,6 +479,8 @@ export function Sidebar({
                 onSelectFlow={handleSelectFlow}
                 onEditFlow={onEditFlow}
                 onDeleteFlow={onDeleteFlow}
+                onCreateAt={onCreateAt}
+                addMenu={addMenu}
               />
             ))}
           </ul>

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -75,6 +75,8 @@ interface TreeItemProps {
   expandedFolders: Set<string>
   toggleFolder: (path: string) => void
   onSelectFlow: (id: string) => void
+  onEditFlow?: (id: string) => void
+  onDeleteFlow?: (id: string) => void
 }
 
 function TreeItem({
@@ -84,6 +86,8 @@ function TreeItem({
   expandedFolders,
   toggleFolder,
   onSelectFlow,
+  onEditFlow,
+  onDeleteFlow,
 }: TreeItemProps) {
   if (node.type === 'folder') {
     const expanded = expandedFolders.has(node.path)
@@ -110,6 +114,8 @@ function TreeItem({
                 expandedFolders={expandedFolders}
                 toggleFolder={toggleFolder}
                 onSelectFlow={onSelectFlow}
+                onEditFlow={onEditFlow}
+                onDeleteFlow={onDeleteFlow}
               />
             ))}
           </ul>
@@ -119,11 +125,17 @@ function TreeItem({
   }
 
   const isActive = node.flowId === selectedFlowId
+  const flowId = node.flowId
   return (
-    <li role="treeitem" aria-selected={isActive} data-testid={`sidebar-flow-${node.flowId}`}>
+    <li
+      role="treeitem"
+      aria-selected={isActive}
+      data-testid={`sidebar-flow-${flowId}`}
+      className="group relative"
+    >
       <button
-        onClick={() => node.flowId && onSelectFlow(node.flowId)}
-        className="flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm transition-colors truncate"
+        onClick={() => flowId && onSelectFlow(flowId)}
+        className="flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm transition-colors truncate pr-12"
         style={{
           paddingLeft: depth * 16 + 8,
           color: isActive ? '#7df9ff' : 'rgba(224, 224, 255, 0.6)',
@@ -136,6 +148,57 @@ function TreeItem({
         </span>
         <span className="truncate">{node.name}</span>
       </button>
+      {flowId && (onEditFlow || onDeleteFlow) && (
+        <div
+          className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
+          style={{ pointerEvents: 'auto' }}
+        >
+          {onEditFlow && (
+            <button
+              aria-label={`Edit ${node.name}`}
+              data-testid={`sidebar-edit-${flowId}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                onEditFlow(flowId)
+              }}
+              title="Edit (E)"
+              className="font-pixel text-xs hover:text-accent transition-colors"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: 'rgba(224, 224, 255, 0.5)',
+                cursor: 'pointer',
+                padding: '0 4px',
+                fontSize: 11,
+              }}
+            >
+              {'\u270E'}
+            </button>
+          )}
+          {onDeleteFlow && (
+            <button
+              aria-label={`Delete ${node.name}`}
+              data-testid={`sidebar-delete-${flowId}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                onDeleteFlow(flowId)
+              }}
+              title="Delete"
+              className="font-pixel text-xs hover:text-red-400 transition-colors"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: 'rgba(224, 224, 255, 0.5)',
+                cursor: 'pointer',
+                padding: '0 4px',
+                fontSize: 11,
+              }}
+            >
+              {'\u2715'}
+            </button>
+          )}
+        </div>
+      )}
     </li>
   )
 }
@@ -145,9 +208,20 @@ interface SidebarProps {
   loading: boolean
   selectedFlowId: string | null
   onSelectFlow: (id: string | null) => void
+  onNewFlow?: () => void
+  onEditFlow?: (id: string) => void
+  onDeleteFlow?: (id: string) => void
 }
 
-export function Sidebar({ flows, loading, selectedFlowId, onSelectFlow }: SidebarProps) {
+export function Sidebar({
+  flows,
+  loading,
+  selectedFlowId,
+  onSelectFlow,
+  onNewFlow,
+  onEditFlow,
+  onDeleteFlow,
+}: SidebarProps) {
   const [search, setSearch] = useState('')
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set())
 
@@ -204,8 +278,28 @@ export function Sidebar({ flows, loading, selectedFlowId, onSelectFlow }: Sideba
       style={{ width: 260, background: '#141428', borderRight: '2px solid #2a2a4a' }}
       aria-label="File explorer"
     >
-      {/* Search */}
-      <div className="p-2 shrink-0" style={{ borderBottom: '1px solid #2a2a4a' }}>
+      {/* New + Search */}
+      <div
+        className="p-2 shrink-0 flex flex-col gap-2"
+        style={{ borderBottom: '1px solid #2a2a4a' }}
+      >
+        {onNewFlow && (
+          <button
+            aria-label="New flow"
+            data-testid="sidebar-new-flow"
+            onClick={onNewFlow}
+            className="w-full font-pixel text-xs py-1.5 border transition-colors"
+            style={{
+              fontSize: 10,
+              background: 'rgba(125, 249, 255, 0.08)',
+              borderColor: '#7df9ff',
+              color: '#7df9ff',
+              cursor: 'pointer',
+            }}
+          >
+            + New flow
+          </button>
+        )}
         <input
           aria-label="Search flows"
           type="text"
@@ -236,6 +330,8 @@ export function Sidebar({ flows, loading, selectedFlowId, onSelectFlow }: Sideba
                 expandedFolders={expandedFolders}
                 toggleFolder={toggleFolder}
                 onSelectFlow={handleSelectFlow}
+                onEditFlow={onEditFlow}
+                onDeleteFlow={onDeleteFlow}
               />
             ))}
           </ul>

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -212,18 +212,15 @@ function TreeItem({
               addMenu?.setOpenForPath(menuOpen ? null : node.path)
             }}
             title="Add (flow or folder)"
-            className={`absolute right-2 top-1/2 -translate-y-1/2 font-pixel text-xs transition-opacity ${
-              menuOpen
-                ? 'opacity-100'
-                : 'opacity-0 group-hover/folder:opacity-100 focus:opacity-100'
-            }`}
+            className="absolute right-2 top-1/2 -translate-y-1/2 font-pixel text-sm transition-colors"
             style={{
               background: 'transparent',
               border: 'none',
-              color: menuOpen ? '#7df9ff' : 'rgba(224, 224, 255, 0.6)',
+              color: menuOpen ? '#7df9ff' : 'rgba(224, 224, 255, 0.55)',
               cursor: 'pointer',
               padding: '0 4px',
-              fontSize: 12,
+              fontSize: 14,
+              lineHeight: 1,
             }}
           >
             {'+'}

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -186,53 +186,59 @@ function TreeItem({
     const expanded = expandedFolders.has(node.path)
     const showAddBtn = !!onCreateAt
     const menuOpen = addMenu?.openForPath === node.path
+    // Wrap the header in its own .group/folder.relative so hover and absolute
+    // positioning scope to just the folder header row, not the entire expanded
+    // subtree (which includes child <ul>). Without this, "top: 50%" on the
+    // "+" button lands at the geometric center of the whole subtree, and
+    // hovering a child flow row triggers the parent folder's group-hover.
     return (
-      <li
-        role="treeitem"
-        aria-expanded={expanded}
-        data-testid={`folder-${node.path}`}
-        className="group/folder relative"
-      >
-        <button
-          onClick={() => toggleFolder(node.path)}
-          className="flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm text-text/70 hover:text-text transition-colors pr-7"
-          style={{ paddingLeft: depth * 16 + 8, cursor: 'pointer' }}
-        >
-          <span className="shrink-0 text-xs" style={{ width: 16, textAlign: 'center' }}>
-            {expanded ? '\u25BE' : '\u25B8'}
-          </span>
-          <span className="truncate">{node.name}</span>
-        </button>
-        {showAddBtn && (
+      <li role="treeitem" aria-expanded={expanded} data-testid={`folder-${node.path}`}>
+        <div className="group/folder relative">
           <button
-            aria-label={`Add inside ${node.name}`}
-            data-testid={`sidebar-add-${node.path}`}
-            onClick={(e) => {
-              e.stopPropagation()
-              addMenu?.setOpenForPath(menuOpen ? null : node.path)
-            }}
-            title="Add (flow or folder)"
-            className="absolute right-2 top-1/2 -translate-y-1/2 font-pixel text-sm transition-colors"
-            style={{
-              background: 'transparent',
-              border: 'none',
-              color: menuOpen ? '#7df9ff' : 'rgba(224, 224, 255, 0.55)',
-              cursor: 'pointer',
-              padding: '0 4px',
-              fontSize: 14,
-              lineHeight: 1,
-            }}
+            onClick={() => toggleFolder(node.path)}
+            className="flex items-center gap-1.5 w-full text-left py-1 font-terminal text-sm text-text/70 hover:text-text transition-colors pr-7"
+            style={{ paddingLeft: depth * 16 + 8, cursor: 'pointer' }}
           >
-            {'+'}
+            <span className="shrink-0 text-xs" style={{ width: 16, textAlign: 'center' }}>
+              {expanded ? '\u25BE' : '\u25B8'}
+            </span>
+            <span className="truncate">{node.name}</span>
           </button>
-        )}
-        {menuOpen && onCreateAt && (
-          <AddMenu
-            parentPath={node.path}
-            onClose={() => addMenu?.setOpenForPath(null)}
-            onCreateAt={onCreateAt}
-          />
-        )}
+          {showAddBtn && (
+            <button
+              aria-label={`Add inside ${node.name}`}
+              data-testid={`sidebar-add-${node.path}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                addMenu?.setOpenForPath(menuOpen ? null : node.path)
+              }}
+              title="Add (flow or folder)"
+              className={`absolute right-2 top-1/2 -translate-y-1/2 font-pixel transition-opacity ${
+                menuOpen
+                  ? 'opacity-100'
+                  : 'opacity-0 group-hover/folder:opacity-100 focus:opacity-100'
+              }`}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: menuOpen ? '#7df9ff' : 'rgba(224, 224, 255, 0.7)',
+                cursor: 'pointer',
+                padding: '0 4px',
+                fontSize: 14,
+                lineHeight: 1,
+              }}
+            >
+              {'+'}
+            </button>
+          )}
+          {menuOpen && onCreateAt && (
+            <AddMenu
+              parentPath={node.path}
+              onClose={() => addMenu?.setOpenForPath(null)}
+              onCreateAt={onCreateAt}
+            />
+          )}
+        </div>
         {expanded && (
           <ul role="group">
             {node.children.map((child, i) => (

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -356,7 +356,7 @@ function TreeItem({
                 e.stopPropagation()
                 onEditFlow(flowId)
               }}
-              title="Edit (E)"
+              title="Edit"
               className="font-pixel text-xs hover:text-accent transition-colors"
               style={{
                 background: 'transparent',

--- a/packages/web/src/hooks/useFlowMutations.ts
+++ b/packages/web/src/hooks/useFlowMutations.ts
@@ -71,24 +71,32 @@ export function useFlowMutations() {
     }
   }, [])
 
-  const deleteFlow = useCallback(async (flowId: string): Promise<boolean> => {
+  // Returns the error directly (or null on success) instead of just a bool —
+  // callers that `await` then immediately read `mutations.error` would get
+  // stale closure state because the post-await `mutations` reference still
+  // points at the pre-setState render. Returning the error inline avoids
+  // that footgun.
+  const deleteFlow = useCallback(async (flowId: string): Promise<MutationError | null> => {
     setState({ inFlight: true, error: null })
     try {
       const res = await fetch(`${API_BASE}/api/flows/${flowId}`, { method: 'DELETE' })
       if (!res.ok && res.status !== 404) {
-        setState({
-          inFlight: false,
-          error: { kind: 'server', status: res.status, message: `HTTP ${res.status}` },
-        })
-        return false
+        const err: MutationError = {
+          kind: 'server',
+          status: res.status,
+          message: `HTTP ${res.status}`,
+        }
+        setState({ inFlight: false, error: err })
+        return err
       }
       // 404 is treated as success — already gone.
       setState({ inFlight: false, error: null })
-      return true
+      return null
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
-      setState({ inFlight: false, error: { kind: 'network', message } })
-      return false
+      const err: MutationError = { kind: 'network', message }
+      setState({ inFlight: false, error: err })
+      return err
     }
   }, [])
 

--- a/packages/web/src/hooks/useFlowMutations.ts
+++ b/packages/web/src/hooks/useFlowMutations.ts
@@ -1,0 +1,96 @@
+import { useCallback, useState } from 'react'
+
+const API_BASE = '' // proxy handles /api -> localhost:8787
+
+export interface CreateFlowResult {
+  id: string
+  title: string
+  version: number
+}
+
+export interface ServerErrorDetail {
+  path: string
+  message: string
+  suggestion?: string
+}
+
+export interface MutationError {
+  /** "validation" mirrors the CLI: server rejected the YAML. */
+  kind: 'validation' | 'server' | 'network'
+  status?: number
+  message: string
+  details?: ServerErrorDetail[]
+}
+
+interface MutationState {
+  inFlight: boolean
+  error: MutationError | null
+}
+
+/**
+ * Mutation hook for create / delete. POSTs raw YAML so the server hits the same
+ * code path as `openhop push` (single source of truth for validation messages).
+ */
+export function useFlowMutations() {
+  const [state, setState] = useState<MutationState>({ inFlight: false, error: null })
+
+  const reset = useCallback(() => {
+    setState({ inFlight: false, error: null })
+  }, [])
+
+  const createFlow = useCallback(async (yamlText: string): Promise<CreateFlowResult | null> => {
+    setState({ inFlight: true, error: null })
+    try {
+      const res = await fetch(`${API_BASE}/api/flows`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/yaml' },
+        body: yamlText,
+      })
+      if (!res.ok) {
+        let details: ServerErrorDetail[] | undefined
+        try {
+          const body = (await res.json()) as { details?: ServerErrorDetail[] }
+          details = body.details
+        } catch {
+          /* fall through with empty details */
+        }
+        const err: MutationError =
+          res.status === 400
+            ? { kind: 'validation', status: 400, message: 'Server rejected the flow', details }
+            : { kind: 'server', status: res.status, message: `HTTP ${res.status}`, details }
+        setState({ inFlight: false, error: err })
+        return null
+      }
+      const data = (await res.json()) as CreateFlowResult
+      setState({ inFlight: false, error: null })
+      return data
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      setState({ inFlight: false, error: { kind: 'network', message } })
+      return null
+    }
+  }, [])
+
+  const deleteFlow = useCallback(async (flowId: string): Promise<boolean> => {
+    setState({ inFlight: true, error: null })
+    try {
+      const res = await fetch(`${API_BASE}/api/flows/${flowId}`, { method: 'DELETE' })
+      if (!res.ok && res.status !== 404) {
+        setState({
+          inFlight: false,
+          error: { kind: 'server', status: res.status, message: `HTTP ${res.status}` },
+        })
+        return false
+      }
+      // 404 is treated as success — already gone.
+      setState({ inFlight: false, error: null })
+      return true
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      setState({ inFlight: false, error: { kind: 'network', message } })
+      return false
+    }
+  }, [])
+
+  return { ...state, createFlow, deleteFlow, reset }
+}

--- a/packages/web/src/hooks/useFlowPolling.ts
+++ b/packages/web/src/hooks/useFlowPolling.ts
@@ -22,13 +22,23 @@ export function useFlowList() {
   const reload = useCallback(() => setTick((t) => t + 1), [])
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/flows`)
+    // AbortController cancels the previous in-flight fetch when `reload()`
+    // bumps `tick`. Without it, two overlapping /api/flows requests can
+    // resolve out of order and a stale response can overwrite the fresh
+    // post-mutation list — putting just-deleted flows back in the sidebar.
+    const controller = new AbortController()
+    fetch(`${API_BASE}/api/flows`, { signal: controller.signal })
       .then((r) => r.json())
       .then((data) => {
         setFlows(data)
         setLoading(false)
       })
-      .catch(() => setLoading(false))
+      .catch((err) => {
+        // AbortError means a newer reload superseded us — leave state alone.
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        setLoading(false)
+      })
+    return () => controller.abort()
   }, [tick])
 
   return { flows, loading, reload }

--- a/packages/web/src/hooks/useFlowPolling.ts
+++ b/packages/web/src/hooks/useFlowPolling.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import type { Flow } from '../types'
 
 const API_BASE = '' // proxy handles /api -> localhost:8787
@@ -15,6 +15,11 @@ export interface FlowListItem {
 export function useFlowList() {
   const [flows, setFlows] = useState<FlowListItem[]>([])
   const [loading, setLoading] = useState(true)
+  const [tick, setTick] = useState(0)
+
+  // `reload()` bumps `tick`, which retriggers the fetch effect. Mutations
+  // (create / delete) call this to refresh the sidebar without remounting.
+  const reload = useCallback(() => setTick((t) => t + 1), [])
 
   useEffect(() => {
     fetch(`${API_BASE}/api/flows`)
@@ -24,9 +29,9 @@ export function useFlowList() {
         setLoading(false)
       })
       .catch(() => setLoading(false))
-  }, [])
+  }, [tick])
 
-  return { flows, loading }
+  return { flows, loading, reload }
 }
 
 export function useFlowData(flowId: string | null) {

--- a/packages/web/src/lib/starter-yaml.ts
+++ b/packages/web/src/lib/starter-yaml.ts
@@ -1,0 +1,44 @@
+/**
+ * Starter YAML for "+ New flow" / "+ New folder" actions in the sidebar.
+ *
+ * Lives in lib/ rather than next to FlowEditorModal so the modal file can
+ * keep a clean component-only export shape — exporting non-component
+ * helpers from a component file trips `react-refresh/only-export-components`
+ * and breaks Vite's fast refresh.
+ */
+
+const STARTER_YAML = `meta:
+  title: New flow
+flow:
+  nodes:
+    - id: browser
+      label: Browser
+      type: actor
+    - id: api
+      label: API
+      type: endpoint
+  steps:
+    - from: browser
+      to: api
+      data: request
+    - from: api
+      to: browser
+      data: response
+`
+
+/**
+ * Build the seed YAML for a "New flow" inside a given folder path. When no
+ * path is supplied the flow lands at the workspace root.
+ *
+ * `\s{2}` (instead of two literal spaces) sidesteps the `no-regex-spaces`
+ * lint rule and reads as deliberate two-space indent matching.
+ */
+export function buildStarterYaml(path?: string): string {
+  if (!path) return STARTER_YAML
+  return STARTER_YAML.replace(
+    /^meta:\n\s{2}title: New flow\n/,
+    `meta:\n  title: New flow\n  path: ${path}\n`
+  )
+}
+
+export { STARTER_YAML }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -8,13 +8,19 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     port: 8788,
-    // Allow access from any hostname — the dev server binds to 0.0.0.0 so
-    // contributors running inside docker / WSL / a dev container can hit it
-    // via `host.docker.internal`, the container's bridge IP, or a tunneled
-    // hostname. Vite's default host check rejects anything other than
-    // `localhost` with a 403 "host not allowed", which surprises people
-    // running everything inside docker-compose.
-    allowedHosts: true,
+    // Explicit allowlist (not `true`) — `allowedHosts: true` disables Vite's
+    // host-header validation entirely and opens the dev server up to DNS
+    // rebinding attacks (a malicious page can resolve a hostname back to the
+    // dev server and pull source). The defaults already cover localhost +
+    // every IP literal; we only need to add the docker/WSL hostnames a
+    // contributor might hit when running inside a container, plus an env-var
+    // escape hatch for tunneled hostnames (ngrok / cloudflared / etc.).
+    allowedHosts: [
+      'host.docker.internal',
+      'openhop',
+      '.localhost',
+      ...(process.env.VITE_ADDITIONAL_ALLOWED_HOSTS?.split(',').map((s) => s.trim()) ?? []),
+    ],
     proxy: {
       '/api': 'http://localhost:8787',
       '/health': 'http://localhost:8787',

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     port: 8788,
+    // Allow access from any hostname — the dev server binds to 0.0.0.0 so
+    // contributors running inside docker / WSL / a dev container can hit it
+    // via `host.docker.internal`, the container's bridge IP, or a tunneled
+    // hostname. Vite's default host check rejects anything other than
+    // `localhost` with a 403 "host not allowed", which surprises people
+    // running everything inside docker-compose.
+    allowedHosts: true,
     proxy: {
       '/api': 'http://localhost:8787',
       '/health': 'http://localhost:8787',


### PR DESCRIPTION
## Summary

Lets users author and edit flows directly in the browser. The same authoring path as the CLI (`openhop push` / `openhop remove`), now inline in the sidebar — no terminal required.

Closes **#74** (inline YAML editor — Add/Edit modal in left menu) and partially closes **#12** (P11: enable editing flows from the UI).

## What's new

**Sidebar:**
- **+ New flow** primary button at the top.
- **✎ Edit** and **✕ Delete** affordances on every flow row, revealed on hover.

**FlowEditorModal** (new component):
- CodeMirror 6 YAML editor with live validation via `parseFlowYaml()` from `@openhop/shared` — sub-100ms feedback.
- Errors render with `path` + `suggestion` fields (mirrors CLI `validate --json`).
- Server-side errors (e.g. node-ref lookups local validation misses) render distinctly under the editor.
- **Cmd/Ctrl-Enter** saves; **Esc** cancels; click-outside cancels.

**Wiring:**
- New `useFlowMutations.ts` — POST + DELETE wrappers. Distinguishes `validation` / `server` / `network` errors so the modal can render path-prefixed details.
- `useFlowList` gains a `reload()` so create/delete refresh the sidebar without remounting.
- `App.tsx` owns the modal state machine (`{closed, new, edit}`) and the delete confirmation. Edit pre-populates by GETting the stored flow and round-tripping through `yaml.stringify`.

## Scope decisions (per #74)

- **Edit = full re-push (POST)**, creating a new flow ID. Patch-ops in-place editing is the CLI's `openhop patch` flow — out of scope, track separately if needed.
- **Delete confirmation: native `window.confirm`** — simpler than a styled dialog, upgradeable later.
- **Static-deploy "fragment mode" for #75 deferred.** The modal takes a minimal prop surface so it can grow that mode without a rewrite.

## New deps (web only)

```
@uiw/react-codemirror     ^4.25.9
@codemirror/lang-yaml     ^6.1.3
yaml                      ^2.8.4
```

Web is bundled at build time — none of these ship to npm package consumers, only to the static web build.

## Test plan

- [x] **Unit tests:** 5 new tests in `flow-mutations.test.ts` covering: STARTER_YAML passes validation; invalid step refs surface path + message; round-trip serialize → parse preserves shape; canned VALID_YAML accepts.
- [x] **Test totals:** shared 93/93, server 19/19, cli 83/83, **web 27/27 (5 new)** = **222/222**.
- [x] **Static checks:** lint / typecheck / format:check / build all clean.
- [x] **Audit gates:** both prod-tree (moderate+) and full-tree (high+) exit 0.
- [x] **Live API smoke** against `openhop serve`:
  - POST valid YAML → 201 `{id, version, title}` (what `createFlow` consumes)
  - POST invalid YAML → 400 `{details: [{path, message, suggestion}]}` (what the modal renders)
  - GET `/api/flows/:id` → `{id, meta, flow}` (round-trip through `YAML.stringify` re-parses cleanly)
  - DELETE → 204; DELETE non-existent → 404 (treated as success in the hook — flow is already gone)
- [ ] **Manual browser smoke** — owed before merge: `openhop serve`, exercise New / Edit / Delete in a real browser, verify flows render after save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flow editor modal: YAML editor with starter YAML (path-aware), keyboard shortcuts, save/cancel, server and local validation feedback
  * Sidebar: root/folder “+” create menus and per-flow edit/delete actions; flows refresh after changes

* **New / Improved APIs**
  * Flow create/delete now expose in-flight state and structured errors; flow list exposes a reload callback

* **Quality / Tests**
  * Unit tests for YAML parsing/validation and starter‑YAML path behavior

* **Chores**
  * Dev dependencies added for YAML editing/parsing support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->