### PR TITLE
feat(cli): OpenSkills fallback when no Tier-1 client detected

### DIFF
--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -337,6 +337,14 @@ export function registerInit(program: Command): void {
       const detectedCount = results.filter(
         (r) => !(r.status === 'skipped' && r.reason === 'not detected')
       ).length
+
+      if (!opts.json && installed.length === 0 && wouldInstall.length === 0) {
+        process.stderr.write(
+          'No Tier-1 client received the skill. For Codex CLI / Gemini CLI / Junie / Copilot / OpenCode / Goose / Antigravity, run:\n' +
+            '  npx openskills install naorsabag/openhop\n'
+        )
+      }
+
       if (detectedCount === 0) process.exit(EXIT_NOT_FOUND)
       process.exit(EXIT_OK)
     })


### PR DESCRIPTION
## Summary
- `openhop init` now prints a stderr line pointing the user at `npx openskills install naorsabag/openhop` when no Tier-1 client received the skill.
- Closes the audit's S7 part-2 / checklist item 30 from `READINESS-AUDIT.md`.
- Suppressed under `--json` so machine consumers keep clean stdout; exit-code policy unchanged.

## Why
`init` covers Claude Code / Cursor / Windsurf / Cline / Continue. Everything else (Codex CLI, Gemini CLI, Junie, Copilot, OpenCode, Goose, Antigravity, …) routes through OpenSkills per the launch plan — but a user running `init` on a machine without any Tier-1 client got no signal that OpenSkills was the next step. Same trigger fires when only an advisory client like Continue.dev was detected (no real skill placement).

## Test plan
- [x] `npm test` in `packages/cli` — 83/83 pass (init suite is 20/20).
- [x] Smoke: `HOME=$(mktemp -d) node packages/cli/dist/index.js init` → fallback line on stderr, exit 4 (`EXIT_NOT_FOUND`).
- [x] Smoke: `HOME=$(mktemp -d) node packages/cli/dist/index.js init --json` → clean JSON on stdout, no stderr line.
- [ ] CI on this PR is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging in the `openhop init` command to provide clearer feedback when a skill is not installed to any client, including a suggested command for installation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->