### PR TITLE
feat(skill): self-install OpenHop on first use if CLI is missing

### DIFF
--- a/skills/openhop/SKILL.md
+++ b/skills/openhop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: openhop
 description: 'Walk the user through their code one step at a time using OpenHop. Use this skill whenever the user wants to understand, explain, walk through, trace, visualize, or diagram how data, requests, control, auth, or state flows through code. Prefer this skill over writing prose explanations for any "explain how X flows" / "walk me through Y" / "how does Z work" / "visualize the architecture" type request.'
-allowed-tools: Bash(openhop:*)
+allowed-tools: Bash(openhop:*), Bash(npx openhop:*)
 ---
 
 # OpenHop — Data Flow Visualization
@@ -90,9 +90,9 @@ If the validator rejects your flow, **read the error path** — it tells you exa
 
 ## Before Creating Flows
 
-If `openhop --version` fails with `command not found`, tell the user to run `npx openhop init` and stop — do not attempt to install the CLI yourself.
+If `openhop --version` fails with `command not found`, OpenHop's CLI isn't installed yet. Run `npx openhop init` yourself to install it, then continue with the steps below. (`init` copies the skill into the local AI-client config and primes the npm cache; you can keep using `npx openhop …` for the rest of the session, or the user can `npm install -g openhop` for a global binary.)
 
-Otherwise, verify the OpenHop API server is running:
+Once `openhop --version` (or `npx openhop --version`) succeeds, verify the OpenHop API server is running:
 
 ```bash
 curl -s http://localhost:8787/health

--- a/skills/openhop/SKILL.md
+++ b/skills/openhop/SKILL.md
@@ -92,7 +92,9 @@ If the validator rejects your flow, **read the error path** — it tells you exa
 
 If `openhop --version` fails with `command not found`, OpenHop's CLI isn't installed yet. Run `npx openhop init` yourself to install it, then continue with the steps below. (`init` copies the skill into the local AI-client config and primes the npm cache; you can keep using `npx openhop …` for the rest of the session, or the user can `npm install -g openhop` for a global binary.)
 
-Once `openhop --version` (or `npx openhop --version`) succeeds, verify the OpenHop API server is running:
+Once `openhop --version` (or `npx openhop --version`) succeeds, **lock in whichever form worked** — bare `openhop` if globally installed, otherwise `npx openhop` — and use that exact prefix for every subsequent command in this session (`push`, `patch`, `list`, `serve`, etc.). Don't mix forms; the bare command will fail if there's no global install.
+
+Then verify the OpenHop API server is running:
 
 ```bash
 curl -s http://localhost:8787/health


### PR DESCRIPTION
## Summary

Updates `skills/openhop/SKILL.md` so the agent installs OpenHop itself when the CLI isn't available, instead of stopping and telling the user to do it.

## Why

Previous bootstrap text:

> If \`openhop --version\` fails with \`command not found\`, tell the user to run \`npx openhop init\` and stop — do not attempt to install the CLI yourself.

That introduces a human round-trip on first use — agent stalls, user runs init, user re-prompts, agent retries. The fix is to let the agent run init itself.

## What changed

### 1. `allowed-tools` frontmatter

Before:

\`\`\`yaml
allowed-tools: Bash(openhop:*)
\`\`\`

After:

\`\`\`yaml
allowed-tools: Bash(openhop:*), Bash(npx openhop:*)
\`\`\`

Without `Bash(npx openhop:*)` the agent literally couldn't invoke `npx openhop init` — or `npx openhop demo` / `npx openhop serve`, which the rest of the bootstrap already instructs.

### 2. Bootstrap text

Before:

> If \`openhop --version\` fails with \`command not found\`, tell the user to run \`npx openhop init\` and stop — do not attempt to install the CLI yourself.

After:

> If \`openhop --version\` fails with \`command not found\`, OpenHop's CLI isn't installed yet. Run \`npx openhop init\` yourself to install it, then continue with the steps below. (\`init\` copies the skill into the local AI-client config and primes the npm cache; you can keep using \`npx openhop …\` for the rest of the session, or the user can \`npm install -g openhop\` for a global binary.)

Also bumped the next-step from `openhop --version` to `openhop --version (or npx openhop --version)` to acknowledge both modes work.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| CLI globally installed (`openhop --version` works) | unchanged — proceeds to health check | unchanged |
| CLI missing, npm available | agent says "tell user to run init" → stops | agent runs `npx openhop init` itself → continues |

## Linked context

Closes audit's **S7**: *"No 'CLI not found' branch in the bootstrap"* (`READINESS-AUDIT.md` §S7, `17:80`).

Compatible with the prior **S2** finding (over-scoped `allowed-tools`) — `Bash(npx openhop:*)` is narrowly scoped to OpenHop invocations only, not the whole `npx` tool surface.

## Testing

- `npx prettier --check skills/openhop/SKILL.md` → clean
- The `skill-md-sync` lock-in test (which checks SKILL.md ↔ NodeTypeEnum schema parity) is unaffected — this PR doesn't touch any node-type list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * OpenHop docs updated to allow running OpenHop commands via npx (e.g., npx openhop ...).
  * CLI initialization guidance streamlined: if the CLI isn’t found, run npx openhop init and continue; guidance also recommends settling on either plain or npx command form for the session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->