### PR TITLE
chore: bump @openhop/web to beta.2 + openhop CLI to beta.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7680,13 +7680,13 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.1.0-beta.3",
+      "version": "0.1.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.4.4",
         "@fastify/static": "^9.1.3",
         "@openhop/server": "0.1.0-beta.1",
-        "@openhop/web": "0.1.0-beta.1",
+        "@openhop/web": "0.1.0-beta.2",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
         "yaml": "^2.8.4",
@@ -8685,7 +8685,7 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.1.0-beta.1",
+      "version": "0.1.0-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@codemirror/lang-yaml": "^6.1.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.4",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
     "@openhop/server": "0.1.0-beta.1",
-    "@openhop/web": "0.1.0-beta.1",
+    "@openhop/web": "0.1.0-beta.2",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ if (process.argv.includes('--api-version')) {
 
 const program = new Command()
 
-program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.3')
+program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.4')
 
 // --- serve ---
 //

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version bumps for the next published beta. Source for what's about to land on the registry.

## Bumps
- `@openhop/web`: `0.1.0-beta.1` → `0.1.0-beta.2`
- `openhop` (CLI): `0.1.0-beta.3` → `0.1.0-beta.4`
- CLI's pinned `@openhop/web` dep updated to `0.1.0-beta.2`
- `@openhop/server` stays at `0.1.0-beta.1` — no source changes since last publish

## What's in beta.2 (web) since beta.1
- pause behavior fix + label overflow + back-edge corridor (#90)
- carrot click opens inspect with multi-target highlight + on-canvas playback controls (#93)
- bookmark-style toggle tabs for sidebar + inspector (#95)
- preserve node progress on Play resume + drill-back (#96)
- shrink sprite SVGs by 46% — 3.7MB → 2.0MB (#97)

## What's in beta.4 (cli) since beta.3
- (no source changes — only the @openhop/web dep bump to ship the new web bundle to `npx openhop demo` users)
- SKILL.md updates from #90 (≤4-word label rule) and #92 (self-install fallback) ride along since `init` ships the bundled `skills/openhop/SKILL.md`

## Distribution
After publish:
- `npx openhop@beta demo` → boots beta.4 CLI + serves beta.2 web bundle
- `npx openhop@beta init` → installs the latest SKILL.md
- `npx openhop@beta init --force` → for users with an older SKILL.md already in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped CLI package version to 0.1.0-beta.4.
  * Updated web package to 0.1.0-beta.2 and aligned CLI dependency.
  * CLI now reports the new version when queried with --version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/98)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/98)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->