### PR TITLE
chore: bump @openhop/web to beta.3 + openhop CLI to beta.5

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
     "@openhop/server": "0.1.0-beta.1",
-    "@openhop/web": "0.1.0-beta.2",
+    "@openhop/web": "0.1.0-beta.3",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ if (process.argv.includes('--api-version')) {
 
 const program = new Command()
 
-program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.4')
+program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.5')
 
 // --- serve ---
 //

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bundles into the published betas:

- #99 — pin actor nodes to the leftmost layer
- #100 — epsilon-tolerant orthogonality so flat edges don't pick a phantom port
- #101 — chrome z-index above pixels + monochrome SVG playback icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI version to 0.1.0-beta.5
  * Updated web package version to 0.1.0-beta.3

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/102)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->