### PR TITLE
chore(npm): per-package READMEs + lowercase URLs + keywords for server/web

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "description": "Animated data-flow diagrams your AI agent can write. Monorepo root.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/naorsabag/OpenHop.git"
+    "url": "https://github.com/naorsabag/openhop.git"
   },
-  "homepage": "https://github.com/naorsabag/OpenHop",
+  "homepage": "https://github.com/naorsabag/openhop",
   "bugs": {
-    "url": "https://github.com/naorsabag/OpenHop/issues"
+    "url": "https://github.com/naorsabag/openhop/issues"
   },
   "license": "MIT",
   "author": "Naor Sabag (https://github.com/naorsabag)",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,40 @@
+# openhop
+
+> CLI for [OpenHop](https://github.com/naorsabag/openhop) — animated data-flow diagrams your AI agent can write.
+
+OpenHop is a SKILL-compatible skill that teaches AI coding agents (Claude Code, Cursor, Windsurf, Cline, Continue, Codex CLI, Gemini CLI, and more) how to render flows as animated pixel-art diagrams. This package is the CLI binary that powers the skill — it ships the API server, the web renderer, and the agent-facing commands all in one npm package.
+
+## Try it in 60 seconds
+
+```bash
+npx openhop init
+```
+
+Restart your AI agent so it picks up the new skill, then ask it:
+
+> "Walk me through the main flow of this codebase."
+
+The agent generates the YAML, pushes it via `openhop push`, and returns a URL with the animation playing.
+
+## Commands
+
+```
+openhop init                         # install the SKILL.md into every detected AI client
+openhop serve                        # start API server on :8787 + web UI on :8788
+openhop push <file.yaml>             # create a flow → returns ID + URL
+openhop patch <flow-id> <file.yaml>  # apply patch operations to an existing flow
+openhop list                         # list flows
+openhop get <flow-id>                # fetch a flow by id
+openhop remove <flow-id>             # delete a flow
+openhop validate <file.yaml>         # validate YAML against the schema (no server)
+openhop demo                         # boot a starter OAuth flow + open browser
+```
+
+## Documentation
+
+Full README, install paths, use cases, and the YAML schema reference live at the repo:
+**[github.com/naorsabag/openhop](https://github.com/naorsabag/openhop)**
+
+## License
+
+MIT © Naor Sabag

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,7 +18,7 @@ The agent generates the YAML, pushes it via `openhop push`, and returns a URL wi
 
 ## Commands
 
-```
+```text
 openhop init                         # install the SKILL.md into every detected AI client
 openhop serve                        # start API server on :8787 + web UI on :8788
 openhop push <file.yaml>             # create a flow → returns ID + URL

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,12 +4,12 @@
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/naorsabag/OpenHop.git",
+    "url": "https://github.com/naorsabag/openhop.git",
     "directory": "packages/cli"
   },
-  "homepage": "https://github.com/naorsabag/OpenHop#readme",
+  "homepage": "https://github.com/naorsabag/openhop#readme",
   "bugs": {
-    "url": "https://github.com/naorsabag/OpenHop/issues"
+    "url": "https://github.com/naorsabag/openhop/issues"
   },
   "license": "MIT",
   "author": "Naor Sabag (https://github.com/naorsabag)",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,37 @@
+# @openhop/server
+
+> Fastify API server for [OpenHop](https://github.com/naorsabag/openhop) — stores and serves data-flow definitions.
+
+This is an internal package consumed by the [`openhop`](https://www.npmjs.com/package/openhop) CLI. **You don't need to install it directly** — `openhop serve` and `openhop demo` boot it for you.
+
+If you do want it standalone (custom integration, embedding the renderer in your own service):
+
+```bash
+npm install @openhop/server
+```
+
+```ts
+import { buildApp } from "@openhop/server"
+
+const app = await buildApp()
+await app.listen({ port: 8787, host: "0.0.0.0" })
+```
+
+## Routes
+
+- `GET /health` — readiness probe
+- `GET /api/flows` — list
+- `POST /api/flows` — create from YAML
+- `GET /api/flows/:id` — fetch
+- `PATCH /api/flows/:id` — apply patch operations
+- `DELETE /api/flows/:id` — remove
+- Swagger docs at `GET /docs`
+
+## Documentation
+
+Full documentation, schema reference, and the OpenHop story:
+**[github.com/naorsabag/openhop](https://github.com/naorsabag/openhop)**
+
+## License
+
+MIT © Naor Sabag

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,15 +4,23 @@
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/naorsabag/OpenHop.git",
+    "url": "https://github.com/naorsabag/openhop.git",
     "directory": "packages/server"
   },
-  "homepage": "https://github.com/naorsabag/OpenHop#readme",
+  "homepage": "https://github.com/naorsabag/openhop#readme",
   "bugs": {
-    "url": "https://github.com/naorsabag/OpenHop/issues"
+    "url": "https://github.com/naorsabag/openhop/issues"
   },
   "license": "MIT",
   "author": "Naor Sabag (https://github.com/naorsabag)",
+  "keywords": [
+    "openhop",
+    "data-flow",
+    "diagram",
+    "fastify",
+    "ai-agents",
+    "yaml"
+  ],
   "type": "module",
   "main": "dist/server.js",
   "types": "dist/index.d.ts",

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,73 +1,22 @@
-# React + TypeScript + Vite
+# @openhop/web
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+> Pre-built static assets for the [OpenHop](https://github.com/naorsabag/openhop) web UI — animated data-flow renderer (PIXI.js).
 
-Currently, two official plugins are available:
+This is an internal package consumed by the [`openhop`](https://www.npmjs.com/package/openhop) CLI. **You don't need to install it directly** — `openhop serve` and `openhop demo` serve these assets for you on `http://localhost:8788`.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+The package contains a built Vite bundle (HTML + JS + sprites) that:
 
-## React Compiler
+- Subscribes to the OpenHop API for a flow's contents
+- Renders nodes as pixel-art sprites
+- Animates data pixels traveling between nodes
+- Supports drill-down into sub-flows
+- Reads flows from URL fragments for the static GitHub Pages deploy
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+## Documentation
 
-## Expanding the ESLint configuration
+Full documentation:
+**[github.com/naorsabag/openhop](https://github.com/naorsabag/openhop)**
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+## License
 
-```js
-export default defineConfig([
-  globalIgnores(["dist"]),
-  {
-    files: ["**/*.{ts,tsx}"],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
-
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from "eslint-plugin-react-x"
-import reactDom from "eslint-plugin-react-dom"
-
-export default defineConfig([
-  globalIgnores(["dist"]),
-  {
-    files: ["**/*.{ts,tsx}"],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs["recommended-typescript"],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+MIT © Naor Sabag

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,15 +4,23 @@
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/naorsabag/OpenHop.git",
+    "url": "https://github.com/naorsabag/openhop.git",
     "directory": "packages/web"
   },
-  "homepage": "https://github.com/naorsabag/OpenHop#readme",
+  "homepage": "https://github.com/naorsabag/openhop#readme",
   "bugs": {
-    "url": "https://github.com/naorsabag/OpenHop/issues"
+    "url": "https://github.com/naorsabag/openhop/issues"
   },
   "license": "MIT",
   "author": "Naor Sabag (https://github.com/naorsabag)",
+  "keywords": [
+    "openhop",
+    "data-flow",
+    "diagram",
+    "pixi",
+    "react",
+    "visualization"
+  ],
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

Fixes the npm registry presentation gap: all three published packages ([\`openhop\`](https://www.npmjs.com/package/openhop), [\`@openhop/server\`](https://www.npmjs.com/package/@openhop/server), [\`@openhop/web\`](https://www.npmjs.com/package/@openhop/web)) currently show "This package does not have a README" on npmjs.com, and their listed repo URLs use the pre-rename PascalCase \`naorsabag/OpenHop\`.

## Changes

| Package | README | URL casing | Keywords |
|---|---|---|---|
| `openhop` (CLI) | NEW (~30 lines: quickstart + commands + repo link) | fixed → `naorsabag/openhop` | unchanged (already had 7) |
| `@openhop/server` | NEW (~20 lines: internal-package marker + standalone usage + route list) | fixed | NEW (6 keywords) |
| `@openhop/web` | REPLACED (the leftover `React + TypeScript + Vite` template that would have shipped to npm on next publish) → proper renderer description | fixed | NEW (6 keywords) |
| (root) | n/a | fixed | unchanged |

## What this changes on the npm pages

After the next `npm publish`, visitors to:

- `npmjs.com/package/openhop` — will see a proper README (currently empty placeholder).
- `npmjs.com/package/@openhop/server` — proper README (currently empty).
- `npmjs.com/package/@openhop/web` — proper README **instead of the Vite template default** that would have shipped on next publish.

All three pages will list the repo as `naorsabag/openhop` (lowercase) instead of the stale PascalCase URL.

## Skipped intentionally

- **Homepage URL.** Left pointing at the GitHub repo's `#readme` anchor. No separate website (`openhop.dev` etc.) to point at for v0.1; the playground deploy is post-launch per `02-hosted-playground.md:3`.
- **`@openhop/shared`.** Stays unpublished — it's bundled into `@openhop/server` and `@openhop/web` at build time (esbuild inlines it), so no runtime dependency leaks. `private: true` already prevents accidental publish.

## Testing

\`npx prettier --check\` clean on all 7 changed files.

The new READMEs render correctly when previewed locally; the one-line npm-marker note in @openhop/server / @openhop/web makes it clear those are internal packages so users don't try to wire them up directly.

## Effect on the audit

Closes the npm-registry-quality gap surfaced in the most recent audit pass — the three published packages now have proper metadata for the v0.1 launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CLI documentation with quick-start and command reference.
  * Added server package documentation describing API behavior and routes.
  * Replaced and updated web package documentation to reflect delivered static bundle and usage.

* **Chores**
  * Standardized repository and package metadata URLs and casing across all packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->