### PR TITLE
chore: bump all three packages + publish server in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,14 @@
 name: publish
 
-# Publishes @openhop/web and the openhop CLI to npm whenever the version in
-# either package.json on master differs from what's already on the registry
-# under the `beta` tag. Lets us ship a release just by merging a "chore: bump"
-# PR — no manual `npm publish` step in someone's terminal.
+# Publishes @openhop/server, @openhop/web, and the openhop CLI to npm whenever
+# the version in any of their package.json files on master differs from what's
+# already on the registry under the `beta` tag. Lets us ship a release just by
+# merging a "chore: bump" PR — no manual `npm publish` step in someone's
+# terminal.
 #
-# Web is published before CLI because the CLI's package.json depends on the
-# web version. If only one bumped, only that one runs (the other is a no-op).
+# Order matters: server + web ship before the CLI because the CLI's
+# package.json depends on both. If only one bumped, only that one runs (the
+# others are no-ops).
 
 on:
   push:
@@ -42,10 +44,22 @@ jobs:
       - name: Resolve target versions
         id: versions
         run: |
+          server_version=$(node -p "require('./packages/server/package.json').version")
           web_version=$(node -p "require('./packages/web/package.json').version")
           cli_version=$(node -p "require('./packages/cli/package.json').version")
+          echo "server=$server_version" >> "$GITHUB_OUTPUT"
           echo "web=$web_version" >> "$GITHUB_OUTPUT"
           echo "cli=$cli_version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if @openhop/server@${{ steps.versions.outputs.server }} is already on npm
+        id: server_status
+        run: |
+          if npm view "@openhop/server@${{ steps.versions.outputs.server }}" version > /dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::@openhop/server@${{ steps.versions.outputs.server }} already on registry, skipping"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Check if @openhop/web@${{ steps.versions.outputs.web }} is already on npm
         id: web_status
@@ -67,7 +81,15 @@ jobs:
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Publish web first — the CLI's package.json depends on the web version.
+      # Server + web ship before the CLI — the CLI's package.json pins both.
+      - name: Publish @openhop/server
+        id: publish_server
+        if: steps.server_status.outputs.publish == 'true'
+        working-directory: packages/server
+        run: npm publish --tag beta --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish @openhop/web
         id: publish_web
         if: steps.web_status.outputs.publish == 'true'
@@ -85,12 +107,14 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Tag + GitHub Release whenever ANY publish happened. Tag scheme
-      # branches on what actually shipped so a web-only bump can't collide
-      # with a CLI tag from a prior run:
-      #   both → v$CLI_VERSION         (combined release; CLI is the
-      #                                  user-facing handle for `npx`)
-      #   cli only → cli/v$CLI_VERSION
-      #   web only → web/v$WEB_VERSION
+      # branches on what actually shipped so a one-package bump can't
+      # collide with a stale tag from a prior multi-package run:
+      #   cli shipped → v$CLI_VERSION         (CLI is the user-facing handle
+      #                                         for `npx openhop@beta`, so its
+      #                                         version anchors the combined
+      #                                         release name)
+      #   server only → server/v$SERVER_VERSION
+      #   web only    → web/v$WEB_VERSION
       - name: Create tag + GitHub Release
         # Gate on actual step outcomes, not the pre-check intent — a failed
         # `npm publish` (network, auth, registry rejection) shouldn't still
@@ -99,27 +123,29 @@ jobs:
         # may have been conditionally skipped.
         if: |
           always() && (
+            steps.publish_server.outcome == 'success' ||
             steps.publish_web.outcome == 'success' ||
             steps.publish_cli.outcome == 'success'
           )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SERVER_VERSION: ${{ steps.versions.outputs.server }}
           WEB_VERSION: ${{ steps.versions.outputs.web }}
           CLI_VERSION: ${{ steps.versions.outputs.cli }}
+          SERVER_PUBLISHED: ${{ steps.publish_server.outcome == 'success' }}
           WEB_PUBLISHED: ${{ steps.publish_web.outcome == 'success' }}
           CLI_PUBLISHED: ${{ steps.publish_cli.outcome == 'success' }}
         run: |
-          if [ "$WEB_PUBLISHED" = "true" ] && [ "$CLI_PUBLISHED" = "true" ]; then
+          if [ "$CLI_PUBLISHED" = "true" ]; then
             tag="v$CLI_VERSION"
-          elif [ "$CLI_PUBLISHED" = "true" ]; then
-            tag="cli/v$CLI_VERSION"
-          else
+          elif [ "$WEB_PUBLISHED" = "true" ]; then
             tag="web/v$WEB_VERSION"
+          else
+            tag="server/v$SERVER_VERSION"
           fi
 
           # If THIS tag already exists (re-run of a workflow whose tag
-          # already landed), skip cleanly. Per-package tags mean we never
-          # check for an unrelated tag.
+          # already landed), skip cleanly.
           if gh release view "$tag" > /dev/null 2>&1; then
             echo "::notice::release $tag already exists, skipping"
             exit 0
@@ -127,6 +153,9 @@ jobs:
 
           {
             echo "## Published to npm (\`beta\` tag)"
+            if [ "$SERVER_PUBLISHED" = "true" ]; then
+              echo "- [\`@openhop/server@$SERVER_VERSION\`](https://www.npmjs.com/package/@openhop/server/v/$SERVER_VERSION)"
+            fi
             if [ "$WEB_PUBLISHED" = "true" ]; then
               echo "- [\`@openhop/web@$WEB_VERSION\`](https://www.npmjs.com/package/@openhop/web/v/$WEB_VERSION)"
             fi

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.1.0-beta.5",
+  "version": "0.1.0-beta.6",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -42,8 +42,8 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.1.0-beta.1",
-    "@openhop/web": "0.1.0-beta.3",
+    "@openhop/server": "0.1.0-beta.2",
+    "@openhop/web": "0.1.0-beta.4",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ if (process.argv.includes('--api-version')) {
 
 const program = new Command()
 
-program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.5')
+program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.6')
 
 // --- serve ---
 //

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.4",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What
- \`@openhop/server\`: \`0.1.0-beta.1\` → \`0.1.0-beta.2\` — first publish that ships the per-package README (the earlier publish on May 8 predated #91, so the tarball had no README).
- \`@openhop/web\`: \`0.1.0-beta.3\` → \`0.1.0-beta.4\` — re-publish so the registry's top-level \`readme\` field gets populated. The prior publish included the README in the tarball, but the npmjs.com page still showed blank because the readme bytes weren't propagated to the package-level doc.
- \`openhop\` CLI: \`0.1.0-beta.5\` → \`0.1.0-beta.6\` — pins the bumped server + web; same readme-propagation fix as web.

## CI changes
\`publish.yml\` now also runs server through the version-skip + publish flow and the release-creation step. Without that, a server-only bump would never produce a tag/release. Tag scheme is now:

| What shipped | Tag |
|---|---|
| CLI (with or without others) | \`v\$CLI_VERSION\` |
| Web only | \`web/v\$WEB_VERSION\` |
| Server only | \`server/v\$SERVER_VERSION\` |

Server is published before web/CLI because the CLI's package.json pins it.

## Why
You asked why \`openhop\` and \`@openhop/server\` had no README on npmjs.com. The CLI's tarball already had it, but the registry manifest's \`readme\` field was empty (an npm-on-workspaces quirk). Server's tarball didn't have it at all because it was published before per-package READMEs landed. Both are fixed by a fresh publish.

## Test plan
- [x] \`npm test -w @openhop/web\` (42/42)
- [ ] After merge: confirm publish.yml runs all three publishes successfully and the auto-release lands at \`v0.1.0-beta.6\`
- [ ] After publish: confirm npmjs.com shows the README on each of the three package pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI package to version 0.1.0-beta.6 with refreshed server and web dependencies
  * Updated Server package to version 0.1.0-beta.2
  * Updated Web package to version 0.1.0-beta.4
  * Enhanced release publishing workflow to include server package in npm beta distribution pipeline with conditional logic

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/105)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->