### PR TITLE
docs(readme): add Claude Code CTA above the fold (V5 d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@
 </p>
 
 <p align="center">
+  <a href="#install-options"><b>→ Add to Claude Code in one command</b></a>
+</p>
+
+<p align="center">
   <a href="#try-it-in-30-seconds">Quickstart</a> ·
   <a href="#install-options">Install</a> ·
   <a href="#use-cases">Use cases</a> ·


### PR DESCRIPTION
## Summary

Closes V5 killer-line **(d)** "Claude Code skill section above the fold" from [`openhop-launch/03-readme-and-landing.md`](../tree/master/../openhop-launch/03-readme-and-landing.md).

V5 audit flagged that the Claude Code Install instructions sit ~3 viewports down on a 15" laptop. The Claude Code platform badge is above the fold, but a passive badge isn't a "section." Adds a one-line CTA between the hero GIF and the nav, anchored to `#install-options`:

```html
<p align="center">
  <a href="#install-options"><b>→ Add to Claude Code in one command</b></a>
</p>
```

So a Claude Code user can jump from "saw the GIF, want it" → install instructions in one click without scrolling.

## Not in this PR — V5 (c) is structurally blocked

V5 (c) "Try it live link before any CLI command" can't be cleanly satisfied with the current hero shape:

- The hero command is `npx openhop init` (per the V1 revert — install-first is intentional)
- There's no hosted playground at v0.1 (see [`02-hosted-playground.md`](../tree/master/../openhop-launch/02-hosted-playground.md))
- A "Try it live" link with nothing to point at would be worse than no link

Will close on its own once `02-hosted-playground.md` ships.

## Base branch note

Targets `docs/readme-v3-badge-colors` (PR #127) → stacks under V2 (#126) → V1 (#125) → master. Cascade auto-retargets on each merge.

## Test plan

- [ ] Verify the CTA scrolls to the Install section on click.
- [ ] On a 15" laptop, the CTA is visible above the fold (it's between the GIF and the nav, so it sits ~80% down the hero — adds zero scroll).
- [ ] Doesn't break the hero rhythm: tagline → vs-callout → privacy → standard badges → platform badges → GIF → CTA → nav.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)