### PR TITLE
fix(web): INSPECT toggle follows panel's dock edge (right or bottom)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -420,7 +420,7 @@ function App() {
             />
             {selectedFlowId && (
               <BookmarkTab
-                edge="right"
+                edge={inspectorSide === 'right' ? 'right' : 'bottom'}
                 open={inspectorOpen}
                 onToggle={() => setInspectorOpen((o) => !o)}
                 label="INSPECT"

--- a/packages/web/src/AppFragment.tsx
+++ b/packages/web/src/AppFragment.tsx
@@ -408,7 +408,7 @@ export default function AppFragment() {
             />
             {decodedFlow && (
               <BookmarkTab
-                edge="right"
+                edge={inspectorSide === 'right' ? 'right' : 'bottom'}
                 open={inspectorOpen}
                 onToggle={() => setInspectorOpen((o) => !o)}
                 label="INSPECT"

--- a/packages/web/src/components/DataInspectionPanel.tsx
+++ b/packages/web/src/components/DataInspectionPanel.tsx
@@ -385,23 +385,28 @@ interface BookmarkTabProps {
   open: boolean
   onToggle: () => void
   /** Which canvas edge the tab anchors to. */
-  edge: 'left' | 'right'
-  /** Vertical text shown on the tab (rotated 90deg). Keep ≤ 8 chars. */
+  edge: 'left' | 'right' | 'bottom'
+  /** Label shown on the tab. Vertical (rotated) for left/right; horizontal for bottom. Keep ≤ 8 chars. */
   label: string
   ariaLabel: string
 }
 
 /**
- * Bookmark-style toggle tab — a small vertical "tag" anchored to the
- * inner edge of the canvas pane. Used for the sidebar (left) and the
- * inspect panel (right). Position is `absolute` relative to the canvas
- * `<main>`, so when its companion panel is open the tab sits flush
- * against the panel; when closed it sits at the viewport edge.
+ * Bookmark-style toggle tab — a "tag" anchored to the inner edge of the
+ * canvas pane. Used for the sidebar (left) and the inspect panel
+ * (right when right-docked, bottom when bottom-docked). Position is
+ * `absolute` relative to the canvas `<main>` so the tab tracks the
+ * panel's leading edge regardless of dock side.
  */
 export function BookmarkTab({ open, onToggle, edge, label, ariaLabel }: BookmarkTabProps) {
-  // Pointer character: arrow toward the canvas when closed (would open
-  // INTO the canvas) and toward the panel when open (would close).
-  const arrow = edge === 'right' ? (open ? '›' : '‹') : open ? '‹' : '›'
+  const isVertical = edge === 'left' || edge === 'right'
+  // Arrow points TOWARD where the click will move the panel:
+  //   closed → arrow points away from the panel (clicking opens it INTO the canvas)
+  //   open   → arrow points toward the panel (clicking closes it back)
+  let arrow: string
+  if (edge === 'right') arrow = open ? '›' : '‹'
+  else if (edge === 'left') arrow = open ? '‹' : '›'
+  else arrow = open ? '▾' : '▴'
   return (
     <button
       type="button"
@@ -411,27 +416,32 @@ export function BookmarkTab({ open, onToggle, edge, label, ariaLabel }: Bookmark
       title={ariaLabel}
       style={{
         position: 'absolute',
-        top: '50%',
-        transform: 'translateY(-50%)',
-        [edge === 'right' ? 'right' : 'left']: 0,
+        ...(isVertical
+          ? { top: '50%', transform: 'translateY(-50%)', [edge]: 0 }
+          : { left: '50%', transform: 'translateX(-50%)', bottom: 0 }),
         // Above DataPixel (z=1000) — same reason the header/sidebars
         // sit above carrots: pixels in mid-flight can extend past the
         // canvas pane bounds.
         zIndex: 1001,
-        width: 24,
-        minWidth: 24,
-        minHeight: 76,
+        ...(isVertical
+          ? { width: 24, minWidth: 24, minHeight: 76 }
+          : { height: 24, minHeight: 24, minWidth: 76 }),
         background: '#0d2612',
         border: '1px solid #1a4a22',
         // Round only the corners pointing into the canvas, so the tab
-        // visually "sticks out" from the edge like a real bookmark.
-        borderRadius: edge === 'right' ? '6px 0 0 6px' : '0 6px 6px 0',
-        [edge === 'right' ? 'borderRight' : 'borderLeft']: 'none',
+        // visually "sticks out" from the panel's leading edge.
+        borderRadius:
+          edge === 'right' ? '6px 0 0 6px' : edge === 'left' ? '0 6px 6px 0' : '6px 6px 0 0',
+        ...(edge === 'right'
+          ? { borderRight: 'none' }
+          : edge === 'left'
+            ? { borderLeft: 'none' }
+            : { borderBottom: 'none' }),
         color: '#7fffaa',
         cursor: 'pointer',
-        padding: '8px 2px',
+        padding: isVertical ? '8px 2px' : '2px 8px',
         display: 'flex',
-        flexDirection: 'column',
+        flexDirection: isVertical ? 'column' : 'row',
         alignItems: 'center',
         justifyContent: 'center',
         gap: 6,
@@ -445,12 +455,15 @@ export function BookmarkTab({ open, onToggle, edge, label, ariaLabel }: Bookmark
       </span>
       <span
         aria-hidden="true"
-        style={{
-          // Vertical label, top-to-bottom along the tab.
-          writingMode: 'vertical-rl',
-          textOrientation: 'mixed',
-          transform: edge === 'right' ? undefined : 'rotate(180deg)',
-        }}
+        style={
+          isVertical
+            ? {
+                writingMode: 'vertical-rl',
+                textOrientation: 'mixed',
+                transform: edge === 'right' ? undefined : 'rotate(180deg)',
+              }
+            : undefined
+        }
       >
         {label}
       </span>


### PR DESCRIPTION
## Summary

**This PR was force-pushed after author feedback** — the prior implementation hoisted the right `BookmarkTab` to the screen's right edge, but that made things worse (toggle overlapped the bottom-docked panel and never indicated where the panel actually was).

Real desired behavior: the toggle sits flush against the panel's **leading edge** wherever the panel docks.

| `inspectorSide` | Toggle position |
|---|---|
| `'right'`  | Vertical tab on the canvas's right edge (existing behavior, unchanged) |
| `'bottom'` | **New:** horizontal tab on the canvas's bottom edge, centered |

## Changes

- `DataInspectionPanel.tsx` — extends `BookmarkTab` `edge` prop from `'left' | 'right'` to `'left' | 'right' | 'bottom'`. For `'bottom'`, the tab renders horizontally (`height: 24; minWidth: 76`) with a horizontal label and an up/down arrow (`▴`/`▾`) that points toward the panel-open direction. zIndex back to `1001` since the tab no longer overlaps the panel.
- `App.tsx` + `AppFragment.tsx` — pick the right `edge` value at the call site from `inspectorSide`.

## Test plan
- [ ] Dock inspect panel right (default), open / close — vertical tab on canvas's right edge, sits flush against panel left edge. (Unchanged behavior.)
- [ ] Dock inspect panel bottom — **horizontal** tab on canvas's bottom edge, centered, sits flush against panel top edge.
- [ ] Resize the bottom-docked panel — toggle stays glued to the top edge of the panel as it grows/shrinks.
- [ ] Open / close arrow on bottom tab makes sense: `▴` when closed (clicking opens panel upward into canvas), `▾` when open (clicking sends panel back down).
- [ ] Left FLOWS tab unchanged — still toggles the sidebar.
- [ ] `cd packages/web && npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
