### PR TITLE
fix(web): sprite URLs use Vite BASE_URL so Pages can find them

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,12 +109,17 @@ jobs:
       # Tag + GitHub Release whenever ANY publish happened. Tag scheme
       # branches on what actually shipped so a one-package bump can't
       # collide with a stale tag from a prior multi-package run:
-      #   cli shipped → v$CLI_VERSION         (CLI is the user-facing handle
-      #                                         for `npx openhop@beta`, so its
-      #                                         version anchors the combined
-      #                                         release name)
-      #   server only → server/v$SERVER_VERSION
-      #   web only    → web/v$WEB_VERSION
+      #   cli shipped         → v$CLI_VERSION         (CLI is the user-facing
+      #                                                 handle for `npx
+      #                                                 openhop@beta`, so its
+      #                                                 version anchors the
+      #                                                 combined release)
+      #   server (± web)      → server/v$SERVER_VERSION (server is the lowest
+      #                                                   layer and a more
+      #                                                   meaningful anchor
+      #                                                   than web when both
+      #                                                   ship together)
+      #   web only            → web/v$WEB_VERSION
       - name: Create tag + GitHub Release
         # Gate on actual step outcomes, not the pre-check intent — a failed
         # `npm publish` (network, auth, registry rejection) shouldn't still
@@ -138,10 +143,11 @@ jobs:
         run: |
           if [ "$CLI_PUBLISHED" = "true" ]; then
             tag="v$CLI_VERSION"
-          elif [ "$WEB_PUBLISHED" = "true" ]; then
-            tag="web/v$WEB_VERSION"
-          else
+          elif [ "$SERVER_PUBLISHED" = "true" ]; then
+            # Covers server-only AND server+web combined runs.
             tag="server/v$SERVER_VERSION"
+          else
+            tag="web/v$WEB_VERSION"
           fi
 
           # If THIS tag already exists (re-run of a workflow whose tag

--- a/packages/web/src/components/DataPixel.tsx
+++ b/packages/web/src/components/DataPixel.tsx
@@ -3,7 +3,9 @@ import { useViewport } from '@xyflow/react'
 import type { FlowStep, FlowData } from '../types'
 import { DataTooltip } from './DataTooltip'
 
-const CARROT_SPRITE = '/sprites/carrot_pixels.svg'
+// Use Vite's BASE_URL so the sprite resolves under the project base on
+// the Pages deploy (`/openhop/sprites/...`) and at the root in dev (`/`).
+const CARROT_SPRITE = `${import.meta.env.BASE_URL}sprites/carrot_pixels.svg`
 const DEFAULT_PIXEL_COLOR = '#ff8a4a' // VARIANT_ACCENT[0] — sprite's original orange.
 
 interface DataPixelProps {

--- a/packages/web/src/components/nodes/node-sprites.ts
+++ b/packages/web/src/components/nodes/node-sprites.ts
@@ -7,20 +7,27 @@ export interface BuildingProps {
   active?: boolean
 }
 
+// Vite's BASE_URL is `/` in dev and `/openhop/` on the GitHub Pages
+// deploy. Without it, root-absolute sprite paths 404 on Pages because
+// the page lives under /openhop/ but `/sprites/foo.svg` resolves to the
+// site root, not the project base. BASE_URL always ends with `/`, so
+// `${BASE}sprites/foo.svg` is the correct concatenation.
+const BASE = import.meta.env.BASE_URL
+
 // Sprite per node type. Types not in this map fall back to the service sprite
 // at render time (see FlowNode.tsx).
 export const NODE_TYPE_SPRITE: Record<string, string> = {
-  actor: '/sprites/user_node.svg',
-  endpoint: '/sprites/endpoint_node.svg',
-  auth: '/sprites/auth_node.svg',
-  database: '/sprites/database_node.svg',
-  external: '/sprites/external_node.svg',
-  cache: '/sprites/cache_node.svg',
-  queue: '/sprites/queue_node.svg',
-  service: '/sprites/service_node.svg',
-  docker: '/sprites/docker_node.svg',
-  k8s: '/sprites/k8s_node.svg',
-  scheduler: '/sprites/scheduler_node.svg',
+  actor: `${BASE}sprites/user_node.svg`,
+  endpoint: `${BASE}sprites/endpoint_node.svg`,
+  auth: `${BASE}sprites/auth_node.svg`,
+  database: `${BASE}sprites/database_node.svg`,
+  external: `${BASE}sprites/external_node.svg`,
+  cache: `${BASE}sprites/cache_node.svg`,
+  queue: `${BASE}sprites/queue_node.svg`,
+  service: `${BASE}sprites/service_node.svg`,
+  docker: `${BASE}sprites/docker_node.svg`,
+  k8s: `${BASE}sprites/k8s_node.svg`,
+  scheduler: `${BASE}sprites/scheduler_node.svg`,
 }
 
 export const SPRITE_SIZE = 108


### PR DESCRIPTION
## Summary
Sprite paths in \`node-sprites.ts\` and \`DataPixel.tsx\` were root-absolute (\`/sprites/foo.svg\`). At dev (\`localhost:8788/\`) they resolved fine, but on the Pages deploy under \`/openhop/\` they 404'd because the browser resolved them against the site root, not the project base.

Prepend \`import.meta.env.BASE_URL\` so the path concatenates to:
- \`/sprites/foo.svg\` in dev (BASE_URL = \`/\`)
- \`/openhop/sprites/foo.svg\` on Pages (BASE_URL = \`/openhop/\`)

Vite already auto-rewrites asset paths in HTML/CSS — this only affects TS string literals.

## Test plan
- [x] \`npm test\` (42/42)
- [x] \`VITE_BASE=/openhop/ npm run build\` — verified the bundle bakes \`hm = '/openhop/'\` and concatenates with \`\${hm}sprites/...\`
- [ ] After merge: confirm node sprites render on https://naorsabag.github.io/openhop/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sprite assets (carrot and node icons) now load correctly when the app is served from a non-root base path (e.g., Pages/GitHub Pages subfolders).

* **Chores**
  * Release workflow tag-selection logic updated to prioritize the server tag for combined releases, preserving CLI precedence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/106)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->