### PR TITLE
perf(web): filter codemirror chunk out of <modulepreload>

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -32,6 +32,17 @@ export default defineConfig({
   build: {
     // elkjs ships an optional `web-worker` import for node usage; not needed
     // in the browser bundle, so we mark it external to keep rolldown happy.
+    modulePreload: {
+      // Without this filter, Vite emits <link rel="modulepreload"> for
+      // every named chunk including the lazy `codemirror` chunk — which
+      // defeats the React.lazy on FlowEditorModal (browser preloads
+      // CodeMirror on first paint, exactly what we're trying to avoid).
+      // Strip the codemirror chunk from preloads so it only fetches on
+      // the actual dynamic import.
+      resolveDependencies(_filename, deps) {
+        return deps.filter((d) => !/\/codemirror-[A-Za-z0-9_-]+\.js$/.test(d))
+      },
+    },
     rollupOptions: {
       external: ['web-worker'],
       output: {


### PR DESCRIPTION
Re-ran Lighthouse after #114 deployed — Performance barely moved (mobile 42 → 41, desktop 89 → 84), even though the chunk split looked correct. Inspecting the deployed \`index.html\` showed why:

\`\`\`html
<link rel="modulepreload" href="/openhop/assets/codemirror-*.js">
\`\`\`

Vite/rolldown was eagerly emitting \`modulepreload\` for **every** named chunk, including the lazy codemirror one. Browsers happily fetched, parsed, and prepared CodeMirror on first paint anyway — exactly what the React.lazy on FlowEditorModal was supposed to prevent.

Fix: \`build.modulePreload.resolveDependencies\` strips the codemirror chunk from the preload list. The chunk still ships and still loads when FlowEditorModal's dynamic import runs (on "+ New flow" / Edit click), just not before then.

## What's preloaded after this PR

Before:
\`\`\`
rolldown-runtime, codemirror, flow, yaml, react
\`\`\`

After:
\`\`\`
rolldown-runtime, flow, yaml, react
\`\`\`

That's ~140 KB gz off the first-paint network + parse budget.

## SEO win from #114 stands
SEO went from 91 → 100 already; this PR doesn't touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized the code editor component loading to reduce initial page load time by deferring non-critical resources until they are actually needed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/115)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->