### PR TITLE
docs(readme): recolor platform badges for dark-mode legibility (V3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.anthropic.com/en/docs/claude-code/skills"><img src="https://img.shields.io/badge/Claude%20Code-✓-262626?style=flat-square" alt="Claude Code" /></a>
-  <a href="https://cursor.com/docs/skills"><img src="https://img.shields.io/badge/Cursor-✓-262626?style=flat-square" alt="Cursor" /></a>
-  <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Codex-✓-262626?style=flat-square" alt="OpenAI Codex" /></a>
+  <a href="https://docs.anthropic.com/en/docs/claude-code/skills"><img src="https://img.shields.io/badge/Claude%20Code-✓-D97757?style=flat-square" alt="Claude Code" /></a>
+  <a href="https://cursor.com/docs/skills"><img src="https://img.shields.io/badge/Cursor-✓-3B82F6?style=flat-square" alt="Cursor" /></a>
+  <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Codex-✓-10A37F?style=flat-square" alt="OpenAI Codex" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Closes the badge portion of V3 "dark-mode legibility" finding from [`openhop-launch/03-readme-and-landing.md`](../tree/master/../openhop-launch/03-readme-and-landing.md).

The three custom platform badges (Claude Code, Cursor, Codex) used color `#262626`, which sits at ~1.5:1 contrast against GitHub's dark-mode background `#0d1117` — the badge "disappears" visually even though its white ✓ tick stays legible. Standard shields.io CI / MIT / npm / stars badges auto-theme, so only these three needed fixing.

Picked brand-evocative colors that hit ≥ 3:1 contrast on both modes:

| Badge | Old | New | Reason |
|---|---|---|---|
| Claude Code | `#262626` | `#D97757` | Anthropic terracotta |
| Cursor | `#262626` | `#3B82F6` | Clean blue, evokes "AI editor" |
| Codex | `#262626` | `#10A37F` | OpenAI green |

All three new shields.io URLs verified to return 200.

## Still open under V3 (not in this PR)

- **Logo + GIF dark-mode visual check.** `assets/logo.png` and `assets/order-flow.gif` need a manual screenshot of the rendered README in GitHub's dark theme. Risk: white background bleed flashing against dark mode. If broken, the fix is GitHub's `<picture>` element with `prefers-color-scheme: dark` (Excalidraw does this).

## Base branch note

Targeting `docs/readme-v2-vs-callout` (PR #126) since this stacks on top. When #126 → #125 → master cascade merges, this PR auto-retargets.

## Test plan

- [ ] Toggle GitHub Settings → Appearance → "Dark default", reload the rendered README, confirm the 3 platform badges now have visible weight against the dark background.
- [ ] Light-mode check: the new colors don't look garish on `#ffffff`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)