### PR TITLE
feat(web/sidebar): resizable width, hover tooltips, single-slash root

### DIFF
--- a/packages/web/src/components/DataInspectionPanel.tsx
+++ b/packages/web/src/components/DataInspectionPanel.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import type { FlowStep, FlowData } from '../types'
+import { ResizeHandle } from './ResizeHandle'
 
 export type DockSide = 'right' | 'bottom'
 
@@ -32,37 +33,6 @@ export function DataInspectionPanel({
   onSizeChange,
   onClose,
 }: DataInspectionPanelProps) {
-  const dragState = useRef<{ startPos: number; startSize: number } | null>(null)
-
-  const onPointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      e.preventDefault()
-      dragState.current = {
-        startPos: side === 'right' ? e.clientX : e.clientY,
-        startSize: size,
-      }
-      ;(e.target as Element).setPointerCapture(e.pointerId)
-    },
-    [side, size]
-  )
-
-  const onPointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      if (!dragState.current) return
-      const pos = side === 'right' ? e.clientX : e.clientY
-      const delta = pos - dragState.current.startPos
-      const next =
-        side === 'right' ? dragState.current.startSize - delta : dragState.current.startSize - delta
-      onSizeChange(Math.min(MAX_SIZE, Math.max(MIN_SIZE, next)))
-    },
-    [side, onSizeChange]
-  )
-
-  const onPointerUp = useCallback((e: React.PointerEvent) => {
-    dragState.current = null
-    ;(e.target as Element).releasePointerCapture(e.pointerId)
-  }, [])
-
   const containerStyle: React.CSSProperties = {
     display: 'flex',
     flexDirection: side === 'right' ? 'row' : 'column',
@@ -79,26 +49,19 @@ export function DataInspectionPanel({
     zIndex: 1001,
   }
 
-  const handleStyle: React.CSSProperties = {
-    cursor: side === 'right' ? 'ew-resize' : 'ns-resize',
-    background: 'transparent',
-    flexShrink: 0,
-    ...(side === 'right' ? { width: 6 } : { height: 6 }),
-  }
-
   return (
     <aside
       data-testid="data-inspection-panel"
       aria-label="Data inspection panel"
       style={containerStyle}
     >
-      <div
-        role="separator"
-        aria-orientation={side === 'right' ? 'vertical' : 'horizontal'}
-        style={handleStyle}
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
+      <ResizeHandle
+        orientation={side === 'right' ? 'vertical' : 'horizontal'}
+        size={size}
+        min={MIN_SIZE}
+        max={MAX_SIZE}
+        onSizeChange={onSizeChange}
+        direction="inverse"
       />
       <div style={{ flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
         <Header side={side} onSideChange={onSideChange} onClose={onClose} />

--- a/packages/web/src/components/ResizeHandle.tsx
+++ b/packages/web/src/components/ResizeHandle.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useRef } from 'react'
+
+export type ResizeOrientation = 'vertical' | 'horizontal'
+/** Which direction increases `size` while dragging.
+ *  - 'forward': pointer moves in the +axis direction (right / down) -> size grows.
+ *  - 'inverse': pointer moves in the -axis direction (left / up)    -> size grows.
+ *  Used because some handles sit on the leading edge (drag inward shrinks) and
+ *  some on the trailing edge (drag outward grows). */
+export type ResizeDirection = 'forward' | 'inverse'
+
+interface ResizeHandleProps {
+  orientation: ResizeOrientation
+  size: number
+  min: number
+  max: number
+  onSizeChange: (size: number) => void
+  direction?: ResizeDirection
+  className?: string
+  style?: React.CSSProperties
+  ariaLabel?: string
+  testId?: string
+}
+
+export function ResizeHandle({
+  orientation,
+  size,
+  min,
+  max,
+  onSizeChange,
+  direction = 'forward',
+  className,
+  style,
+  ariaLabel,
+  testId,
+}: ResizeHandleProps) {
+  const dragState = useRef<{ startPos: number; startSize: number } | null>(null)
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault()
+      dragState.current = {
+        startPos: orientation === 'vertical' ? e.clientX : e.clientY,
+        startSize: size,
+      }
+      ;(e.target as Element).setPointerCapture(e.pointerId)
+    },
+    [orientation, size]
+  )
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragState.current) return
+      const pos = orientation === 'vertical' ? e.clientX : e.clientY
+      const delta = pos - dragState.current.startPos
+      const next =
+        direction === 'forward'
+          ? dragState.current.startSize + delta
+          : dragState.current.startSize - delta
+      onSizeChange(Math.min(max, Math.max(min, next)))
+    },
+    [orientation, direction, min, max, onSizeChange]
+  )
+
+  const onPointerUp = useCallback((e: React.PointerEvent) => {
+    dragState.current = null
+    ;(e.target as Element).releasePointerCapture(e.pointerId)
+  }, [])
+
+  const baseStyle: React.CSSProperties = {
+    cursor: orientation === 'vertical' ? 'ew-resize' : 'ns-resize',
+    background: 'transparent',
+    flexShrink: 0,
+    ...(orientation === 'vertical' ? { width: 6 } : { height: 6 }),
+    ...style,
+  }
+
+  return (
+    <div
+      role="separator"
+      aria-orientation={orientation}
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className={className}
+      style={baseStyle}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    />
+  )
+}

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -1,5 +1,20 @@
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react'
 import type { FlowListItem } from '../hooks/useFlowPolling'
+import { ResizeHandle } from './ResizeHandle'
+
+const SIDEBAR_WIDTH_KEY = 'openhop:sidebar:width'
+const SIDEBAR_MIN_WIDTH = 180
+const SIDEBAR_MAX_WIDTH = 480
+const SIDEBAR_DEFAULT_WIDTH = 260
+
+function loadSidebarWidth(): number {
+  if (typeof window === 'undefined') return SIDEBAR_DEFAULT_WIDTH
+  const raw = window.localStorage.getItem(SIDEBAR_WIDTH_KEY)
+  if (!raw) return SIDEBAR_DEFAULT_WIDTH
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) return SIDEBAR_DEFAULT_WIDTH
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, parsed))
+}
 
 interface TreeNode {
   name: string
@@ -220,7 +235,8 @@ function TreeItem({
               >
                 {'/'}
               </span>
-              <span className="truncate text-text/90">{headerLabel}</span>
+              {/* Root label intentionally empty: icon-slot slash already identifies the row. */}
+              <span className="truncate text-text/90" title="/" />
             </div>
           ) : (
             <button
@@ -231,7 +247,9 @@ function TreeItem({
               <span className="shrink-0 text-xs" style={{ width: 16, textAlign: 'center' }}>
                 {expanded ? '\u25BE' : '\u25B8'}
               </span>
-              <span className="truncate">{headerLabel}</span>
+              <span className="truncate" title={node.name}>
+                {headerLabel}
+              </span>
             </button>
           )}
           <div
@@ -341,7 +359,9 @@ function TreeItem({
         <span className="shrink-0 text-xs" style={{ width: 16, textAlign: 'center', opacity: 0.5 }}>
           {'\u25C7'}
         </span>
-        <span className="truncate">{node.name}</span>
+        <span className="truncate" title={node.name}>
+          {node.name}
+        </span>
       </button>
       {flowId && (onEditFlow || onDeleteFlow) && (
         <div
@@ -428,6 +448,16 @@ export function Sidebar({
   )
   const [search, setSearch] = useState('')
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set())
+  const [width, setWidth] = useState<number>(loadSidebarWidth)
+
+  const handleResize = useCallback((next: number) => {
+    setWidth(next)
+    try {
+      window.localStorage.setItem(SIDEBAR_WIDTH_KEY, String(Math.round(next)))
+    } catch {
+      // localStorage may be unavailable (private mode, quota); width still applies for this session.
+    }
+  }, [])
 
   const tree = useMemo(() => buildTree(flows), [flows])
 
@@ -480,7 +510,7 @@ export function Sidebar({
     <aside
       className="shrink-0 flex flex-col overflow-hidden"
       style={{
-        width: 260,
+        width,
         background: '#141428',
         borderRight: '2px solid #2a2a4a',
         position: 'relative',
@@ -529,6 +559,23 @@ export function Sidebar({
           </ul>
         )}
       </div>
+      <ResizeHandle
+        orientation="vertical"
+        size={width}
+        min={SIDEBAR_MIN_WIDTH}
+        max={SIDEBAR_MAX_WIDTH}
+        onSizeChange={handleResize}
+        direction="forward"
+        ariaLabel="Resize sidebar"
+        testId="sidebar-resize-handle"
+        style={{
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          height: '100%',
+        }}
+      />
     </aside>
   )
 }


### PR DESCRIPTION
## Summary

Three independent UX fixes on the left flow-tree sidebar:

1. **Resizable width.** Drag handle on the sidebar's right edge sets the pane width (180-480px clamp, persisted under `openhop:sidebar:width`). Pattern mirrored from `DataInspectionPanel`'s `ResizeHandle`.
2. **Hover tooltips on truncated labels.** Adds native `title=` attributes to the three label spans in the tree (root row, folder row, flow leaf row) — when the label is `truncate`-clipped, hover reveals the full text.
3. **Single-slash root row.** Previously rendered `/` in the icon slot AND `/` again as the label, producing a visible `/ /`. Empty the label slot for the synthetic root row; icon-slot slash is sufficient.

## Test plan
- [ ] Drag the right edge — sidebar resizes smoothly between 180 and 480 px.
- [ ] Reload the page — chosen width persists.
- [ ] Hover a long flow name truncated by `truncate` — tooltip shows full name.
- [ ] Root folder row shows a single `/`, not `/ /`.
- [ ] `cd packages/web && npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)