### PR TITLE
docs(readme): rewrite hero per launch-plan V1 audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 </p>
 
 <p align="center">
-  Animated diagrams your AI agent can write.
+  <b>Your AI walks you through your code, one step at a time.</b><br/>
+  Animated, multi-level data flows — described in YAML, drawn by your coding agent.
 </p>
 
 <p align="center">
@@ -30,7 +31,7 @@
 </p>
 
 <p align="center">
-  <a href="#try-it-in-60-seconds">Quickstart</a> ·
+  <a href="#try-it-in-30-seconds">Quickstart</a> ·
   <a href="#install-options">Install</a> ·
   <a href="#use-cases">Use cases</a> ·
   <a href="#how-it-works">How it works</a> ·
@@ -49,22 +50,32 @@ You ask in plain English; your agent writes the flow as YAML and pushes it; Open
 pixels traveling between components on a pixel-art canvas. Click any node to drill into its
 sub-flow.
 
-## Try it in 60 seconds
+## Try it in 30 seconds
+
+```bash
+npx openhop demo
+```
+
+That's it. The command:
+
+1. Spawns the API + web UI locally (no install state, no signup)
+2. Pushes a canonical OAuth flow
+3. Opens your browser at the live animation
+
+Liked what you saw? Install the skill so your own agent can author flows from your codebase:
 
 ```bash
 npx openhop init
 ```
 
-**That's it!**
-
-Now restart your agent so it picks up the new skill, and ask:
+Then restart your agent and ask:
 
 > "Walk me through the main flow of this codebase."
 
 The agent generates the YAML, pushes it, and returns a URL with the animation playing.
 
 > [!NOTE]
-> `npx openhop init` auto-detects Claude Code, Cursor, Windsurf, Cline, and Continue. For other clients, see [Install](#install).
+> `npx openhop init` auto-detects Claude Code, Cursor, Windsurf, Cline, and Continue. For other clients, see [Install](#install-options).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -53,22 +53,12 @@ sub-flow.
 ## Try it in 30 seconds
 
 ```bash
-npx openhop demo
-```
-
-That's it. The command:
-
-1. Spawns the API + web UI locally (no install state, no signup)
-2. Pushes a canonical OAuth flow
-3. Opens your browser at the live animation
-
-Liked what you saw? Install the skill so your own agent can author flows from your codebase:
-
-```bash
 npx openhop init
 ```
 
-Then restart your agent and ask:
+**That's it!**
+
+Now restart your agent so it picks up the new skill, and ask:
 
 > "Walk me through the main flow of this codebase."
 


### PR DESCRIPTION
## Summary

Closes two of the three V1 "fresh-eyes audit" findings from [`openhop-launch/03-readme-and-landing.md`](../tree/master/../openhop-launch/03-readme-and-landing.md):

- **Passive tagline → active voice.** *"Animated diagrams your AI agent can write"* assumed the reader already knew what an "agent" did. Replaced with the doc's skeleton tagline *"Your AI walks you through your code, one step at a time"* + a one-line descriptor.
- **Broken `#install` anchor in the NOTE block** repointed to `#install-options` so the in-page link actually scrolls.

Also renamed `## Try it in 60 seconds` → `## Try it in 30 seconds` and updated the matching nav anchor.

## Not in this PR (reverted after author review)

- **Hero command swap (`init` → `demo`).** Initially included per the doc's "don't lead with install instructions" Do, but reverted on author preference — install-first is intentional here.

## Deferred (separate follow-up PRs)

- **Quantified claim block** (`~Nx fewer tokens`) — needs a measured ratio + `docs/token-comparison.md` worked example.
- **`#262626` custom badges** — V3 dark-mode finding.
- **Self-referential OpenHop-of-OpenHop diagram** — V1 dogfood opportunity that replaces the mermaid `How it works` block.

## Test plan

- [ ] All in-page anchors resolve — verified statically.
- [ ] CI green on the new branch.
- [ ] Manual read-through on github.com renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
