### PR TITLE
fix(web): pin actor nodes to leftmost layer

### DIFF
--- a/packages/web/__tests__/flow-layout.test.ts
+++ b/packages/web/__tests__/flow-layout.test.ts
@@ -121,6 +121,21 @@ describe('computeElkLayout', () => {
     expect(cron!.y).toBe(events!.y)
   })
 
+  it('pins actor-typed nodes to the leftmost layer even when they also appear as a target', async () => {
+    const yaml = readFileSync(new URL('../../../examples/order-flow.yaml', import.meta.url), 'utf8')
+    const parsed = parseFlowYaml(yaml)
+    expect(parsed.success).toBe(true)
+    if (!parsed.success || !parsed.data) return
+
+    const { computeElkLayout } = await import('../src/lib/flow-layout.ts')
+    const topology = buildFlowTopology(parsed.data as Flow)
+    const layout = await computeElkLayout(topology)
+    const userPos = layout.positions.get('user')
+    expect(userPos).toBeTruthy()
+    const minX = Math.min(...[...layout.positions.values()].map((p) => p.x))
+    expect(userPos!.x).toBe(minX)
+  })
+
   it('routes the api to order-service edge clear of the rate-limit node in the real example', async () => {
     const yaml = readFileSync(new URL('../../../examples/order-flow.yaml', import.meta.url), 'utf8')
     const parsed = parseFlowYaml(yaml)

--- a/packages/web/src/lib/flow-layout.ts
+++ b/packages/web/src/lib/flow-layout.ts
@@ -876,18 +876,23 @@ function buildElkGraph(topology: FlowTopology, portAssignments?: Map<string, Edg
         },
       }))
 
+      // Actors represent the human/external initiator — pin them to the
+      // leftmost layer so the flow always reads "user → system → ..." even
+      // when the actor also has incoming edges (e.g. a final response
+      // step).
+      const isActor = topology.nodeSnapshots.get(id)?.nodeType === 'actor'
+      const nodeLayoutOptions: Record<string, string> = {}
+      if (portAssignments) nodeLayoutOptions.portConstraints = 'FIXED_SIDE'
+      if (isActor) nodeLayoutOptions['elk.layered.layering.layerConstraint'] = 'FIRST'
+
       return {
         id,
         width: NODE_WIDTH,
         height: NODE_HEIGHT,
-        ...(portAssignments
-          ? {
-              layoutOptions: {
-                portConstraints: 'FIXED_SIDE',
-              },
-              ports,
-            }
+        ...(Object.keys(nodeLayoutOptions).length > 0
+          ? { layoutOptions: nodeLayoutOptions }
           : null),
+        ...(portAssignments ? { ports } : null),
       }
     }),
     edges: topology.displayEdges.map((edge) => ({


### PR DESCRIPTION
## Summary
- ELK could place actor nodes (the human/external initiator) at any layer that minimized total edge length, sometimes pushing `user` / `browser` inward when it also appeared as a final response target.
- Added `elk.layered.layering.layerConstraint=FIRST` for `type: actor` nodes so the actor always anchors the leftmost column.
- New test in `__tests__/flow-layout.test.ts` asserts that `user` lands at `min(x)` across the order-flow example layout.

## Test plan
- [x] `npm test` in `packages/web` (41/41 passing — new test included)
- [ ] Visually verify `npx openhop@beta demo` after merge: `browser` on far left of the auth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flow layout behavior to ensure actor-typed nodes are correctly positioned at the leftmost layer in flow diagrams, even when they appear as edge targets. Improved per-node layout options computation for more accurate positioning.

* **Tests**
  * Added test validation for flow layout behavior to ensure consistent positioning of actor nodes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->