### PR TITLE
docs(skill): explain create/destroy + add dedicated examples

### DIFF
--- a/examples/create-destroy.yaml
+++ b/examples/create-destroy.yaml
@@ -1,0 +1,50 @@
+meta:
+  title: Ephemeral Worker
+  path: examples/create-destroy
+  description: A dispatcher spawns a one-shot worker, the worker reports back, then it's destroyed
+
+flow:
+  nodes:
+    - id: queue
+      label: Job Queue
+      type: queue
+    - id: dispatcher
+      label: Dispatcher
+      type: service
+
+  steps:
+    # Step 1: Queue feeds a job to the dispatcher.
+    - from: queue
+      to: dispatcher
+      data: dequeued job
+
+    # Step 2: Dispatcher spawns a Worker for this job. The Worker
+    # node doesn't exist in `nodes` above — `create:` brings it
+    # into being and animates a spawn pixel from dispatcher to
+    # the freshly-rendered node.
+    - create: worker
+      from: dispatcher
+      node:
+        id: worker
+        label: Worker
+        type: service
+      data:
+        label: spawn
+        fields:
+          - name: job_id
+            type: string
+
+    # Step 3: The worker does its thing and reports back.
+    - from: worker
+      to: dispatcher
+      data:
+        label: result
+        fields:
+          - name: status
+            type: string
+            added: true
+
+    # Step 4: Worker is no longer needed — `destroy:` removes the
+    # node from the canvas. Any later step referencing `worker`
+    # would render as invalid.
+    - destroy: worker

--- a/examples/sub-flows.yaml
+++ b/examples/sub-flows.yaml
@@ -1,0 +1,73 @@
+meta:
+  title: Sub-flows
+  path: examples/sub-flows
+  description: A service node with a nested flow — click "+" on the service to drill in
+
+flow:
+  nodes:
+    - id: client
+      label: Client
+      type: actor
+    - id: api
+      label: API
+      type: endpoint
+
+    # Any node can carry a nested `flow:` block. The renderer shows
+    # a "+" badge on the node; clicking it zooms the canvas into
+    # this sub-flow's nodes + steps. Infinite depth supported.
+    - id: order-service
+      label: Order Service
+      type: service
+      flow:
+        nodes:
+          - id: validate
+            label: Validate
+            type: service
+          - id: enrich
+            label: Enrich
+            type: service
+          - id: persist
+            label: Persist
+            type: service
+        steps:
+          - from: validate
+            to: enrich
+            data: clean request
+          - from: enrich
+            to: persist
+            data:
+              label: enriched record
+              fields:
+                - name: items
+                  type: list
+                - name: user_id
+                  type: int
+                  added: true
+
+    - id: db
+      label: Postgres
+      type: database
+
+  steps:
+    - from: client
+      to: api
+      data: POST /orders
+    # `drilldown: true` auto-opens the sub-flow during playback when
+    # the camera lands on this step. Use sparingly — once per flow
+    # is usually enough; chained drilldowns get disorienting.
+    - from: api
+      to: order-service
+      data: validated input
+      drilldown: true
+    - from: order-service
+      to: db
+      data: persist row
+    - from: db
+      to: order-service
+      data: order_id
+    - from: order-service
+      to: api
+      data: 201 Created
+    - from: api
+      to: client
+      data: order created

--- a/skills/openhop/SKILL.md
+++ b/skills/openhop/SKILL.md
@@ -33,16 +33,16 @@ Activate this skill on prompts like:
 
 Each row reuses one of the bundled `examples/*.yaml` flows so the inputs match what the validator already accepts. The URL comes from the `url` field of `openhop push <file> --json`.
 
-| Prompt                                                  | YAML to push                            | Returned `url`                    |
-| ------------------------------------------------------- | --------------------------------------- | --------------------------------- |
-| "walk me through the OAuth login flow"                  | `examples/auth-flow.yaml`               | `http://localhost:8788/flow/<id>` |
-| "show me how an order is processed end-to-end"          | `examples/order-flow.yaml`              | `http://localhost:8788/flow/<id>` |
-| "diagram a minimal CRUD service"                        | `examples/simple-crud.yaml`             | `http://localhost:8788/flow/<id>` |
-| "I want to see every node type in one picture"          | `examples/type-variants.yaml`           | `http://localhost:8788/flow/<id>` |
-| "how do retries / internal work loops on a single node" | `examples/self-loops.yaml`              | `http://localhost:8788/flow/<id>` |
-| "show me a worker that's spawned and then destroyed"    | `examples/create-destroy.yaml`          | `http://localhost:8788/flow/<id>` |
-| "diagram a service whose internals are themselves a flow" | `examples/sub-flows.yaml`             | `http://localhost:8788/flow/<id>` |
-| "visualize a three-tier app (browser → API → DB)"       | the YAML in "Quickest valid flow" below | `http://localhost:8788/flow/<id>` |
+| Prompt                                                    | YAML to push                            | Returned `url`                    |
+| --------------------------------------------------------- | --------------------------------------- | --------------------------------- |
+| "walk me through the OAuth login flow"                    | `examples/auth-flow.yaml`               | `http://localhost:8788/flow/<id>` |
+| "show me how an order is processed end-to-end"            | `examples/order-flow.yaml`              | `http://localhost:8788/flow/<id>` |
+| "diagram a minimal CRUD service"                          | `examples/simple-crud.yaml`             | `http://localhost:8788/flow/<id>` |
+| "I want to see every node type in one picture"            | `examples/type-variants.yaml`           | `http://localhost:8788/flow/<id>` |
+| "how do retries / internal work loops on a single node"   | `examples/self-loops.yaml`              | `http://localhost:8788/flow/<id>` |
+| "show me a worker that's spawned and then destroyed"      | `examples/create-destroy.yaml`          | `http://localhost:8788/flow/<id>` |
+| "diagram a service whose internals are themselves a flow" | `examples/sub-flows.yaml`               | `http://localhost:8788/flow/<id>` |
+| "visualize a three-tier app (browser → API → DB)"         | the YAML in "Quickest valid flow" below | `http://localhost:8788/flow/<id>` |
 
 For brand-new flows, sketch your own YAML against the Schema Reference below and push the same way.
 

--- a/skills/openhop/SKILL.md
+++ b/skills/openhop/SKILL.md
@@ -40,6 +40,8 @@ Each row reuses one of the bundled `examples/*.yaml` flows so the inputs match w
 | "diagram a minimal CRUD service"                        | `examples/simple-crud.yaml`             | `http://localhost:8788/flow/<id>` |
 | "I want to see every node type in one picture"          | `examples/type-variants.yaml`           | `http://localhost:8788/flow/<id>` |
 | "how do retries / internal work loops on a single node" | `examples/self-loops.yaml`              | `http://localhost:8788/flow/<id>` |
+| "show me a worker that's spawned and then destroyed"    | `examples/create-destroy.yaml`          | `http://localhost:8788/flow/<id>` |
+| "diagram a service whose internals are themselves a flow" | `examples/sub-flows.yaml`             | `http://localhost:8788/flow/<id>` |
 | "visualize a three-tier app (browser → API → DB)"       | the YAML in "Quickest valid flow" below | `http://localhost:8788/flow/<id>` |
 
 For brand-new flows, sketch your own YAML against the Schema Reference below and push the same way.
@@ -267,7 +269,7 @@ flow:
 - `type`: **closed enum, exactly one of**: `actor | endpoint | auth | database | external | cache | queue | service | docker | k8s | scheduler | custom`. Anything else fails validation. Default if omitted: `service`.
 - `icon`: Iconify icon ID (e.g. `"logos:postgresql"`) — overlays on top of the node's pixel art. Works on any `type`, not just `custom`. Browse: https://icon-sets.iconify.design/logos/
 - `color`: hex color
-- `flow`: nested sub-flow { nodes, steps } — makes node expandable with +
+- `flow`: nested sub-flow `{ nodes, steps }` — makes the node expandable; the renderer shows a "+" badge and clicking zooms into the inner flow. Infinite depth supported (sub-flows can themselves contain nodes with sub-flows). Pair with `drilldown: true` on a step targeting the parent node to auto-open the sub-flow on playback. See [`examples/sub-flows.yaml`](../../examples/sub-flows.yaml).
 
 > **Critical: types are categories, labels are names.** The 12 `type` values are how the renderer knows which sprite + color to draw (database = barrel, cache = lightning, etc.). The `label` is what the user reads on the node. **Never** put a variant name (like `redis`, `oauth`, `stripe`) into `type` — that's a label. Put it in `label`, and use the matching category in `type` (`cache`, `auth`, `external`).
 >
@@ -297,7 +299,7 @@ Each node type has common real-world variants. Use them to choose an accurate `l
 Either a move step, parallel, create, or destroy:
 
 - Move: `{ from, to (string or string[]), data (string or object), drilldown (bool) }`
-- Parallel: `{ parallel: [move steps] }` (min 2). All sub-steps fire **concurrently** on playback — pixels travel at the same time. Use this when two or more transfers logically happen together, e.g. an orchestrator fans out work to several services at once, or two upstream nodes deliver payloads to the same target in the same tick.
+- Parallel: `{ parallel: [move steps] }` (min 2). All sub-steps fire **concurrently** on playback — pixels travel at the same time. Use this when two or more transfers logically happen together, e.g. an orchestrator fans out work to several services at once, or two upstream nodes deliver payloads to the same target in the same tick. Each sub-step is itself a move (`from`/`to`/`data`). See [`examples/self-loops.yaml`](../../examples/self-loops.yaml) and [`examples/order-flow.yaml`](../../examples/order-flow.yaml) for in-context use.
 
   ```yaml
   - parallel:
@@ -309,8 +311,29 @@ Either a move step, parallel, create, or destroy:
         data: { label: auth context, fields: [{ name: user_id, type: int }] }
   ```
 
-- Create: `{ create: "node-id", from: "creator-node", node: { id, label, type?, icon?, color? }, data? }`
-- Destroy: `{ destroy: "node-id" }`
+- Create: `{ create: "node-id", from: "creator-node", node: { id, label, type?, icon?, color? }, data? }`. Use when a node is **brought into existence** by another node mid-flow — a dispatcher spawning a worker, a request handler instantiating a session object, a service allocating a temporary buffer. The node **does NOT need to be listed in the top-level `flow.nodes`**; `create:` adds it to the canvas at this step's tick, animating a spawn pixel from `from` into the new node. Subsequent steps may reference the new id like any other node.
+
+  ```yaml
+  - create: worker
+    from: dispatcher
+    node:
+      id: worker
+      label: Worker
+      type: service
+    data:
+      label: spawn
+      fields:
+        - name: job_id
+          type: string
+  ```
+
+- Destroy: `{ destroy: "node-id" }`. Use when a node should **disappear from the canvas** after this step — the ephemeral counterpart of `create:`. Common pairings: a worker reporting result then terminating, a session lifecycle ending, a temporary buffer being released. The destroyed node fades out; any subsequent step that references it is invalid.
+
+  ```yaml
+  - destroy: worker
+  ```
+
+  Pair `create:` and `destroy:` to model **lifecycle**: a node exists only between its create step and its destroy step. See [`examples/create-destroy.yaml`](../../examples/create-destroy.yaml) for a complete spawn-work-terminate flow.
 
 ### Data
 


### PR DESCRIPTION
## Summary

The SKILL.md listed `create` / `destroy` as one-line schema entries with no semantics, no use cases, and no end-to-end example. Two dedicated minimal examples were missing for the two features that are hardest for an agent to pattern-match: **create/destroy lifecycle** and **sub-flows in isolation**. `order-flow.yaml` covers both but mixes them with a dozen other patterns, so it's noisy for an agent learning one concept.

## Changes

### `skills/openhop/SKILL.md`

- **Create** entry expanded with semantics (\"brought into existence by another node mid-flow\"), use-case framing (dispatcher/worker, session lifecycle, temporary buffer), explicit note that the new node need not appear in top-level `flow.nodes`, and minimal YAML.
- **Destroy** entry expanded the same way, including the lifecycle pairing rule (a created node exists only between its create and destroy steps).
- **Parallel** entry now points at `examples/self-loops.yaml` and `examples/order-flow.yaml` for in-context use.
- **Node `flow:`** entry expanded to call out the \"+\" badge, infinite depth, and `drilldown: true` interaction; references the new `examples/sub-flows.yaml`.
- **Prompt → YAML table** gains two rows so an agent can bind an intent (\"show me a worker that's spawned and then destroyed\" / \"diagram a service whose internals are themselves a flow\") to a concrete file.

### New examples

- **`examples/create-destroy.yaml`** — dispatcher spawns worker, worker reports back, worker is destroyed. 4 steps, 2 pre-existing nodes, 1 created-then-destroyed node. Minimal lifecycle demo.
- **`examples/sub-flows.yaml`** — order-service node carries a nested flow (validate → enrich → persist); the parent step uses `drilldown: true` to auto-zoom into it on playback.

Both new YAMLs pass `openhop validate`.

## Test plan
- [ ] \`npx openhop validate examples/create-destroy.yaml\` and \`npx openhop validate examples/sub-flows.yaml\` both report \`✓ Valid flow\` (verified locally).
- [ ] Render each via \`openhop push <file> --json\` and confirm: create-destroy plays the worker spawn/destroy correctly; sub-flows shows a \"+\" badge on order-service and the drilldown step auto-zooms.
- [ ] Agent test: with the updated SKILL.md loaded, ask the agent \"show me a worker being spawned and destroyed\" and confirm it picks `examples/create-destroy.yaml` from the prompt → YAML table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)