### PR TITLE
docs(readme): add vs-callout staking the category (V2 audit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 </p>
 
 <p align="center">
+  <sub><i>Mermaid for diagrams · Excalidraw for whiteboards · <b>OpenHop for animated agent-authored flows.</b></i></sub>
+</p>
+
+<p align="center">
   <b>Local-first. Your code never leaves your machine. No telemetry.</b>
 </p>
 


### PR DESCRIPTION
## Summary

Closes V2 "competitor comparison" finding from [`openhop-launch/03-readme-and-landing.md`](../tree/master/../openhop-launch/03-readme-and-landing.md):

- **One-line "vs" callout under the tagline** — grants Mermaid and Excalidraw their dignity while staking the OpenHop category. Doc Do: *"vs only if flattering to everyone."*
- Rendered as small italic (`<sub><i>…</i></sub>`) so it doesn't compete visually with the bolded tagline above it.

> *Mermaid for diagrams · Excalidraw for whiteboards · **OpenHop for animated agent-authored flows.***

V1 already replaced the passive tagline (PR #125), which addressed most of V2's marginal-pass concern. This callout pushes V2 from "OpenHop wins most exciting only because of the GIF" to "OpenHop wins most exciting because the text claims a clear category."

## Base branch note

Targeting `docs/readme-v1-hero-fixes` (PR #125) since V2 builds on V1's tagline change. When #125 merges, this PR auto-retargets to master.

## Test plan

- [ ] Visual check on github.com: callout renders smaller than the tagline, doesn't break the hero rhythm.
- [ ] Dark-mode legibility for the smaller italic text.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)