### PR TITLE
docs(readme): swap features for live demo, sharing, and token-use sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,9 @@ Click and play, no install required: **<https://naorsabag.github.io/openhop/>**
 
 ## Token use
 
-The agent emits YAML, not prose — so a "walk me through this codebase" answer is small enough to keep in context across many turns instead of evicting the rest of your conversation.
+No MCP server, so nothing sits in your context all session. OpenHop is an on-demand skill that loads only when you ask for a flow, plus a local CLI the agent shells out to.
 
-A few example flows from [`examples/`](examples/), with rough token estimates (≈ 1 token per 4 characters of YAML):
-
-| Flow                  | Steps | YAML size | YAML tokens (est.) |
-| --------------------- | ----- | --------- | ------------------ |
-| `simple-crud.yaml`    | 4     | 1.6 KB    | ~400               |
-| `auth-flow.yaml`      | 9     | 2.2 KB    | ~560               |
-| `order-flow.yaml`     | 18    | 8.9 KB    | ~2,200             |
-
-For comparison, a generic agent answering the same "walk me through X" question in prose typically runs **5–15× larger**, depending on how verbose the agent is and how much code it quotes inline. The ratio matters more than the absolute number — the win compounds as the flow gets bigger, because YAML reuses node names while prose has to keep re-introducing them.
+Rule of thumb: **~100 tokens per step.** A 10-step flow runs about ~1,000 tokens end-to-end (skill load + agent thinking + CLI calls).
 
 ## Install Options
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,6 @@ The agent generates the YAML, pushes it, and returns a URL with the animation pl
 
 Click and play, no install required: **<https://naorsabag.github.io/openhop/>**
 
-The playground is the same renderer OpenHop ships locally — same sprites, same animation, same drill-down, same Play / Pause / Prev / Next controls. The sidebar is pre-loaded with example flows (`auth-flow`, `order-flow`, `simple-crud`, `self-loops`, `type-variants`); pick one and step through it to get a feel for the product before you install anything.
-
-You can also paste any OpenHop share URL into the address bar and the page renders the flow inside it — no server, no account, no upload. See [Sharing flows](#sharing-flows) for how that works.
-
 ## Token use
 
 The agent emits YAML, not prose — so a "walk me through this codebase" answer is small enough to keep in context across many turns instead of evicting the rest of your conversation.

--- a/README.md
+++ b/README.md
@@ -80,11 +80,9 @@ Click and play, no install required: **<https://naorsabag.github.io/openhop/>**
 
 ## Token use
 
-No MCP server, so nothing sits in your context all session. OpenHop is an on-demand skill that loads only when you ask for a flow, plus a local CLI the agent shells out to.
+No MCP server — nothing sits in your context all session. It's an on-demand skill that loads only when you ask for a flow, plus a local CLI the agent shells out to.
 
-Flows are authored in **compact YAML**, not JSON — no quotes, no braces, just indentation — which keeps the payload the agent emits small.
-
-Rule of thumb: **~100 tokens per step.** A 10-step flow runs about ~1,000 tokens end-to-end (skill load + agent thinking + CLI calls).
+Flows are authored in **compact YAML**, not JSON, so the payload the agent emits stays small: **~100 tokens per step** (a 10-step flow ≈ 1,000 tokens of output).
 
 ## Install Options
 
@@ -133,17 +131,9 @@ cd openhop && npm install && npm run dev
 
 ## Sharing flows
 
-OpenHop is local-first — there's no hosted backend, no flow storage, no servers we keep running. So how do you send a teammate a flow?
+OpenHop is local-first — no hosted backend, no flow storage. To share a flow, open the [playground](https://naorsabag.github.io/openhop/), paste your YAML and hit **Save**: the page compresses the flow into the URL hash and copies a self-contained link to your clipboard. Nothing is uploaded — URL fragments stay in the browser.
 
-**Via the GitHub Pages playground** at <https://naorsabag.github.io/openhop/>:
-
-1. Open the playground, click **+ New flow** (or paste your YAML into the editor) and hit **Save**.
-2. The page compresses the full YAML into the URL hash (`https://naorsabag.github.io/openhop/#<lz-encoded>`) and copies the link to your clipboard.
-3. Send the link. Anyone who opens it sees the same animated flow — at their own pace, with the same Play / Pause / Prev / Next / drill-down controls — without installing anything.
-
-Nothing is uploaded. The whole flow lives inside the URL fragment (the part after `#`), which browsers don't send to servers. If the share link gets corrupted in transit (truncated email, mangled paste), the playground surfaces a "share link looks corrupted" banner instead of failing silently.
-
-For longer flows that don't fit comfortably in a URL, share the YAML file itself — the renderer is the same either way.
+For flows too large to fit in a URL, share the YAML file directly.
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ OpenHop is a skill that lets your agent emit an **animated, multi-level data-flo
 
 **Why an animated flow beats a static Mermaid/PlantUML picture:**
 
-- 🎞 **Step through it, don't squint at it.** Play, pause, prev/next, restart. The flow runs *over time*, the way the code actually does. You watch one hop happen, then the next, then the next.
+- 🎞 **Step through it, don't squint at it.** Play, pause, prev/next, restart. The flow runs _over time_, the way the code actually does. You watch one hop happen, then the next, then the next.
 - 🔍 **Drill into sub-flows.** Click any node to zoom into how it works inside. Infinite depth, same controls at every level.
 - 🧠 **Token-light by design.** The YAML the agent emits is a fraction of the prose walkthrough it replaces — see [Token use](#token-use) for the numbers on real flows.
 - 🔒 **Local-first, no telemetry.** Your code never leaves your machine. No analytics, no phone-home, no account required.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 </p>
 
 <p align="center">
-  <b>Local-first. Your code never leaves your machine. No telemetry.</b>
+  <b>Local-first. Token-light. Your code never leaves your machine. No telemetry.</b>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Click and play, no install required: **<https://naorsabag.github.io/openhop/>**
 
 No MCP server, so nothing sits in your context all session. OpenHop is an on-demand skill that loads only when you ask for a flow, plus a local CLI the agent shells out to.
 
+Flows are authored in **compact YAML**, not JSON — no quotes, no braces, just indentation — which keeps the payload the agent emits small.
+
 Rule of thumb: **~100 tokens per step.** A 10-step flow runs about ~1,000 tokens end-to-end (skill load + agent thinking + CLI calls).
 
 ## Install Options

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 AI coding agents are great at explaining how code works — in 800-line bullet walls and complicated static diagrams you can't actually follow.
 
-OpenHop is a skill that lets your agent emit an **animated, multi-level data-flow diagram** instead. You ask in plain English; your agent writes the flow as YAML and pushes it; OpenHop renders animated data pixels traveling between components on a pixel-art canvas — and you walk it at your own pace.
+OpenHop is a skill that lets your agent emit an **animated, multi-level data-flow diagram** instead. You ask in plain English; your agent writes the flow as YAML and pushes it; OpenHop takes care of the rest — and you walk it at your own pace.
 
 **Why an animated flow beats a static Mermaid/PlantUML picture:**
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@
 
 <p align="center">
   <a href="#try-it-in-30-seconds">Quickstart</a> ·
+  <a href="#live-demo">Live demo</a> ·
+  <a href="#token-use">Token use</a> ·
   <a href="#install-options">Install</a> ·
+  <a href="#sharing-flows">Sharing</a> ·
   <a href="#use-cases">Use cases</a> ·
   <a href="#how-it-works">How it works</a> ·
   <a href="#examples">Examples</a> ·
@@ -43,11 +46,16 @@
 
 ## Why
 
-AI coding agents are great at explaining how code works — in 800-line bullet walls and complicated diagrams you can't verify.
-OpenHop is a skill that lets your agent emit **animated data-flow diagrams**, making it much easier to understand what it’s actually yapping about.
-You ask in plain English; your agent writes the flow as YAML and pushes it; OpenHop renders animated data
-pixels traveling between components on a pixel-art canvas. Click any node to drill into its
-sub-flow.
+AI coding agents are great at explaining how code works — in 800-line bullet walls and complicated static diagrams you can't actually follow.
+
+OpenHop is a skill that lets your agent emit an **animated, multi-level data-flow diagram** instead. You ask in plain English; your agent writes the flow as YAML and pushes it; OpenHop renders animated data pixels traveling between components on a pixel-art canvas — and you walk it at your own pace.
+
+**Why an animated flow beats a static Mermaid/PlantUML picture:**
+
+- 🎞 **Step through it, don't squint at it.** Play, pause, prev/next, restart. The flow runs *over time*, the way the code actually does. You watch one hop happen, then the next, then the next.
+- 🔍 **Drill into sub-flows.** Click any node to zoom into how it works inside. Infinite depth, same controls at every level.
+- 🧠 **Token-light by design.** The YAML the agent emits is a fraction of the prose walkthrough it replaces — see [Token use](#token-use) for the numbers on real flows.
+- 🔒 **Local-first, no telemetry.** Your code never leaves your machine. No analytics, no phone-home, no account required.
 
 ## Try it in 30 seconds
 
@@ -66,15 +74,27 @@ The agent generates the YAML, pushes it, and returns a URL with the animation pl
 > [!NOTE]
 > `npx openhop init` auto-detects Claude Code, Cursor, Windsurf, Cline, and Continue. For other clients, see [Install](#install-options).
 
-## Features
+## Live demo
 
-- 🎞 **Agent-authored.** Ships with a skill any SKILL-compatible agent can load (Claude Code, Cursor, Windsurf, Cline, Continue, and more). Your agent writes the YAML, you watch it animate.
-- 🔍 **Multi-level drill-down.** Click a node to zoom into its sub-flow. Infinite depth.
-- ⚡ **Live re-render.** `openhop patch` applies incremental changes without a full reload.
-- 🧠 **Strict schema + fuzzy typo hints.** Invalid YAML fails loudly with helpful suggestions.
-- 🐚 **CLI + HTTP API + web UI.** Script it, hit it from tools, or browse at `http://localhost:8788`.
-- 🔒 **Local-first, no telemetry.** Runs entirely on your machine — no analytics, no phone-home, no account required.
-- ✂️ **Token-light.** A typical flow YAML is ~5–20× smaller than the equivalent prose explanation an agent would otherwise emit.
+Click and play, no install required: **<https://naorsabag.github.io/openhop/>**
+
+The playground is the same renderer OpenHop ships locally — same sprites, same animation, same drill-down, same Play / Pause / Prev / Next controls. The sidebar is pre-loaded with example flows (`auth-flow`, `order-flow`, `simple-crud`, `self-loops`, `type-variants`); pick one and step through it to get a feel for the product before you install anything.
+
+You can also paste any OpenHop share URL into the address bar and the page renders the flow inside it — no server, no account, no upload. See [Sharing flows](#sharing-flows) for how that works.
+
+## Token use
+
+The agent emits YAML, not prose — so a "walk me through this codebase" answer is small enough to keep in context across many turns instead of evicting the rest of your conversation.
+
+A few example flows from [`examples/`](examples/), with rough token estimates (≈ 1 token per 4 characters of YAML):
+
+| Flow                  | Steps | YAML size | YAML tokens (est.) |
+| --------------------- | ----- | --------- | ------------------ |
+| `simple-crud.yaml`    | 4     | 1.6 KB    | ~400               |
+| `auth-flow.yaml`      | 9     | 2.2 KB    | ~560               |
+| `order-flow.yaml`     | 18    | 8.9 KB    | ~2,200             |
+
+For comparison, a generic agent answering the same "walk me through X" question in prose typically runs **5–15× larger**, depending on how verbose the agent is and how much code it quotes inline. The ratio matters more than the absolute number — the win compounds as the flow gets bigger, because YAML reuses node names while prose has to keep re-introducing them.
 
 ## Install Options
 
@@ -121,12 +141,19 @@ git clone https://github.com/naorsabag/openhop.git
 cd openhop && npm install && npm run dev
 ```
 
-> **OpenHop v0.1 is local-first.**
-> The CLI runs entirely on your machine. There's no hosted backend, no flow
-> storage, no servers we keep running. Sharing today = sharing the YAML file
-> (or the URL-fragment share link from the [hosted playground](https://naorsabag.github.io/openhop/),
-> which compresses the flow into the URL hash — still no server-side
-> storage).
+## Sharing flows
+
+OpenHop is local-first — there's no hosted backend, no flow storage, no servers we keep running. So how do you send a teammate a flow?
+
+**Via the GitHub Pages playground** at <https://naorsabag.github.io/openhop/>:
+
+1. Open the playground, click **+ New flow** (or paste your YAML into the editor) and hit **Save**.
+2. The page compresses the full YAML into the URL hash (`https://naorsabag.github.io/openhop/#<lz-encoded>`) and copies the link to your clipboard.
+3. Send the link. Anyone who opens it sees the same animated flow — at their own pace, with the same Play / Pause / Prev / Next / drill-down controls — without installing anything.
+
+Nothing is uploaded. The whole flow lives inside the URL fragment (the part after `#`), which browsers don't send to servers. If the share link gets corrupted in transit (truncated email, mangled paste), the playground surfaces a "share link looks corrupted" banner instead of failing silently.
+
+For longer flows that don't fit comfortably in a URL, share the YAML file itself — the renderer is the same either way.
 
 ## Use cases
 


### PR DESCRIPTION
## Summary

- Rewrite the **Why** section to lead with the animated step-through + drill-down differentiation versus static Mermaid/PlantUML pictures (you walk it at your own pace, with Play / Pause / Prev / Next, and can drill into sub-flows).
- Drop the **Features** list and add a dedicated **Live demo** section pointing at https://naorsabag.github.io/openhop/ as the no-install entry point.
- Add a **Sharing flows** section that explains the URL-fragment share path through the Pages deploy (Save → hash-encoded URL → clipboard → anyone can open).
- Add a **Token use** section with a 3-row table (`simple-crud`, `auth-flow`, `order-flow`) showing estimated YAML tokens, plus a ranged 5–15× claim against an agent's prose walkthrough. Estimates are framed as estimates (≈ 1 token / 4 chars), not measurements — happy to swap in real `cl100k_base` numbers in a follow-up if preferred.
- Refresh the TOC to match (`Live demo`, `Token use`, `Sharing` anchors added).

No behavior or schema changes; README-only.

## Test plan

- [ ] Render the README on GitHub and check that TOC anchors land on the new sections.
- [ ] Confirm the live demo link (https://naorsabag.github.io/openhop/) and the share-URL flow described in **Sharing flows** still match the playground behavior.
- [ ] Eyeball the token-use table — confirm the step counts and file sizes are still accurate (they're tied to `examples/*.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with “Live demo”, “Token use”, and “Sharing flows” sections
  * Reframed onboarding to emphasize an animated, multi-level data-flow experience with step-through playback and drill-down
  * Added token-light YAML guidance with per-step token sizing and prose-size comparisons
  * Documented playground URL-hash sharing (no upload) and direct-YAML fallback for larger flows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/140)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->