### PR TITLE
ci(publish): auto-tag + GitHub Release on each npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write # tag + release creation
   id-token: write
 
 concurrency:
@@ -81,3 +81,49 @@ jobs:
         run: npm publish --tag beta --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Tag + GitHub Release whenever ANY publish happened. The tag tracks
+      # the CLI version since that's the user-visible artifact (`npx
+      # openhop@beta …`); the release notes list whatever shipped this run
+      # so a web-only or cli-only bump is still recorded.
+      - name: Create tag + GitHub Release
+        if: |
+          steps.web_status.outputs.publish == 'true' ||
+          steps.cli_status.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEB_VERSION: ${{ steps.versions.outputs.web }}
+          CLI_VERSION: ${{ steps.versions.outputs.cli }}
+          WEB_PUBLISHED: ${{ steps.web_status.outputs.publish }}
+          CLI_PUBLISHED: ${{ steps.cli_status.outputs.publish }}
+        run: |
+          tag="v$CLI_VERSION"
+          # If the tag already exists (rare — re-running a workflow on a
+          # commit whose CLI version was already tagged), skip cleanly.
+          if gh release view "$tag" > /dev/null 2>&1; then
+            echo "::notice::release $tag already exists, skipping"
+            exit 0
+          fi
+
+          {
+            echo "## Published to npm (\`beta\` tag)"
+            if [ "$WEB_PUBLISHED" = "true" ]; then
+              echo "- [\`@openhop/web@$WEB_VERSION\`](https://www.npmjs.com/package/@openhop/web/v/$WEB_VERSION)"
+            fi
+            if [ "$CLI_PUBLISHED" = "true" ]; then
+              echo "- [\`openhop@$CLI_VERSION\`](https://www.npmjs.com/package/openhop/v/$CLI_VERSION)"
+            fi
+            echo
+            echo "## Try it"
+            echo '```sh'
+            echo "npx openhop@beta demo"
+            echo '```'
+            echo
+            echo "Auto-generated notes (commit history) below."
+          } > /tmp/release-body.md
+
+          gh release create "$tag" \
+            --title "$tag" \
+            --notes-file /tmp/release-body.md \
+            --generate-notes \
+            --target "$GITHUB_SHA"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,7 @@ jobs:
 
       # Publish web first — the CLI's package.json depends on the web version.
       - name: Publish @openhop/web
+        id: publish_web
         if: steps.web_status.outputs.publish == 'true'
         working-directory: packages/web
         run: npm publish --tag beta --access public
@@ -76,6 +77,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish openhop CLI
+        id: publish_cli
         if: steps.cli_status.outputs.publish == 'true'
         working-directory: packages/cli
         run: npm publish --tag beta --access public
@@ -90,15 +92,22 @@ jobs:
       #   cli only → cli/v$CLI_VERSION
       #   web only → web/v$WEB_VERSION
       - name: Create tag + GitHub Release
+        # Gate on actual step outcomes, not the pre-check intent — a failed
+        # `npm publish` (network, auth, registry rejection) shouldn't still
+        # produce a "successful publish" release record. `always()` keeps
+        # this step eligible to run even though the upstream publish step
+        # may have been conditionally skipped.
         if: |
-          steps.web_status.outputs.publish == 'true' ||
-          steps.cli_status.outputs.publish == 'true'
+          always() && (
+            steps.publish_web.outcome == 'success' ||
+            steps.publish_cli.outcome == 'success'
+          )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WEB_VERSION: ${{ steps.versions.outputs.web }}
           CLI_VERSION: ${{ steps.versions.outputs.cli }}
-          WEB_PUBLISHED: ${{ steps.web_status.outputs.publish }}
-          CLI_PUBLISHED: ${{ steps.cli_status.outputs.publish }}
+          WEB_PUBLISHED: ${{ steps.publish_web.outcome == 'success' }}
+          CLI_PUBLISHED: ${{ steps.publish_cli.outcome == 'success' }}
         run: |
           if [ "$WEB_PUBLISHED" = "true" ] && [ "$CLI_PUBLISHED" = "true" ]; then
             tag="v$CLI_VERSION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,10 +82,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Tag + GitHub Release whenever ANY publish happened. The tag tracks
-      # the CLI version since that's the user-visible artifact (`npx
-      # openhop@beta …`); the release notes list whatever shipped this run
-      # so a web-only or cli-only bump is still recorded.
+      # Tag + GitHub Release whenever ANY publish happened. Tag scheme
+      # branches on what actually shipped so a web-only bump can't collide
+      # with a CLI tag from a prior run:
+      #   both → v$CLI_VERSION         (combined release; CLI is the
+      #                                  user-facing handle for `npx`)
+      #   cli only → cli/v$CLI_VERSION
+      #   web only → web/v$WEB_VERSION
       - name: Create tag + GitHub Release
         if: |
           steps.web_status.outputs.publish == 'true' ||
@@ -97,9 +100,17 @@ jobs:
           WEB_PUBLISHED: ${{ steps.web_status.outputs.publish }}
           CLI_PUBLISHED: ${{ steps.cli_status.outputs.publish }}
         run: |
-          tag="v$CLI_VERSION"
-          # If the tag already exists (rare — re-running a workflow on a
-          # commit whose CLI version was already tagged), skip cleanly.
+          if [ "$WEB_PUBLISHED" = "true" ] && [ "$CLI_PUBLISHED" = "true" ]; then
+            tag="v$CLI_VERSION"
+          elif [ "$CLI_PUBLISHED" = "true" ]; then
+            tag="cli/v$CLI_VERSION"
+          else
+            tag="web/v$WEB_VERSION"
+          fi
+
+          # If THIS tag already exists (re-run of a workflow whose tag
+          # already landed), skip cleanly. Per-package tags mean we never
+          # check for an unrelated tag.
           if gh release view "$tag" > /dev/null 2>&1; then
             echo "::notice::release $tag already exists, skipping"
             exit 0


### PR DESCRIPTION
Extends \`.github/workflows/publish.yml\` so every successful npm publish is also recorded as a git tag and a GitHub Release. Without this, npm publishes leave no trace on github.com beyond the bump commit — and the Releases tab stays empty (which is what you noticed after the repo went public).

## Behavior
- Triggered when either web OR cli successfully publishes.
- Tag name: \`v\$(cli version)\` — e.g. \`v0.1.0-beta.6\`. The CLI version is what users \`npx\`, so it's the most recognizable handle.
- Release body lists whichever package(s) shipped on that run, so web-only or cli-only bumps still produce a record.
- \`--generate-notes\` appends GitHub's auto-summarized commit history since the prior tag.
- Skips cleanly if the tag already exists (re-runs are idempotent).

Required permission bump: \`contents: read\` → \`contents: write\` on the workflow.

## Test plan
- [x] One-shot \`v0.1.0-beta.5\` release created retroactively for the current beta state.
- [ ] On the next beta bump, confirm the workflow tags + releases automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now creates GitHub releases and tags automatically when packages are published.
  * Tag names are chosen dynamically depending on which packages published (combined, CLI-only, or web-only).
  * Release creation is skipped if a matching tag/release already exists.
  * Generated release notes include npm beta package links and an example npx usage.
  * CI permissions updated to allow release/tag creation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/104)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->