### PR TITLE
docs(readme): split Use cases into its own section + fix Why-prose authorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 <p align="center">
   <a href="#try-it-in-60-seconds">Quickstart</a> ·
-  <a href="#give-your-agent-the-skill">AI skill</a> ·
+  <a href="#install">Install</a> ·
   <a href="#use-cases">Use cases</a> ·
   <a href="#how-it-works">How it works</a> ·
   <a href="#examples">Examples</a>
@@ -63,27 +63,50 @@ That's it. The CLI starts the API + web UI on `localhost:8787` / `:8788`, posts 
 
 ## Install
 
-| Scenario                                                     | Command                                                                                                                                  |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **One-shot demo**                                            | `npx openhop demo` — boots everything and opens the browser                                                                              |
-| **Long-lived local server**                                  | `npx openhop serve` — API + web UI, no starter flow (or `npm install -g openhop` first if you'd rather have the global `openhop` binary) |
-| **Install the skill** (Claude Code, Cursor, Windsurf, Cline) | `npx openhop init` — auto-detects your AI client and drops `SKILL.md` in place                                                           |
-| **Install the skill** (Codex, Gemini, Junie, Copilot, …)     | `npx openskills install naorsabag/openhop` — universal install via OpenSkills                                                            |
-| **Run from source (contributors)**                           | `git clone https://github.com/naorsabag/openhop.git && cd openhop && npm install && npm run dev` — see [Contributing](#contributing)     |
+OpenHop has two pieces and they do different things:
 
-## Give your agent the skill
+1. **The local CLI + server** — runs on `:8787` (API) and `:8788` (web UI). Renders flows.
+2. **The skill** — a `SKILL.md` file that lives in your AI agent's config dir. Teaches the agent how to call the CLI.
 
-OpenHop ships a skill file at [`skills/openhop/SKILL.md`](skills/openhop/SKILL.md) that teaches any
-SKILL-compatible agent how to use OpenHop.
+You need the **CLI** to see anything render. You need the **skill** if you want your AI agent to call it for you. Most people want both.
 
-For Claude Code, copy the skill into your skills directory:
+### Path A — just kicking the tires (no agent setup)
 
 ```bash
-mkdir -p ~/.claude/skills/openhop
-cp skills/openhop/SKILL.md ~/.claude/skills/openhop/
+npx openhop demo
 ```
 
-That's it — the agent now knows how to use OpenHop. Open your codebase in any SKILL-compatible client and ask it for a flow (see [Use cases](#use-cases) below for prompt ideas). The agent loads the skill, sketches the flow in YAML, calls `openhop push`, and hands you back a URL with the animation playing.
+Installs the CLI on first run, starts the server, pushes a canonical OAuth example, and opens it in your browser. Press Ctrl-C to stop. **This is the fastest way to see what OpenHop does**, and it's all you need if you only want to look at example flows.
+
+### Path B — agent-driven use (the actual product)
+
+You need both pieces installed.
+
+**Step 1 — install the skill** so your agent knows how to call OpenHop:
+
+| Client                                             | One-time command                           |
+| -------------------------------------------------- | ------------------------------------------ |
+| Claude Code, Cursor, Windsurf, Cline, Continue     | `npx openhop init`                         |
+| Codex CLI, Gemini CLI, Junie, Copilot, OpenCode, … | `npx openskills install naorsabag/openhop` |
+
+**Step 2 — run the server** in a terminal you'll keep open:
+
+```bash
+npx openhop serve
+```
+
+That's the long-lived form of `npx openhop demo` — same API + web UI, no starter flow. Leave it running.
+
+**Step 3 — ask your agent for a flow** (see [Use cases](#use-cases) for prompt ideas). The agent generates YAML, pushes it via `openhop push`, hands you back a URL with the animation playing.
+
+### Path C — contributor (run from source)
+
+```bash
+git clone https://github.com/naorsabag/openhop.git
+cd openhop && npm install && npm run dev
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Once the skill is installed, point your agent at a codebase and ask it things li
 - "Diagram the WebSocket reconnection state machine."
 - "Walk me through what happens after `npm publish` — every step until the package is on the registry."
 
-The skill activates on prompts asking your agent to **understand, explain, walk through, trace, visualize, or diagram** how data, requests, control, auth, or state flows through code. When it recognizes that shape, it switches from prose to YAML + animation. The full trigger-phrase list lives in [`skills/openhop/SKILL.md`](skills/openhop/SKILL.md).
+The skill activates on prompts asking your agent to **explain, walk through, trace, visualize, or diagram** how data, requests, control, auth, or state flows through code. When it recognizes that shape, it switches from prose to YAML + animation. The full trigger-phrase list lives in [`skills/openhop/SKILL.md`](skills/openhop/SKILL.md).
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -63,43 +63,47 @@ That's it. The CLI starts the API + web UI on `localhost:8787` / `:8788`, posts 
 
 ## Install
 
-OpenHop has two pieces and they do different things:
+OpenHop is a skill — a `SKILL.md` file your AI agent reads to learn how to render flows. **Installing the skill is the only required step.** The CLI + server (which actually paints the pixels) ship in the same npm package and the agent boots them automatically the first time you ask for a flow.
 
-1. **The local CLI + server** — runs on `:8787` (API) and `:8788` (web UI). Renders flows.
-2. **The skill** — a `SKILL.md` file that lives in your AI agent's config dir. Teaches the agent how to call the CLI.
+Pick the install path that matches your AI client.
 
-You need the **CLI** to see anything render. You need the **skill** if you want your AI agent to call it for you. Most people want both.
-
-### Path A — just kicking the tires (no agent setup)
+### Path A — Claude Code, Cursor, Windsurf, Cline, Continue
 
 ```bash
-npx openhop demo
+npx openhop init
 ```
 
-Installs the CLI on first run, starts the server, pushes a canonical OAuth example, and opens it in your browser. Press Ctrl-C to stop. **This is the fastest way to see what OpenHop does**, and it's all you need if you only want to look at example flows.
+Auto-detects which of those clients you have installed and drops `SKILL.md` into each one's skills directory. Open your codebase in any of them and ask for a flow (see [Use cases](#use-cases) below).
 
-### Path B — agent-driven use (the actual product)
+### Path B — Codex CLI, Gemini CLI, Junie, Copilot, OpenCode, Goose, Antigravity, …
 
-You need both pieces installed.
+```bash
+npx openskills install naorsabag/openhop
+```
 
-**Step 1 — install the skill** so your agent knows how to call OpenHop:
+[OpenSkills](https://github.com/numman-ali/openskills) is the universal cross-vendor installer. It knows where each of these clients keeps skills and drops `SKILL.md` in the right place. Same activation flow afterwards.
 
-| Client                                             | One-time command                           |
-| -------------------------------------------------- | ------------------------------------------ |
-| Claude Code, Cursor, Windsurf, Cline, Continue     | `npx openhop init`                         |
-| Codex CLI, Gemini CLI, Junie, Copilot, OpenCode, … | `npx openskills install naorsabag/openhop` |
+### Want to start the server yourself?
 
-**Step 2 — run the server** in a terminal you'll keep open:
+The agent will run `openhop serve` on demand, so you don't have to. If you'd rather pre-start it (e.g. you want it running before you ask for the first flow, or you want it in a specific terminal):
 
 ```bash
 npx openhop serve
 ```
 
-That's the long-lived form of `npx openhop demo` — same API + web UI, no starter flow. Leave it running.
+That's the long-lived API + web UI on `:8787` / `:8788`, no starter flow. Leave it running.
 
-**Step 3 — ask your agent for a flow** (see [Use cases](#use-cases) for prompt ideas). The agent generates YAML, pushes it via `openhop push`, hands you back a URL with the animation playing.
+### Just looking?
 
-### Path C — contributor (run from source)
+```bash
+npx openhop demo
+```
+
+Boots the server and pushes a canonical OAuth example so you can see what a rendered flow looks like — no agent or skill install needed. Useful as a preview; the actual product is agent-driven.
+
+### Contributors
+
+Run from source:
 
 ```bash
 git clone https://github.com/naorsabag/openhop.git

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Once the skill is installed, point your agent at a codebase and ask it things li
 - "Diagram the WebSocket reconnection state machine."
 - "Walk me through what happens after `npm publish` — every step until the package is on the registry."
 
-The skill activates on prompts that ask your agent to **explain, walk through, trace, visualize, or diagram** how something works in code — data flows, request paths, lifecycles, state machines, processing pipelines, click-to-action traces. When it recognizes that shape, it switches from prose to YAML + animation.
+The skill activates on prompts asking your agent to **understand, explain, walk through, trace, visualize, or diagram** how data, requests, control, auth, or state flows through code. When it recognizes that shape, it switches from prose to YAML + animation. The full trigger-phrase list lives in [`skills/openhop/SKILL.md`](skills/openhop/SKILL.md).
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Once the skill is installed, point your agent at a codebase and ask it things li
 - "Diagram the WebSocket reconnection state machine."
 - "Walk me through what happens after `npm publish` — every step until the package is on the registry."
 
-The shape that activates the skill is "explain / walk through / trace / visualize / diagram \_ flow". When the agent recognizes one of those patterns it switches from prose to YAML + animation.
+The skill activates on prompts that ask your agent to **explain, walk through, trace, visualize, or diagram** how something works in code — data flows, request paths, lifecycles, state machines, processing pipelines, click-to-action traces. When it recognizes that shape, it switches from prose to YAML + animation.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -73,25 +73,17 @@ Pick the install path that matches your AI client.
 npx openhop init
 ```
 
-Auto-detects which of those clients you have installed and drops `SKILL.md` into each one's skills directory. Open your codebase in any of them and ask for a flow (see [Use cases](#use-cases) below).
-
-### Path B — Codex CLI, Gemini CLI, Junie, Copilot, OpenCode, Goose, Antigravity, …
+### Path B — Codex CLI, Gemini CLI, Junie, Copilot, OpenCode, Goose, Antigravity, … (via [OpenSkills](https://github.com/numman-ali/openskills))
 
 ```bash
 npx openskills install naorsabag/openhop
 ```
 
-[OpenSkills](https://github.com/numman-ali/openskills) is the universal cross-vendor installer. It knows where each of these clients keeps skills and drops `SKILL.md` in the right place. Same activation flow afterwards.
-
 ### Want to start the server yourself?
-
-The agent will run `openhop serve` on demand, so you don't have to. If you'd rather pre-start it (e.g. you want it running before you ask for the first flow, or you want it in a specific terminal):
 
 ```bash
 npx openhop serve
 ```
-
-That's the long-lived API + web UI on `:8787` / `:8788`, no starter flow. Leave it running.
 
 ### Just looking?
 
@@ -99,18 +91,12 @@ That's the long-lived API + web UI on `:8787` / `:8788`, no starter flow. Leave 
 npx openhop demo
 ```
 
-Boots the server and pushes a canonical OAuth example so you can see what a rendered flow looks like — no agent or skill install needed. Useful as a preview; the actual product is agent-driven.
-
 ### Contributors
-
-Run from source:
 
 ```bash
 git clone https://github.com/naorsabag/openhop.git
 cd openhop && npm install && npm run dev
 ```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 Once the skill is installed, point your agent at a codebase and ask it things like:
 
-- _"Walk me through the OAuth flow in this codebase."_
-- _"Diagram how a request flows through this Express app."_
-- _"Show me how the checkout pipeline processes an order, end to end."_
-- _"Trace what happens when a user clicks **Submit**."_
-- _"Visualize the auth middleware — every step, every state transition."_
-- _"How does cache invalidation work in this service?"_
-- _"Diagram the WebSocket reconnection state machine."_
-- _"Walk me through what happens after `npm publish` — every step until the package is on the registry."_
+- "Walk me through the OAuth flow in this codebase."
+- "Diagram how a request flows through this Express app."
+- "Show me how the checkout pipeline processes an order, end to end."
+- "Trace what happens when a user clicks **Submit**."
+- "Visualize the auth middleware — every step, every state transition."
+- "How does cache invalidation work in this service?"
+- "Diagram the WebSocket reconnection state machine."
+- "Walk me through what happens after `npm publish` — every step until the package is on the registry."
 
 The shape that activates the skill is "explain / walk through / trace / visualize / diagram \_ flow". When the agent recognizes one of those patterns it switches from prose to YAML + animation.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 <p align="center">
   <a href="#try-it-in-60-seconds">Quickstart</a> ·
   <a href="#give-your-agent-the-skill">AI skill</a> ·
+  <a href="#use-cases">Use cases</a> ·
   <a href="#how-it-works">How it works</a> ·
   <a href="#examples">Examples</a>
 </p>
@@ -37,9 +38,10 @@
 ## Why
 
 AI coding agents are great at explaining how code works — in 800-line bullet walls you can't verify.
-OpenHop is a skill that lets your agent emit **animated data-flow diagrams** instead. You describe
-the flow in YAML (your agent writes it for you); OpenHop renders animated data pixels traveling
-between components on a pixel-art canvas. Click any node to drill into its sub-flow.
+OpenHop is a skill that lets your agent emit **animated data-flow diagrams** instead. You ask in
+plain English; your agent writes the flow as YAML and pushes it; OpenHop renders animated data
+pixels traveling between components on a pixel-art canvas. Click any node to drill into its
+sub-flow.
 
 ## Features
 
@@ -81,7 +83,11 @@ mkdir -p ~/.claude/skills/openhop
 cp skills/openhop/SKILL.md ~/.claude/skills/openhop/
 ```
 
-Then ask your agent things like:
+That's it — the agent now knows how to use OpenHop. Open your codebase in any SKILL-compatible client and ask it for a flow (see [Use cases](#use-cases) below for prompt ideas). The agent loads the skill, sketches the flow in YAML, calls `openhop push`, and hands you back a URL with the animation playing.
+
+## Use cases
+
+Once the skill is installed, point your agent at a codebase and ask it things like:
 
 - _"Walk me through the OAuth flow in this codebase."_
 - _"Diagram how a request flows through this Express app."_
@@ -92,7 +98,7 @@ Then ask your agent things like:
 - _"Diagram the WebSocket reconnection state machine."_
 - _"Walk me through what happens after `npm publish` — every step until the package is on the registry."_
 
-The agent loads the skill, sketches the flow in YAML, calls `openhop push`, and hands you back a URL with the animation playing.
+The shape that activates the skill is "explain / walk through / trace / visualize / diagram \_ flow". When the agent recognizes one of those patterns it switches from prose to YAML + animation.
 
 ## CLI
 


### PR DESCRIPTION
## Summary

Two README polish fixes following #86:

### 1. Fix Why-section prose

Previous text:
> You describe the flow in YAML (your agent writes it for you)

That contradicts itself. Users don't write YAML — they describe the codebase area in plain English and the agent emits the YAML. Rewrote as:

> You ask in plain English; your agent writes the flow as YAML and pushes it; OpenHop renders animated data pixels traveling between components on a pixel-art canvas.

### 2. Split prompts into a dedicated `## Use cases` section

#86 added 8 example prompts but inlined them inside "Give your agent the skill," mixing two concerns (one-time install vs every-day usage). Split them:

- The install section keeps the install steps + a one-line pointer to Use cases.
- New `## Use cases` section is the home of the prompt examples + a one-line trigger-shape note ("explain / walk through / trace / visualize / diagram \_ flow").
- Anchor `#use-cases` added to the top-of-README nav so it's discoverable from the page header.

## Diff

| File | +/- |
|---|---|
| `README.md` | +12 / -5 |

## Testing

- `npx prettier --check README.md` → clean
- Anchor link `#use-cases` resolves to the new heading (GitHub auto-generates anchors from `## Heading` titles)

## Linked context

Direct follow-up to #86 (which created the prompt examples). No new audit items closed by this change — it's structural / prose polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Navigation updated to surface separate “Install” and “Use cases” anchors.
  * “Why” rewritten to highlight plain‑English prompts, YAML output, animated data‑flow diagrams, and clickable node drill‑down.
  * Installation guidance restructured: treating a single skill file as the primary manual step, CLI/server auto-start behavior, two install paths (init vs package install), optional serve/demo commands, and contributor run‑from‑source notes.
  * “Use cases” rewritten with example prompts and a clarified trigger‑phrase pattern enabling YAML+animation mode; prior scenario table and older workflow copy removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->