### PR TITLE
docs(readme): polish quickstart — That's it\!, restart-and-ask, supported-clients as a Note callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Install the skill:
 npx openhop init
 ```
 
-**That's it!** Now restart your agent so it picks up the new skill, and ask:
+**That's it!**
+
+Now restart your agent so it picks up the new skill, and ask:
 
 > "Walk me through the main flow of this codebase."
 

--- a/README.md
+++ b/README.md
@@ -37,17 +37,20 @@
 
 ## Try it in 60 seconds
 
-Install the skill (auto-detects Claude Code, Cursor, Windsurf, Cline, Continue — for other clients see [Install](#install)):
+Install the skill:
 
 ```bash
 npx openhop init
 ```
 
-Restart your agent so it picks up the new skill, then open your codebase and ask:
+**That's it!** Now restart your agent so it picks up the new skill, and ask:
 
 > "Walk me through the main flow of this codebase."
 
 The agent generates the YAML, pushes it, and returns a URL with the animation playing.
+
+> [!NOTE]
+> `npx openhop init` auto-detects Claude Code, Cursor, Windsurf, Cline, and Continue. For other clients, see [Install](#install).
 
 ## Why
 


### PR DESCRIPTION
## Summary

Three readability tweaks to the "Try it in 60 seconds" section.

### Before

\`\`\`
## Try it in 60 seconds

Install the skill (auto-detects Claude Code, Cursor, Windsurf, Cline, Continue — for other clients see Install):

\`\`\`bash
npx openhop init
\`\`\`

Restart your agent so it picks up the new skill, then open your codebase and ask:

> "Walk me through the main flow of this codebase."

The agent generates the YAML, pushes it, and returns a URL with the animation playing.
\`\`\`

### After

\`\`\`
## Try it in 60 seconds

Install the skill:

\`\`\`bash
npx openhop init
\`\`\`

**That's it\!** Now restart your agent so it picks up the new skill, and ask:

> "Walk me through the main flow of this codebase."

The agent generates the YAML, pushes it, and returns a URL with the animation playing.

> [\!NOTE]
> \`npx openhop init\` auto-detects Claude Code, Cursor, Windsurf, Cline, and Continue.
> For other clients, see Install.
\`\`\`

## What changed

| Change | Why |
|---|---|
| Moved supported-clients aside out of the install lead-in into a `> [\!NOTE]` callout at section bottom | Keeps the install line focused on the action; GitHub renders `[\!NOTE]` as a blue info-callout |
| Added **That's it\!** between command and next-step | Marks completion of the install step naturally |
| "Restart your agent…, then open your codebase and ask" → "Now restart your agent…, and ask" | Flows better after the bolded "That's it\!" |

## Testing

\`npx prettier --check README.md\` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the "Try it in 60 seconds" quickstart: clearly labeled the Install step, preserved the example command block, and converted the previous inline auto-detection note into a prominent callout that directs other clients to the Install section for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->