### PR TITLE
perf(web): memo FlowNode + GPU-layer sprites

### DIFF
--- a/packages/web/src/components/nodes/FlowNode.tsx
+++ b/packages/web/src/components/nodes/FlowNode.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import type { FlowData } from '../../types'
@@ -44,7 +45,7 @@ export type FlowNodeData = {
 
 type FlowNodeType = Node<FlowNodeData, 'flowNode'>
 
-export function FlowNodeComponent({ data, id }: NodeProps<FlowNodeType>) {
+function FlowNodeComponentInner({ data, id }: NodeProps<FlowNodeType>) {
   const {
     label,
     nodeType,
@@ -314,3 +315,16 @@ export function FlowNodeComponent({ data, id }: NodeProps<FlowNodeType>) {
     </div>
   )
 }
+
+// React Flow doesn't memoize custom node components — every viewport
+// change (pan / zoom) emits a store update that re-renders every
+// node. With 60+ nodes (e.g. the type-variants showcase flow), that
+// reconciler churn dominates the frame budget. memo() short-circuits
+// on shallow-equal data so renders only happen when the node's actual
+// state changes (active, currentStep, isDynamic transitions, etc).
+//
+// Caveat: works because FlowCanvas's `nodes` useMemo holds data
+// references stable across viewport changes — its deps list excludes
+// the viewport. If we ever spread `node.data` from a non-memoized
+// source, this becomes a no-op.
+export const FlowNodeComponent = memo(FlowNodeComponentInner)

--- a/packages/web/src/components/nodes/NodeBuilding.tsx
+++ b/packages/web/src/components/nodes/NodeBuilding.tsx
@@ -20,7 +20,21 @@ export function SpriteBuilding({
 
   return (
     <div
-      style={{ position: 'relative', width: SPRITE_SIZE, height: SPRITE_SIZE, overflow: 'visible' }}
+      style={{
+        position: 'relative',
+        width: SPRITE_SIZE,
+        height: SPRITE_SIZE,
+        overflow: 'visible',
+        // Promote the sprite to its own compositor layer so the
+        // rasterized image is cached. Without this, every zoom level
+        // change re-rasterizes the (large) SVG source through the CPU
+        // for each visible node — on flows with many nodes the cost
+        // compounds and pan/zoom drops frames. translate3d forces the
+        // layer on engines that need both hints; will-change tells
+        // Chrome we're about to transform so it pre-promotes.
+        willChange: 'transform',
+        transform: 'translate3d(0, 0, 0)',
+      }}
     >
       <img
         src={src}


### PR DESCRIPTION
The 61-node \`type-variants\` showcase flow felt sluggish on pan/zoom. Two root causes, both fixed here.

## 1. \`FlowNodeComponent\` was not memoized
React Flow doesn't auto-memo custom node components, so every viewport store-update from pan/zoom re-renders **every visible node**. With 60+ nodes the reconciler churn dominates the frame budget.

\`memo()\` short-circuits on shallow-equal \`data\`. FlowCanvas's \`nodes\` useMemo already keeps \`data\` references stable across viewport changes (its deps list excludes viewport state), so this lands correctly.

## 2. SVG sprites re-rasterize per zoom level
\`image-rendering: pixelated\` keeps it nearest-neighbor **after** rasterization, but with a vector source the browser still walks the SVG at each new output size. The largest sprites are heavy in source form (k8s 368 KB, scheduler 339 KB, docker 313 KB).

Adds \`will-change: transform; transform: translate3d(0, 0, 0)\` to the sprite wrapper. The rasterized image is promoted to its own compositor layer and cached; subsequent zoom transforms become pure compositor work — no CPU re-raster per frame.

## Downsides (you asked)

**memo:**
- Adds a shallow-compare on each render (microseconds; not measurable).
- Won't help during *playback*, where most node props change every step. This is purely a pan/zoom optimization, which is the use case you reported.
- Zero correctness risk — the component is pure.

**GPU layer per sprite:**
- VRAM cost: 60 layers × 108×108 RGBA ≈ 2.8 MB. Negligible on any modern device.
- Higher first-paint cost (each layer needs creation); imperceptible on the scales we have.
- Chrome's soft cap for compositor layers is ~125 layers/document. We're at ~60, well under.
- Pixel-art with \`image-rendering: pixelated\` is unaffected by the compositor's subpixel handling — pixel-perfect stays pixel-perfect.

## Test plan
- [x] \`npm test\` (42/42)
- [x] \`npm run typecheck\`
- [ ] After deploy: open the type-variants flow, pan/zoom — should feel smooth at 60 fps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized flow node component rendering to reduce unnecessary re-renders during pan and zoom interactions.
  * Enhanced sprite rendering performance through CSS optimization for smoother visual updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/117)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->