### PR TITLE
fix(web): raise edit modal zIndex above carrots (100 -> 2000)

### DIFF
--- a/packages/web/src/components/FlowEditorModal.tsx
+++ b/packages/web/src/components/FlowEditorModal.tsx
@@ -166,7 +166,7 @@ export function FlowEditorModal({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        zIndex: 100,
+        zIndex: 2000,
       }}
     >
       <div


### PR DESCRIPTION
## Summary

`FlowEditorModal` sat at `zIndex: 100`, while:

- Carrots (`DataPixel`) render at `zIndex: 1000`
- The inspect panel + sidebar dropdown sit at `zIndex: 1001`

So a carrot mid-flight could paint **on top of** the edit modal, and the inspect panel could occlude it. Bumping to `2000` puts the modal unambiguously above both layers while leaving headroom for future overlays.

## Test plan
- [ ] Open the flow editor while carrots are animating — no carrot paints over the modal.
- [ ] Open the flow editor with the inspect panel open — modal sits above the panel.
- [ ] Backdrop click + escape still dismiss correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Flow Editor Modal visibility by adjusting its layering to prevent other page content from appearing on top of the modal when it's open. This ensures clearer interaction with the editor.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/131)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->