### PR TITLE
fix(cli): proxy /api and /health from web server to API (unbreaks the demo)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7681,13 +7681,13 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.1.0-beta.0",
+      "version": "0.1.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.4.4",
         "@fastify/static": "^9.1.3",
         "@openhop/server": "0.1.0-beta.0",
-        "@openhop/web": "0.1.0-beta.0",
+        "@openhop/web": "0.1.0-beta.1",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
         "yaml": "^2.8.4",
@@ -8686,7 +8686,7 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.1.0-beta.0",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@codemirror/lang-yaml": "^6.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7681,12 +7681,12 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.1.0-beta.2",
+      "version": "0.1.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.4.4",
         "@fastify/static": "^9.1.3",
-        "@openhop/server": "0.1.0-beta.0",
+        "@openhop/server": "0.1.0-beta.1",
         "@openhop/web": "0.1.0-beta.1",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
@@ -8167,7 +8167,7 @@
     },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.1.0-beta.0",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1150,6 +1150,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@fastify/http-proxy": {
+      "version": "11.4.4",
+      "resolved": "https://registry.npmjs.org/@fastify/http-proxy/-/http-proxy-11.4.4.tgz",
+      "integrity": "sha512-wXoKaxW31pQc6H48Xqx//j6A2ikOiadht55DNkEFaseEUkJ9MzvURLK6Qqg0OOIEZGjTiEjjnbERv3NLFBc2Ug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "@fastify/reply-from": "^12.6.2",
+        "fast-querystring": "^1.1.2",
+        "fastify-plugin": "^5.1.0",
+        "ws": "^8.18.3"
+      }
+    },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
@@ -1187,6 +1208,30 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/reply-from": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@fastify/reply-from/-/reply-from-12.6.2.tgz",
+      "integrity": "sha512-FhMvsRJa4HMG0q0/Yi06sgwVFd/Wc8E/+RbHsqB0Q+883C66RPrS6qwZKBPje2mVzsyEb9sjq7wlyvi35zRW0A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "end-of-stream": "^1.4.4",
+        "fast-content-type-parse": "^3.0.0",
+        "fast-querystring": "^1.1.2",
+        "fastify-plugin": "^5.0.1",
+        "toad-cache": "^3.7.0",
+        "undici": "^7.0.0"
       }
     },
     "node_modules/@fastify/send": {
@@ -3686,6 +3731,14 @@
       "dev": true,
       "license": "EPL-2.0"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
@@ -3976,6 +4029,21 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
@@ -5264,7 +5332,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -6242,6 +6309,14 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -7492,8 +7567,27 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -7590,6 +7684,7 @@
       "version": "0.1.0-beta.0",
       "license": "MIT",
       "dependencies": {
+        "@fastify/http-proxy": "^11.4.4",
         "@fastify/static": "^9.1.3",
         "@openhop/server": "0.1.0-beta.0",
         "@openhop/web": "0.1.0-beta.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
     "@openhop/server": "0.1.0-beta.0",
-    "@openhop/web": "0.1.0-beta.0",
+    "@openhop/web": "0.1.0-beta.1",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.1.0-beta.0",
+    "@openhop/server": "0.1.0-beta.1",
     "@openhop/web": "0.1.0-beta.1",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -36,11 +36,12 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:cli-contract": "vitest run __tests__/contract.test.ts",
-    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=esm --external:commander --external:yaml --external:zod --external:@openhop/server --external:@openhop/web --external:fastify --external:@fastify/static --outfile=dist/index.js --banner:js='#!/usr/bin/env node'",
+    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=esm --external:commander --external:yaml --external:zod --external:@openhop/server --external:@openhop/web --external:fastify --external:@fastify/static --external:@fastify/http-proxy --outfile=dist/index.js --banner:js='#!/usr/bin/env node'",
     "prepack": "rm -rf skills && cp -r ../../skills ./skills",
     "prepare": "npm run build"
   },
   "dependencies": {
+    "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
     "@openhop/server": "0.1.0-beta.0",
     "@openhop/web": "0.1.0-beta.0",

--- a/packages/cli/src/demo.ts
+++ b/packages/cli/src/demo.ts
@@ -132,7 +132,7 @@ export function registerDemo(program: Command): void {
       let web: { url: string; close: () => Promise<void> }
       try {
         const { startWebServer } = await import('./web-server.js')
-        web = await startWebServer({ port: webPort })
+        web = await startWebServer({ port: webPort, apiUrl: api.url })
       } catch (err) {
         errStderr(red(`✗ Failed to start web UI: ${errorMessage(err)}`))
         await api.close()

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ if (process.argv.includes('--api-version')) {
 
 const program = new Command()
 
-program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.2')
+program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.3')
 
 // --- serve ---
 //

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ if (process.argv.includes('--api-version')) {
 
 const program = new Command()
 
-program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.0')
+program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.1')
 
 // --- serve ---
 //
@@ -87,7 +87,7 @@ program
       logStderr(dim(`Starting OpenHop web UI on port ${webPort}...`))
       try {
         const { startWebServer } = await import('./web-server.js')
-        web = await startWebServer({ port: webPort })
+        web = await startWebServer({ port: webPort, apiUrl: api.url })
       } catch (err) {
         errStderr(red(`Failed to start web UI: ${errorMessage(err)}`))
         // Web failure is non-fatal — API can still run for headless agents.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ if (process.argv.includes('--api-version')) {
 
 const program = new Command()
 
-program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.1')
+program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.2')
 
 // --- serve ---
 //

--- a/packages/cli/src/web-server.ts
+++ b/packages/cli/src/web-server.ts
@@ -6,18 +6,33 @@
  * globally, locally, or invoked through `npx`. The web package ships only
  * `dist/` (per its `files:[dist]` whitelist) — its build-time deps are not
  * pulled in at install time.
+ *
+ * The web bundle's data fetches (e.g. `/api/flows/<id>`) are RELATIVE URLs,
+ * matching the dev-time setup where Vite proxies `/api` → `:8787`. In the
+ * built / published bundle there's no Vite, so the web server must do the
+ * proxying itself — otherwise the SPA's fetches hit this static server,
+ * which has no /api routes and either 404s or (worse) lets the SPA fallback
+ * return index.html as the response body. Hence @fastify/http-proxy below.
  */
 
 import { dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import Fastify, { type FastifyInstance } from 'fastify'
 import fastifyStatic from '@fastify/static'
+import fastifyHttpProxy from '@fastify/http-proxy'
 
 export interface StartWebOptions {
   /** TCP port. Default: 8788 (matches the URL the CLI's `push` returns). */
   port?: number
   /** Bind host. Default: 127.0.0.1. */
   host?: string
+  /**
+   * Origin of the API server (e.g. `http://127.0.0.1:8787`). Required for the
+   * SPA's `/api/*` and `/health` requests to reach the API; without it the
+   * SPA's data fetches fall through to the static + SPA fallback and return
+   * HTML, which the SPA can't parse as JSON.
+   */
+  apiUrl: string
 }
 
 export interface RunningWeb {
@@ -28,7 +43,7 @@ export interface RunningWeb {
   close(): Promise<void>
 }
 
-export async function startWebServer(opts: StartWebOptions = {}): Promise<RunningWeb> {
+export async function startWebServer(opts: StartWebOptions): Promise<RunningWeb> {
   const port = opts.port ?? 8788
   const host = opts.host ?? '127.0.0.1'
 
@@ -37,12 +52,28 @@ export async function startWebServer(opts: StartWebOptions = {}): Promise<Runnin
   const webDistRoot = join(dirname(webPkgPath), 'dist')
 
   const app = Fastify({ logger: false })
+
+  // /api/* and /health → proxy to the API server. Registered BEFORE the
+  // static plugin so /api requests hit the proxy first, not the static
+  // 404-handler-with-SPA-fallback that would mask the proxy.
+  await app.register(fastifyHttpProxy, {
+    upstream: opts.apiUrl,
+    prefix: '/api',
+    rewritePrefix: '/api',
+  })
+  await app.register(fastifyHttpProxy, {
+    upstream: opts.apiUrl,
+    prefix: '/health',
+    rewritePrefix: '/health',
+  })
+
   await app.register(fastifyStatic, {
     root: webDistRoot,
     prefix: '/',
   })
   // SPA fallback — `/flow/<id>` and other client-routed paths return the
-  // app shell so the web router can pick them up.
+  // app shell so the web router can pick them up. /api/* and /health are
+  // already handled by the proxy above so they never reach this fallback.
   app.setNotFoundHandler((_req, reply) => {
     return reply.sendFile('index.html')
   })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -45,7 +45,7 @@ export async function buildApp(opts: { logger?: boolean } = {}): Promise<Fastify
           title: 'OpenHop API',
           description:
             'Data flow visualization platform. AI tools POST flow definitions (YAML/JSON) and OpenHop renders them as animated diagrams.',
-          version: '0.1.0-beta.0',
+          version: '0.1.0-beta.1',
         },
       },
     })

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -58,14 +58,14 @@ export async function flowRoutes(app: FastifyInstance): Promise<void> {
             type: 'object',
             properties: {
               status: { type: 'string', example: 'ok' },
-              version: { type: 'string', example: '0.1.0-beta.0' },
+              version: { type: 'string', example: '0.1.0-beta.1' },
             },
           },
         },
       },
     },
     async (_req, reply) => {
-      return reply.send({ status: 'ok', version: '0.1.0-beta.0' })
+      return reply.send({ status: 'ok', version: '0.1.0-beta.1' })
     }
   )
 

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -21,10 +21,27 @@ interface StoredFlowFile {
   root: Root // the full Root object on disk
 }
 
+/**
+ * Resolve the default storage directory. Order:
+ *   1. Constructor `dir` arg (explicit override, used by tests)
+ *   2. `OPENHOP_DATA_DIR` env var (per-process / per-deployment override)
+ *   3. `<homedir>/.openhop/flows` (cross-OS default — Linux:
+ *      `/home/<user>/`, macOS: `/Users/<user>/`, Windows:
+ *      `C:\Users\<user>\`).
+ *
+ * Flows persist across server restarts: the same user account on the
+ * same machine always sees the same flow set, even after `npx openhop
+ * demo` / `serve` is killed and re-run. Set `OPENHOP_DATA_DIR=...` to
+ * isolate (e.g. ephemeral demo, per-project workspace, CI fixture).
+ */
+function defaultDataDir(): string {
+  return process.env.OPENHOP_DATA_DIR || join(homedir(), '.openhop', 'flows')
+}
+
 export class FlowStore {
   private initialized = false
 
-  constructor(private dir: string = join(homedir(), '.openhop', 'flows')) {}
+  constructor(private dir: string = defaultDataDir()) {}
 
   private async ensureDir(): Promise<void> {
     if (this.initialized) return

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",

--- a/packages/web/src/hooks/useFlowPolling.ts
+++ b/packages/web/src/hooks/useFlowPolling.ts
@@ -56,9 +56,19 @@ export function useFlowData(flowId: string | null) {
       return
     }
     setLoading(true)
+    setFlow(null)
     fetch(`${API_BASE}/api/flows/${flowId}`)
-      .then((r) => r.json())
-      .then((data) => {
+      .then(async (r) => {
+        // 404 / 5xx / etc → treat as "no flow"; the App's `!apiFlow` branch
+        // renders the "Flow not found" UX. Without this the error body
+        // (`{"error":"not_found",...}`) would slip through .json() and
+        // produce a flow object with `flow: undefined`, crashing the
+        // canvas on `flow.steps`/`flow.nodes` access.
+        if (!r.ok) {
+          setLoading(false)
+          return
+        }
+        const data = await r.json()
         setFlow({ meta: data.meta, flow: data.flow }) // StoredFlow has { id, meta, flow, version, ... }
         versionRef.current = data.version
         setLoading(false)
@@ -72,10 +82,12 @@ export function useFlowData(flowId: string | null) {
     const interval = setInterval(async () => {
       try {
         const res = await fetch(`${API_BASE}/api/flows/${flowId}/version`)
+        if (!res.ok) return // Flow gone (e.g. deleted from another tab) — leave state for now.
         const { version } = await res.json()
         if (version > versionRef.current) {
           // Version changed — re-fetch full flow
           const fullRes = await fetch(`${API_BASE}/api/flows/${flowId}`)
+          if (!fullRes.ok) return
           const data = await fullRes.json()
           setFlow({ meta: data.meta, flow: data.flow })
           versionRef.current = data.version


### PR DESCRIPTION
## The bug

End-to-end smoke against the published `0.1.0-beta.0` packages (Verdaccio + `npx openhop@beta demo` from a fresh directory) exposed a launch-blocker: opening the URL the CLI prints (`http://localhost:8788/flow/<id>`) shows a green canvas and crashes.

Browser console:
```
GET /api/flows/<id> 404 (Not Found)
TypeError: Cannot read properties of undefined (reading 'steps')
```

The SPA's data fetches use relative URLs (`/api/flows/<id>`), matching the dev-time setup where Vite's `server.proxy` forwards `/api` → `:8787`. **In the production bundle there's no Vite** — `web-server.ts` only registers `@fastify/static` + a SPA fallback. The SPA's fetch hits the static server, the fallback returns `index.html`, the SPA tries to JSON-parse HTML, the React tree explodes.

## The fix

- Add `@fastify/http-proxy` to the CLI's runtime deps + esbuild externals.
- `web-server.ts` now requires `apiUrl: string` and registers two proxies **before** the static plugin:
  - `/api/*` → `${apiUrl}/api/*`
  - `/health` → `${apiUrl}/health`
- `index.ts` (`serve`) and `demo.ts` both pass `apiUrl: api.url` to `startWebServer`.
- Bump CLI to `0.1.0-beta.1` so the next `npx openhop@beta demo` resolves to the fixed bundle. Server + web unchanged at `0.1.0-beta.0`.

## Test plan (Verdaccio)

Reproduced + verified end-to-end against a local Verdaccio:

1. `npm publish --tag beta` of `openhop@0.1.0-beta.1`.
2. Wipe `~/.npm/_npx`, `~/.openhop/flows`, the smoke install dir.
3. `npx --yes openhop@beta demo` from clean.
4. Probes through port 8788 (the URL `demo` prints):

| Path | Before (beta.0) | After (beta.1) |
|---|---|---|
| `GET /` | HTML SPA | HTML SPA (unchanged) |
| `GET /flow/<id>` | HTML SPA | HTML SPA (unchanged) |
| `GET /health` | HTML SPA fallback | `{"status":"ok",…}` ✅ |
| `GET /api/flows/<id>` | HTML SPA fallback | full flow JSON ✅ |
| `GET /api/flows` | HTML SPA fallback | flow list JSON ✅ |

Direct API on `:8787` unchanged. Static + SPA fallback unchanged for non-API paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped CLI to 0.1.0-beta.3; web and server to 0.1.0-beta.1
  * Added build, prepack, and prepare scripts; added Fastify HTTP proxy dependency

* **New Features**
  * Web UI now proxies /api and /health to the external API so client-side requests reach the correct server
  * CLI serve/demo now passes the API URL when starting the web UI
  * Health check now returns a version field

* **Refactor**
  * Improved flow polling to handle non-OK responses and prevent stale state updates
* **Chores**
  * Bumped CLI to 0.1.0-beta.3; web and server to 0.1.0-beta.1
  * Added build, prepack, and prepare scripts; added Fastify HTTP proxy dependency

* **New Features**
  * Web UI now proxies /api and /health to the external API so client-side requests reach the correct server
  * CLI serve/demo now passes the API URL when starting the web UI
  * Health check now returns a version field

* **Refactor**
  * Improved flow polling to handle non-OK responses and prevent stale state updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->