### PR TITLE
chore: bump @openhop/server @openhop/web openhop to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-11
+
 ### Added
 
 - CLI: machine-first contract per `openhop-launch/16-cli-as-universal-api.md`.
@@ -21,12 +23,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI: `help --json` per-command `exitCodes` array and `examples` array — agents can plan invocations and know which failure modes to expect from each command.
 - CLI: `push --json` includes `nodeCount` field.
 - CLI: `npm run test:cli-contract` script alias targeting the end-to-end contract suite.
+- Skill (`skills/openhop/SKILL.md`): explicit semantics + use-case framing for `create:` and `destroy:` steps. Lifecycle pairing rule documented.
+- Skill: new "Voice" section requiring verbose plain-English step `data` labels and reserving short labels for nodes. Do/don't table covering the eight most common terse patterns.
+- Skill: prompt → YAML table now binds intents like "show me two things happening at the same time" and "show me a worker spawned and destroyed" to dedicated examples.
+- New examples bundled into the published CLI tarball:
+  - `examples/create-destroy.yaml` — minimal lifecycle demo (4 steps).
+  - `examples/sub-flows.yaml` — service node with nested flow + `drilldown: true`.
+  - `examples/parallel.yaml` — focused fan-out demo (in and out parallel branches).
+- Web: left flow-tree sidebar is now horizontally resizable (180–480 px), with the chosen width persisted to `localStorage` under `openhop:sidebar:width`. Shared `ResizeHandle` component extracted.
+- Web: hover tooltips on truncated flow / folder labels in the sidebar (native `title=` attribute).
+- Web: `__setMaxZoom(n)` browser-console hook for live-tuning the per-step playback auto-zoom.
+
+### Changed
+
+- Web: INSPECT panel toggle now anchors to the panel's leading edge regardless of dock side. Right-docked → vertical tab on canvas's right edge; bottom-docked → horizontal tab on canvas's bottom edge.
+- Web: per-step playback auto-zoom defaults to native sprite size (1.0) instead of the previous bbox-fit value; overview/paused mode keeps the natural fit.
+- Web: step gap during playback bumped from 700 ms to 1100 ms so the eye registers the destination node after a delivery before the next step lights up. Pixel travel unchanged at 1800 ms.
+- Web: canvas `maxZoom` restored to 6 (default React Flow wheel-cap) after the auto-zoom override addressed the underlying readability concern.
+- Web: `FlowEditorModal` z-index lifted to 2000 so the editor sits unambiguously above carrots (z 1000) and the inspect panel (z 1001).
+- Web: BookmarkTab z-index lifted to 1002 to remain clickable when its position overlaps the inspect panel's leading edge.
+- Existing examples (`auth-flow`, `order-flow`, `self-loops`, `simple-crud`) migrated to verbose plain-English voice for step `data` labels. Field schemas (`name` / `type` / diff markers) unchanged.
+- `simple-crud.yaml` upgraded to demonstrate both the bare-string and object-form (`{ label, fields }`) step data shapes.
+
+### Fixed
+
+- Web: edit modal could be occluded by a carrot mid-flight or by the inspect panel — z-index bump resolves both.
+- Web: in-page anchor `#install` in the README's "Try it" NOTE now correctly resolves to `#install-options`.
+- Web: `flow.steps` honoring `destroy:` on static nodes (not just `create`'d ones).
+- Web: actor pinning no longer forces an actor to FIRST when another actor feeds into it.
 
 ### Notes
 
 - `get --json` returns the server's `storedFlow` shape (`{meta, flow, version, ...}`) rather than the spec example's `{id, yaml, svg, metadata}`. SVG rendering doesn't exist server-side in v0.1; YAML re-serialization on the client is lossy. Documented inline in `packages/cli/src/get.ts`.
   - `openhop help [command] --json` — emit the full command tree as JSON for agent introspection.
 - CLI: stdin input via `-` on `push`, `patch`, `validate`, `render`.
+- `__setMaxZoom` is a debug-only hook. Safe to call from the console; will be removed in a future release once the default value (1.0) is fully validated.
 
 ## [0.1.0] - 2026-04-26
 
@@ -44,5 +75,6 @@ Initial public release.
 - GitHub Actions CI: lint, format check, typecheck, build, test, coverage, npm audit, gitleaks, CodeQL.
 - Issue and pull request templates; Dependabot configuration.
 
-[Unreleased]: https://github.com/naorsabag/OpenHop/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/naorsabag/OpenHop/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/naorsabag/OpenHop/releases/tag/v0.2.0
 [0.1.0]: https://github.com/naorsabag/OpenHop/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -422,6 +422,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -439,6 +440,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -456,6 +458,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -473,6 +476,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -490,6 +494,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -507,6 +512,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -524,6 +530,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -541,6 +548,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -558,6 +566,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -575,6 +584,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -592,6 +602,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -609,6 +620,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -626,6 +638,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -643,6 +656,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -660,6 +674,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -677,6 +692,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -694,6 +710,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -711,6 +728,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -728,6 +746,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -745,6 +764,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -762,6 +782,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -779,6 +800,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -796,6 +818,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -813,6 +836,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -830,6 +854,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -847,6 +872,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7685,13 +7711,13 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.4.4",
         "@fastify/static": "^9.1.3",
-        "@openhop/server": "0.1.0",
-        "@openhop/web": "0.1.0",
+        "@openhop/server": "0.2.0",
+        "@openhop/web": "0.2.0",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
         "yaml": "^2.8.4",
@@ -8171,7 +8197,7 @@
     },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
@@ -8690,7 +8716,7 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@codemirror/lang-yaml": "^6.1.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -42,8 +42,8 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.1.0",
-    "@openhop/web": "0.1.0",
+    "@openhop/server": "0.2.0",
+    "@openhop/web": "0.2.0",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ if (process.argv.includes('--api-version')) {
 
 const program = new Command()
 
-program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.1.0')
+program.name('openhop').description('OpenHop — Data Flow Visualization CLI').version('0.2.0')
 
 // --- serve ---
 //

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Cuts the first npm release since `v0.1.0` (2026-05-11 05:35 UTC). 17 commits of merged work have been sitting on master invisible to anyone running `npx openhop ...`. This bump fixes that.

The publish workflow (`.github/workflows/publish.yml`) auto-detects `package.json` version drift against the npm registry on push-to-master, publishes each package whose version changed in dependency order (server → web → cli), and then tags `v0.2.0` + creates the matching GitHub Release. **Merging this PR triggers the release.** No manual `npm publish` needed.

### Versions

| Package | Old | New |
|---|---|---|
| `@openhop/server` | 0.1.0 | 0.2.0 |
| `@openhop/web` | 0.1.0 | 0.2.0 |
| `openhop` (CLI) | 0.1.0 | 0.2.0 |

CLI's pinned deps on `@openhop/server` and `@openhop/web` also bumped to `0.2.0`. `package-lock.json` regenerated.

### CHANGELOG

`[Unreleased]` block promoted to `[0.2.0]`. Added entries grouped Added / Changed / Fixed / Notes for the work since v0.1.0:

- CLI: machine-first contract, `validate`, `get`, `init`, JSON output discipline (already in the prior unreleased block — preserved).
- Skill: explicit create/destroy semantics, new Voice section, prompt → YAML table additions.
- New examples bundled into the CLI tarball: `create-destroy.yaml`, `sub-flows.yaml`, `parallel.yaml`.
- Web: sidebar resize + tooltips + single-slash root, INSPECT dock-aware toggle, edit modal z-index above carrots, carrot dwell tuned (gap 700 → 1100 ms, auto-zoom 1.0 default).
- Web: `__setMaxZoom(n)` debug-only browser-console hook (still in; will be stripped in a later release once the default lands cleanly).
- Existing example YAMLs migrated to verbose plain-English voice.

### What the workflow does after merge

1. Detects `packages/{server,web,cli}/package.json` version drift.
2. Publishes `@openhop/server@0.2.0` → `@openhop/web@0.2.0` → `openhop@0.2.0` (in that order; CLI pins both).
3. Skips any package whose target version already exists on the registry (none in this case).
4. Tags `v0.2.0` against this commit and creates the GitHub Release with auto-generated notes plus the CHANGELOG-style "Published to npm" header.

### Test plan
- [ ] CI green on this PR (build, test, audit, gitleaks, codeql).
- [ ] After merge: \`gh run watch <publish-run-id>\` — server/web/cli all publish successfully.
- [ ] After publish: \`npm view openhop version\` → \`0.2.0\`.
- [ ] After publish: \`npx openhop@latest demo\` in a fresh shell on a clean machine works end-to-end.
- [ ] GitHub Release \`v0.2.0\` appears with the CHANGELOG body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)