### PR TITLE
feat(web): default inspector dock to bottom on mobile

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -230,7 +230,12 @@ function App() {
   // (Tailwind `md` breakpoint, 768px) so the canvas gets full width on
   // phones; on desktop it stays open as before.
   const [inspectorOpen, setInspectorOpen] = useState(() => !isMobileViewport())
-  const [inspectorSide, setInspectorSide] = useState<DockSide>('right')
+  // Mobile defaults to bottom-dock so when the user opens the inspector
+  // from its bookmark tab, the canvas keeps full width above. Desktop
+  // keeps the right-dock it's always had.
+  const [inspectorSide, setInspectorSide] = useState<DockSide>(() =>
+    isMobileViewport() ? 'bottom' : 'right'
+  )
   const [inspectorSize, setInspectorSize] = useState(320)
   // Sidebar (flow tree) collapsed/expanded state. Bookmark tab on the
   // left edge of the canvas toggles it. Same mobile-default rule as

--- a/packages/web/src/AppFragment.tsx
+++ b/packages/web/src/AppFragment.tsx
@@ -214,7 +214,12 @@ export default function AppFragment() {
   // Both side panels start collapsed on narrow viewports so the canvas
   // gets full width on phones; on desktop they stay open as before.
   const [inspectorOpen, setInspectorOpen] = useState(() => !isMobileViewport())
-  const [inspectorSide, setInspectorSide] = useState<DockSide>('right')
+  // Mobile defaults to bottom-dock so when the user opens the inspector
+  // from its bookmark tab, the canvas keeps full width above. Desktop
+  // keeps the right-dock it's always had.
+  const [inspectorSide, setInspectorSide] = useState<DockSide>(() =>
+    isMobileViewport() ? 'bottom' : 'right'
+  )
   const [inspectorSize, setInspectorSize] = useState(320)
   const [sidebarOpen, setSidebarOpen] = useState(() => !isMobileViewport())
 


### PR DESCRIPTION
## Summary

On narrow viewports (Tailwind `md` breakpoint, < 768px) the inspector now defaults to **bottom-dock** instead of right-dock when the user opens it. Closed-by-default behavior on mobile is unchanged.

Why: on a phone, right-docking the inspector crushes the canvas to a sliver. Bottom-docking keeps the canvas full-width above the panel — the standard mobile drawer pattern.

Applied to both `App.tsx` (local) and `AppFragment.tsx` (GitHub Pages playground).

## Test plan

- [x] `npx prettier --check` clean on touched files
- [x] `npm run typecheck -w @openhop/web` passes
- [x] `npm test -w @openhop/web` — 42/42 pass
- [ ] Manual: open <https://naorsabag.github.io/openhop/> on a phone (or DevTools < 768px), tap the INSPECT bookmark tab — panel should slide up from the bottom, not in from the right
- [ ] Manual: on desktop, confirm INSPECT still opens on the right and the dock-switch button in the header still toggles to bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inspector panel now adapts its position based on your device type: mobile users will see it docked at the bottom of the screen, while desktop users experience it on the right side, optimizing the interface for different screen sizes and improving overall usability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/142)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->