### PR TITLE
fix(web): orthogonal float epsilon — flat edges no longer dive past target

### DIFF
--- a/packages/web/__tests__/flow-layout.test.ts
+++ b/packages/web/__tests__/flow-layout.test.ts
@@ -12,6 +12,7 @@ import {
   NODE_WIDTH,
   SELF_LOOP_HEIGHT,
   SELF_LOOP_WIDTH,
+  orthogonalizeRoutePoints,
 } from '../src/lib/flow-layout.ts'
 
 const orderFlow = {
@@ -285,6 +286,54 @@ describe('buildOrthogonalPath', () => {
 })
 
 describe('inferPortAssignmentsFromRoutes', () => {
+  it('treats sub-pixel y differences as flat (e.g. claude-router → mongodb in orion-main)', () => {
+    // After shiftRoutesAfterSnap, two endpoints that should share y can
+    // drift by ~1 ULP due to float arithmetic. Without epsilon-tolerant
+    // orthogonalization this triggers a phantom vertical corner; that 3rd
+    // point makes the final segment a tiny vertical, and
+    // inferPortAssignmentsFromRoutes then runs targetHandleFromSegment on
+    // (0, ~3e-15), where |dx|=0 < |dy|=3e-15, so it falls into the
+    // vertical branch and picks 'bottom' instead of 'left'. Regression:
+    // the road visibly dove past the database into empty space.
+    //
+    // Run through orthogonalizeRoutePoints first so we exercise the same
+    // pipeline computeElkLayout uses (orthogonalize → infer); without that
+    // step the test would already pass on broken code because the raw
+    // 2-point route biases the horizontal-dominant branch.
+    const topology = buildFlowTopology({
+      flow: {
+        nodes: [
+          { id: 'a', label: 'A', type: 'service' },
+          { id: 'b', label: 'B', type: 'database' },
+        ],
+        steps: [{ from: 'a', to: 'b' }],
+      },
+    } as Flow)
+
+    const edge = topology.displayEdges[0]
+    const positions = new Map([
+      ['a', { x: 0, y: 0 }],
+      ['b', { x: 200, y: 0 }],
+    ])
+    // The two y values differ at the last bit of float precision.
+    const rawNoisyRoute = [
+      { x: 100, y: 80.00000000000001 },
+      { x: 200, y: 80 },
+    ]
+    const orthogonalized = orthogonalizeRoutePoints(rawNoisyRoute)
+    // With the epsilon fix, orthogonalize keeps the 2-point route and
+    // doesn't fabricate a corner. (Without the fix, it would expand to
+    // three points with a phantom near-zero vertical at the end.)
+    expect(orthogonalized).toHaveLength(2)
+
+    const assignments = inferPortAssignmentsFromRoutes(
+      topology,
+      positions,
+      new Map([[edge.id, orthogonalized]])
+    )
+    expect(assignments.get(edge.id)).toMatchObject({ source: 'right', target: 'left' })
+  })
+
   it('chooses the closest routed side from the first and last orthogonal segments', () => {
     const assignments = inferPortAssignmentsFromRoutes(
       buildFlowTopology(orderFlow),

--- a/packages/web/src/lib/flow-layout.ts
+++ b/packages/web/src/lib/flow-layout.ts
@@ -351,7 +351,15 @@ function chooseOrthogonalCorner(
   return { x: next.x, y: current.y }
 }
 
-function orthogonalizeRoutePoints(points: RoutePoint[]): RoutePoint[] {
+// Sub-pixel epsilon for orthogonality checks. After shiftRoutesAfterSnap,
+// two points that should share a coordinate can drift by ~1 ULP (3e-15) due
+// to float arithmetic. Without this tolerance, orthogonalize inserts a
+// phantom corner and inferPortAssignmentsFromRoutes then treats a tiny dy
+// as the dominant axis — picking 'bottom' for what should be a flat
+// 'left' entry. (Seen on claude-router → mongodb in the orion main flow.)
+const ORTHOGONAL_EPSILON = 0.5
+
+export function orthogonalizeRoutePoints(points: RoutePoint[]): RoutePoint[] {
   const route: RoutePoint[] = []
 
   for (let index = 0; index < points.length; index++) {
@@ -363,7 +371,10 @@ function orthogonalizeRoutePoints(points: RoutePoint[]): RoutePoint[] {
       continue
     }
 
-    if (current.x !== point.x && current.y !== point.y) {
+    if (
+      Math.abs(current.x - point.x) > ORTHOGONAL_EPSILON &&
+      Math.abs(current.y - point.y) > ORTHOGONAL_EPSILON
+    ) {
       const corner = chooseOrthogonalCorner(
         route[route.length - 2],
         current,


### PR DESCRIPTION
## Summary
Reproduced on the orion-main flow at \`/flow/eIxRYAM39kwT\`: the \`claude-router → mongodb\` road entered the database from the top instead of the left, then dove out into empty space (the user-visible "dead end").

Root cause is sub-pixel float drift after \`shiftRoutesAfterSnap\`: two endpoints that should share \`y\` differed by ~1 ULP (3e-15). \`orthogonalizeRoutePoints\` used strict \`\!==\`, declared the segment diagonal, and inserted a phantom vertical corner. \`inferPortAssignmentsFromRoutes\` then ran \`targetHandleFromSegment(0, -3e-15)\` and picked \`bottom\` (because \`|dx|=0\` is not \`≥ |dy|=3e-15\`), so \`extendRouteToNodeCenters\` shifted the endpoint upward away from the node — that's the dead-end.

Fix: 0.5px epsilon on the axis-equality test. Below that we treat the segment as already orthogonal, so float noise can't fabricate a corner.

## Test plan
- [x] \`npm test\` in \`packages/web\` — 41/41 pass, including the new regression in \`flow-layout.test.ts\` for the sub-pixel-y case
- [x] Verified locally against the live \`flow/eIxRYAM39kwT\`: route now goes \`claude-router:right → mongodb:left\` as a single horizontal segment instead of detouring past mongodb's top edge
- [ ] Visually confirm in \`npx openhop@beta demo\` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edge routing precision in flow layouts by handling sub-pixel floating-point variations to prevent phantom orthogonal corners and incorrect port assignments.
* **Tests**
  * Added a regression test covering orthogonal route handling with sub-pixel mismatches to prevent future regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/100)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->