### PR TITLE
fix(web): don't pin actor to FIRST when another actor feeds it

### DIFF
--- a/packages/web/src/lib/flow-layout.ts
+++ b/packages/web/src/lib/flow-layout.ts
@@ -866,7 +866,13 @@ function buildElkGraph(topology: FlowTopology, portAssignments?: Map<string, Edg
   // not another actor.
   const incomingFromActor = new Set<string>()
   for (const e of topology.displayEdges) {
-    if (topology.nodeSnapshots.get(e.source)?.nodeType === 'actor') {
+    // Self-loop (source === target) doesn't introduce a second
+    // FIRST-pinned node, so it can't trigger the ELK error this guard
+    // protects against — exclude it.
+    if (
+      e.source !== e.target &&
+      topology.nodeSnapshots.get(e.source)?.nodeType === 'actor'
+    ) {
       incomingFromActor.add(e.target)
     }
   }

--- a/packages/web/src/lib/flow-layout.ts
+++ b/packages/web/src/lib/flow-layout.ts
@@ -869,10 +869,7 @@ function buildElkGraph(topology: FlowTopology, portAssignments?: Map<string, Edg
     // Self-loop (source === target) doesn't introduce a second
     // FIRST-pinned node, so it can't trigger the ELK error this guard
     // protects against — exclude it.
-    if (
-      e.source !== e.target &&
-      topology.nodeSnapshots.get(e.source)?.nodeType === 'actor'
-    ) {
+    if (e.source !== e.target && topology.nodeSnapshots.get(e.source)?.nodeType === 'actor') {
       incomingFromActor.add(e.target)
     }
   }

--- a/packages/web/src/lib/flow-layout.ts
+++ b/packages/web/src/lib/flow-layout.ts
@@ -856,6 +856,21 @@ export function computeFallbackPositions(topology: FlowTopology): Map<string, Po
 }
 
 function buildElkGraph(topology: FlowTopology, portAssignments?: Map<string, EdgePortAssignment>) {
+  // Pre-compute which nodes have an incoming edge from ANOTHER actor.
+  // Those can't be pinned to ELK's FIRST layer — ELK throws
+  // UnsupportedConfigurationException if a FIRST node receives an
+  // intra-layer edge from another FIRST node. Skipping the pin only
+  // when the source is also an actor keeps the common case ("user is
+  // both first sender and final receiver of a response") working —
+  // because the response edge's source is typically a service/endpoint,
+  // not another actor.
+  const incomingFromActor = new Set<string>()
+  for (const e of topology.displayEdges) {
+    if (topology.nodeSnapshots.get(e.source)?.nodeType === 'actor') {
+      incomingFromActor.add(e.target)
+    }
+  }
+
   return {
     id: 'openhop-flow',
     layoutOptions: {
@@ -888,13 +903,16 @@ function buildElkGraph(topology: FlowTopology, portAssignments?: Map<string, Edg
       }))
 
       // Actors represent the human/external initiator — pin them to the
-      // leftmost layer so the flow always reads "user → system → ..." even
-      // when the actor also has incoming edges (e.g. a final response
-      // step).
+      // leftmost layer so the flow always reads "user → system → ..."
+      // (including when the actor is also the final response target).
+      // Skip the pin only for actors fed by another actor (see
+      // incomingFromActor above) — ELK rejects intra-layer FIRST→FIRST
+      // edges.
       const isActor = topology.nodeSnapshots.get(id)?.nodeType === 'actor'
+      const pinFirst = isActor && !incomingFromActor.has(id)
       const nodeLayoutOptions: Record<string, string> = {}
       if (portAssignments) nodeLayoutOptions.portConstraints = 'FIXED_SIDE'
-      if (isActor) nodeLayoutOptions['elk.layered.layering.layerConstraint'] = 'FIRST'
+      if (pinFirst) nodeLayoutOptions['elk.layered.layering.layerConstraint'] = 'FIRST'
 
       return {
         id,


### PR DESCRIPTION
You spotted this — flow \`NdFjXxlxv717\` (claude-sandbox step 5) had all nodes crushed together because **ELK was crashing** and the renderer fell back to \`computeFallbackPositions\` (tighter \`FALLBACK_COLUMN_GAP=220\` vs ELK's \`200+80\`).

## Root cause

ELK threw:

\`\`\`
org.eclipse.elk.core.UnsupportedConfigurationException: Node
'openhop-flow.user' has its layer constraint set to FIRST, but has
at least one incoming edge that does not come from a FIRST_SEPARATE
node.
\`\`\`

The actor-pin from #99 was unconditional. The sandbox flow has **two \`type: actor\` nodes** (\`user\` and \`agent-cfg\`) with \`user → agent-cfg\` between them. Both got pinned to layer 0; ELK refuses intra-layer FIRST→FIRST edges → crash → silent fallback to the tight grid layout.

## Fix

Tighten the pin predicate: skip \`layerConstraint=FIRST\` only when the actor is fed by **another actor**. The common case where an actor is the final response target (e.g. \`user ← api\` in orion-main) still pins correctly because the response edge's source is an endpoint/service, not an actor.

## Verified

- \`examples/order-flow\` (1 actor, response loop) — \`user\` still leftmost
- \`claude-sandbox\` flow \`NdFjXxlxv717\` (2 actors connected) — ELK no longer crashes, gaps back to 200/80 px
- \`v0.1.0\` flow \`eIxRYAM39kwT\` (orion-main) — \`user\` still leftmost at x=40

## Test plan
- [x] \`npm test -w @openhop/web\` (42/42)
- [ ] Refresh the sandbox flow on Pages — spacing should look like the other flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated landing page with enhanced feature descriptions and platform support details
  * Improved AI client skill badge styling with colored indicators
  * Revised quickstart timeline to 30 seconds
  * Updated installation link references

* **Improvements**
  * Optimized flow visualization layout algorithm for better node positioning

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/129)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->