### PR TITLE
perf(web): lazy editor + vendor-split + meta description

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Animated data-flow diagrams your AI agent can write. One SKILL.md plugs OpenHop into Claude Code, Cursor, Codex, and 11+ other clients."
+    />
+    <meta name="theme-color" content="#0a1f0e" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap" rel="stylesheet" />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,9 +1,12 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
+import { lazy, Suspense, useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import YAML from 'yaml'
 import { Sidebar } from './components/Sidebar'
 import { FlowCanvas } from './components/FlowCanvas'
 import { DataInspectionPanel, BookmarkTab, type DockSide } from './components/DataInspectionPanel'
-import { FlowEditorModal } from './components/FlowEditorModal'
+// Lazy — see AppFragment.tsx for rationale (CodeMirror chunk weight).
+const FlowEditorModal = lazy(() =>
+  import('./components/FlowEditorModal').then((m) => ({ default: m.FlowEditorModal }))
+)
 import { buildStarterYaml } from './lib/starter-yaml'
 import { isMobileViewport } from './lib/mobile'
 import { useFlowList, useFlowData } from './hooks/useFlowPolling'
@@ -536,16 +539,22 @@ function App() {
         </div>
       </div>
 
-      {/* Editor modal — overlays everything when open */}
-      <FlowEditorModal
-        open={editor.mode !== 'closed'}
-        title={editor.mode === 'edit' ? 'Edit flow' : 'New flow'}
-        initialYaml={editor.mode === 'closed' ? '' : editor.initialYaml}
-        saving={mutations.inFlight}
-        serverError={mutations.error}
-        onSave={handleEditorSave}
-        onCancel={handleEditorCancel}
-      />
+      {/* Editor modal — overlays everything when open. Mount-on-open
+          so the lazy chunk only downloads when the user actually opens
+          the editor. */}
+      {editor.mode !== 'closed' && (
+        <Suspense fallback={null}>
+          <FlowEditorModal
+            open
+            title={editor.mode === 'edit' ? 'Edit flow' : 'New flow'}
+            initialYaml={editor.initialYaml}
+            saving={mutations.inFlight}
+            serverError={mutations.error}
+            onSave={handleEditorSave}
+            onCancel={handleEditorCancel}
+          />
+        </Suspense>
+      )}
     </div>
   )
 }

--- a/packages/web/src/AppFragment.tsx
+++ b/packages/web/src/AppFragment.tsx
@@ -1,9 +1,15 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import YAML from 'yaml'
 import { parseFlowYaml } from '@openhop/shared'
 import { FlowCanvas } from './components/FlowCanvas'
 import { DataInspectionPanel, BookmarkTab, type DockSide } from './components/DataInspectionPanel'
-import { FlowEditorModal } from './components/FlowEditorModal'
+// FlowEditorModal pulls in CodeMirror + the YAML language pack — together
+// the heaviest unused chunk on first paint. Defer the import until the
+// user actually opens the editor (+ New flow / Edit). React.lazy needs a
+// default export; the .then() unwraps the named export.
+const FlowEditorModal = lazy(() =>
+  import('./components/FlowEditorModal').then((m) => ({ default: m.FlowEditorModal }))
+)
 import { Sidebar } from './components/Sidebar'
 import { buildStarterYaml } from './lib/starter-yaml'
 import { buildShareUrl, decodeFragment, encodeFragment } from './lib/share-url'
@@ -498,16 +504,25 @@ export default function AppFragment() {
         </div>
       </div>
 
-      <FlowEditorModal
-        open={editor.mode !== 'closed'}
-        title={editor.mode === 'edit' ? 'Edit flow (copy share URL)' : 'New flow (copy share URL)'}
-        initialYaml={editor.mode === 'closed' ? '' : editor.initialYaml}
-        saving={copying}
-        serverError={null}
-        onSave={handleEditorSave}
-        onCancel={handleEditorCancel}
-        mode="fragment"
-      />
+      {/* Mount the modal only when actually open — keeps the lazy
+          chunk request on the click, not on first paint. Suspense is a
+          no-op fallback because the modal is opaque while loading. */}
+      {editor.mode !== 'closed' && (
+        <Suspense fallback={null}>
+          <FlowEditorModal
+            open
+            title={
+              editor.mode === 'edit' ? 'Edit flow (copy share URL)' : 'New flow (copy share URL)'
+            }
+            initialYaml={editor.initialYaml}
+            saving={copying}
+            serverError={null}
+            onSave={handleEditorSave}
+            onCancel={handleEditorCancel}
+            mode="fragment"
+          />
+        </Suspense>
+      )}
 
       {toast && (
         <div

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -34,6 +34,29 @@ export default defineConfig({
     // in the browser bundle, so we mark it external to keep rolldown happy.
     rollupOptions: {
       external: ['web-worker'],
+      output: {
+        // Split heavy vendor deps out of the entry bundle so the app
+        // shell hits the network as fewer bytes and the browser can
+        // parallelize downloads. The single-chunk build shipped
+        // ~2.5 MB on first paint; splitting drops the entry chunk and
+        // moves rarely-changing vendor code into separate
+        // cache-friendly chunks. CodeMirror is also lazy-loaded at
+        // the React layer (see App*.tsx), so its chunk only fetches
+        // when the editor opens.
+        //
+        // Function form because rolldown's `manualChunks` doesn't
+        // accept the object form the older rollup API used.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+          if (id.includes('/elkjs/') || id.includes('/@xyflow/')) return 'flow'
+          if (id.includes('/@codemirror/') || id.includes('/@uiw/react-codemirror/'))
+            return 'codemirror'
+          if (id.includes('/yaml/') || id.includes('/lz-string/')) return 'yaml'
+          if (id.includes('/react/') || id.includes('/react-dom/') || id.includes('/scheduler/'))
+            return 'react'
+          return undefined
+        },
+      },
     },
   },
 })


### PR DESCRIPTION
Lighthouse mobile scored 42/100 on https://naorsabag.github.io/openhop/ (full report below). Largest culprit: the build shipped a single 2.5 MB / 768 KB gz bundle on first paint, with ~2.4 s of unused JavaScript. Three changes here.

## 1. Lazy-load FlowEditorModal
\`CodeMirror\` + \`@codemirror/lang-yaml\` is the heaviest dependency that isn't on the critical path. \`React.lazy\` + mount-on-open means the chunk only fetches on the first "+ New flow" / Edit click.

## 2. Vite manualChunks
Function form (rolldown rejects the object form rollup used). New chunk layout:

| chunk | gz | when |
|---|---|---|
| \`index\` (entry) | 45 KB | always |
| \`react\` | 56 KB | always |
| \`flow\` (\`@xyflow/react\`, \`elkjs\`) | 493 KB | always |
| \`yaml\` (\`yaml\`, \`lz-string\`) | 32 KB | always |
| \`codemirror\` | 140 KB | **lazy** — only when editor opens |
| \`FlowEditorModal\` | 2 KB | **lazy** — only when editor opens |

Initial download drops from 768 KB → ~626 KB gz, and most of the saving is on the *executed* main-thread JS, where Lighthouse penalty is biggest.

## 3. \`<meta name="description">\` + \`<meta name="theme-color">\`
Fixes the SEO miss (\`Document does not have a meta description\`) and gives mobile the green address-bar tint that matches the canvas background.

## Lighthouse before
Mobile: Performance **42** · A11y 96 · BP 100 · SEO 91. FCP 5.5 s · LCP 6.5 s · TBT 980 ms · TTI 7.4 s.
Desktop: Performance **89** · A11y 93 · BP 100 · SEO 91. FCP 1.3 s · LCP 1.4 s.

## Test plan
- [x] \`npm test -w @openhop/web\` (42/42)
- [x] \`VITE_BASE=/openhop/ VITE_FRAGMENT_MODE=1 npm run build\` — chunks split as listed above
- [ ] After Pages redeploys: rerun Lighthouse, confirm Perf improves and SEO hits 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized asset loading for faster initial page load times
  * Enhanced code splitting to improve browser caching and overall performance

* **Documentation**
  * Updated site metadata for improved search engine discoverability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->