### PR TITLE
chore: 0.1.0 release — drop beta channel + auto-promote latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,12 @@ name: publish
 
 # Publishes @openhop/server, @openhop/web, and the openhop CLI to npm whenever
 # the version in any of their package.json files on master differs from what's
-# already on the registry under the `beta` tag. Lets us ship a release just by
-# merging a "chore: bump" PR — no manual `npm publish` step in someone's
-# terminal.
+# already on the registry. Lets us ship a release just by merging a
+# "chore: bump" PR — no manual `npm publish` step in someone's terminal.
+#
+# `npm publish` (no --tag) sets the `latest` dist-tag, so the npmjs.com
+# page + `npm install <pkg>` (no @beta suffix) get the new version on every
+# successful publish — no separate dist-tag promote step needed.
 #
 # Order matters: server + web ship before the CLI because the CLI's
 # package.json depends on both. If only one bumped, only that one runs (the
@@ -86,7 +89,7 @@ jobs:
         id: publish_server
         if: steps.server_status.outputs.publish == 'true'
         working-directory: packages/server
-        run: npm publish --tag beta --access public
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -94,7 +97,7 @@ jobs:
         id: publish_web
         if: steps.web_status.outputs.publish == 'true'
         working-directory: packages/web
-        run: npm publish --tag beta --access public
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -102,7 +105,7 @@ jobs:
         id: publish_cli
         if: steps.cli_status.outputs.publish == 'true'
         working-directory: packages/cli
-        run: npm publish --tag beta --access public
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -111,7 +114,7 @@ jobs:
       # collide with a stale tag from a prior multi-package run:
       #   cli shipped         → v$CLI_VERSION         (CLI is the user-facing
       #                                                 handle for `npx
-      #                                                 openhop@beta`, so its
+      #                                                 openhop`, so its
       #                                                 version anchors the
       #                                                 combined release)
       #   server (± web)      → server/v$SERVER_VERSION (server is the lowest
@@ -158,7 +161,7 @@ jobs:
           fi
 
           {
-            echo "## Published to npm (\`beta\` tag)"
+            echo "## Published to npm"
             if [ "$SERVER_PUBLISHED" = "true" ]; then
               echo "- [\`@openhop/server@$SERVER_VERSION\`](https://www.npmjs.com/package/@openhop/server/v/$SERVER_VERSION)"
             fi
@@ -171,7 +174,7 @@ jobs:
             echo
             echo "## Try it"
             echo '```sh'
-            echo "npx openhop@beta demo"
+            echo "npx openhop demo"
             echo '```'
             echo
             echo "Auto-generated notes (commit history) below."

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.1.0-beta.6",
+  "version": "0.1.0",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -42,8 +42,8 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.1.0-beta.2",
-    "@openhop/web": "0.1.0-beta.4",
+    "@openhop/server": "0.1.0",
+    "@openhop/web": "0.1.0",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ if (process.argv.includes('--api-version')) {
 
 const program = new Command()
 
-program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0-beta.6')
+program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0')
 
 // --- serve ---
 //

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two changes in one PR.

## 1. 0.1.0 (drop the beta suffix)
- \`@openhop/server\`: \`0.1.0-beta.2\` → \`0.1.0\`
- \`@openhop/web\`:    \`0.1.0-beta.4\` → \`0.1.0\`
- \`openhop\` CLI:     \`0.1.0-beta.6\` → \`0.1.0\`
  - plus pinned \`@openhop/web\` / \`@openhop/server\` deps + the hardcoded \`--version\` in \`packages/cli/src/index.ts\`.

Bundles 13 PRs of work since \`v0.1.0-beta.6\` (web heavy: #106–#117; CLI: #116, #118; server: untouched but bumped to keep the set consistent).

## 2. `publish.yml` targets \`latest\` automatically
Dropped \`--tag beta\` from all three publish steps. \`npm publish\` with no \`--tag\` writes the \`latest\` dist-tag, so:
- npmjs.com pages render the new README/version immediately after publish.
- \`npm install openhop\` (no \`@beta\`) gets the new version.
- No more manual \`npm dist-tag add … latest\` after each release.

## After merge
1. The publish workflow runs on the merge commit.
2. Ships \`@openhop/server@0.1.0\`, \`@openhop/web@0.1.0\`, \`openhop@0.1.0\` to npm.
3. Creates a \`v0.1.0\` GitHub Release with auto-generated changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI, Web, and Server packages to 0.1.0 (moved from beta versions).
  * Updated package dependency versions accordingly.
  * Publishing workflow changed to release to the default (latest) npm tag; "try it" command updated to `npx openhop demo`.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/119)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->