### PR TITLE
docs(readme): add user prompt examples + contact section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,18 @@ mkdir -p ~/.claude/skills/openhop
 cp skills/openhop/SKILL.md ~/.claude/skills/openhop/
 ```
 
-Then ask your agent:
+Then ask your agent things like:
 
-> "Walk me through the OAuth flow in this codebase."
+- _"Walk me through the OAuth flow in this codebase."_
+- _"Diagram how a request flows through this Express app."_
+- _"Show me how the checkout pipeline processes an order, end to end."_
+- _"Trace what happens when a user clicks **Submit**."_
+- _"Visualize the auth middleware — every step, every state transition."_
+- _"How does cache invalidation work in this service?"_
+- _"Diagram the WebSocket reconnection state machine."_
+- _"Walk me through what happens after `npm publish` — every step until the package is on the registry."_
 
-The agent will sketch the nodes in YAML, push via `openhop push`, and hand you back a URL.
+The agent loads the skill, sketches the flow in YAML, calls `openhop push`, and hands you back a URL with the animation playing.
 
 ## CLI
 
@@ -148,6 +155,10 @@ openhop push examples/order-flow.yaml
 
 PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 Security reports via [GitHub's private vulnerability reporting](https://github.com/naorsabag/openhop/security/advisories/new).
+
+## Contact
+
+General questions: open a [GitHub issue](https://github.com/naorsabag/openhop/issues/new) or email [openhop.dev@gmail.com](mailto:openhop.dev@gmail.com).
 
 ## License
 


### PR DESCRIPTION
## Summary

Two small README additions that close real gaps:

### 1. User-facing example prompts (8 of them)

Before today the README had **one** example prompt — \`"Walk me through the OAuth flow in this codebase."\` That left users with nothing to anchor on for what to actually ask their agent.

Replaced the single line with a list of 8 concrete prompt shapes:

- Auth flows
- Request lifecycles
- E-commerce / pipeline traces
- Click-to-action traces
- Middleware visualization
- Cache invalidation
- State machines
- Tooling lifecycles (e.g. \`npm publish\`)

These cover the common phrase patterns the skill's frontmatter \`description:\` already advertises (per \`17-install-and-activation-flow.md:344-353\`), so users have direct examples to copy-paste against their own codebase.

### 2. Contact section (closes W11)

Added a \`## Contact\` section right above \`## License\` with two channels:

- Primary: open a GitHub issue (public, searchable, funnels feedback)
- Backup: email \`openhop.dev@gmail.com\` (for things that shouldn't be public)

Closes the README "no contact email" gap from \`READINESS-AUDIT.md\` §W11 and \`18-zero-cost-stack.md:257\`.

## Diff

| File | +/- | Lines |
|---|---|---|
| \`README.md\` | +14 / -3 | one section reworked, one section added |

## Testing

- \`npx prettier --check README.md\` → \`All matched files use Prettier code style\!\` (no CI format-check breakage like #82/#83 hit)
- Renders correctly on GitHub: bullet list of prompts, new \`## Contact\` heading
- Email is wrapped in a \`mailto:\` autolink for one-click composition
- GitHub Issues link uses \`/issues/new\` so the user lands directly on the new-issue form

## Checklist

- [x] Build passes (no code changes)
- [x] Prettier clean
- [x] CHANGELOG entry not needed (README polish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the "Give your agent the skill" section with comprehensive prompt list including diagramming and use-case questions
  * Added a new "Contact" section providing support resources including GitHub issues and email contact information
  * Enhanced instructions with clearer guidance on using `openhop push` and receiving URL responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->