### PR TITLE
chore: bump @openhop/server @openhop/web openhop to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Initial public release.
 - GitHub Actions CI: lint, format check, typecheck, build, test, coverage, npm audit, gitleaks, CodeQL.
 - Issue and pull request templates; Dependabot configuration.
 
-[Unreleased]: https://github.com/naorsabag/OpenHop/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/naorsabag/OpenHop/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/naorsabag/OpenHop/releases/tag/v0.3.0
 [0.2.0]: https://github.com/naorsabag/OpenHop/releases/tag/v0.2.0
 [0.1.0]: https://github.com/naorsabag/OpenHop/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-12
+
 ### Added
 
 - Two new node types: `ai_agent` (LLM-driven agent — bunny-robot sprite) and `browser` (a browser-window sprite). Both appear in `NodeTypeEnum` and ship as cropped + color-quantized SVG sprites under `packages/web/public/sprites/`. See `examples/ai-browsing-agent.yaml` for a flow that exercises both.
+- `examples/showcase/` — eight hand-authored flows visualizing real code paths in well-known OSS projects (langgraph, openai-codex, block-goose, vercel-ai-sdk, browser-use, nextauthjs, openclaw) plus a self-referential openhop flow. Each is `openhop validate`-clean against the zod schema.
+
+### Changed
+
+- Skill (`skills/openhop/SKILL.md`): trigger surface broadened beyond code walkthroughs. The `description:` field now routes on explicit diagram / visualization / walkthrough verbs over any system, product, feature, codebase, workflow, pipeline, or user journey — not only code. Adds an explicit negative gate so generic explainer prompts ("how does TCP work?", "what is OAuth?") do not activate the skill. Trigger phrase examples reorganised into diagram / code-walkthrough / product-feature buckets.
+- Web: INSPECT panel defaults to bottom-dock on narrow viewports (Tailwind `md` breakpoint, < 768 px). Desktop continues to default to right-dock. Closed-by-default behaviour on mobile is unchanged — the new dock side only kicks in when the user opens the panel from its bookmark tab.
 
 ## [0.2.0] - 2026-05-11
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7716,13 +7716,13 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.4.4",
         "@fastify/static": "^9.1.3",
-        "@openhop/server": "0.2.0",
-        "@openhop/web": "0.2.0",
+        "@openhop/server": "0.3.0",
+        "@openhop/web": "0.3.0",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
         "yaml": "^2.8.4",
@@ -8202,7 +8202,7 @@
     },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
@@ -8721,7 +8721,7 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -46,8 +46,8 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.2.0",
-    "@openhop/web": "0.2.0",
+    "@openhop/server": "0.3.0",
+    "@openhop/web": "0.3.0",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Cuts the first release since v0.2.0 (2026-05-11). The publish workflow auto-publishes each package whose `package.json` version differs from the registry, then tags `v0.3.0` and creates the GitHub release.

| Package | From | To |
|---|---|---|
| `@openhop/server` | 0.2.0 | **0.3.0** |
| `@openhop/web` | 0.2.0 | **0.3.0** |
| `openhop` (CLI) | 0.2.0 | **0.3.0** |

CLI's pinned deps on `@openhop/server` / `@openhop/web` also bumped.

### Why republish

Verified by extracting the current `openhop@0.2.0` tarball from npm: it still ships the **old narrow** skill description ("walk the user through their code..."). The broadened description from #143 is on master but not reaching `npx openhop init` users until we cut a release.

### What's in this release (user-visible)

- **Skill triggers broadened (#143)** — agents now route on explicit diagram / visualization / walkthrough verbs across any system, product, feature, codebase, workflow, pipeline, or user journey — not only code. Adds an explicit negative gate so generic explainer prompts ("how does TCP work?", "explain closures") don't over-activate the skill.
- **INSPECT panel defaults to bottom-dock on mobile (#142)** — narrow viewports (< 768 px) keep the canvas full-width when the user opens the inspector. Desktop unchanged.

### Not changelogged

- **#139** — internal: `--version` now reads from `package.json` via prebuild generator. No user-facing behavior.
- **#140 / #141** — README only; doesn't ship in any tarball (the `files` field in `packages/cli/package.json` is `["dist", "skills"]`).
- **#144 (in flight, share-URL shortening)** — not merged yet; will land in the next release.

## Test plan

- [x] `npm run typecheck --workspaces --if-present` — all 3 workspaces pass
- [x] `npm run test:cli-contract -w openhop` — 37/37 pass against freshly-built `dist/index.js` (catches `--version` drift)
- [x] `packages/cli/src/version.ts` regenerates to `0.3.0` via prebuild `sync:version`
- [ ] Once merged: confirm the auto-publish workflow ships all three packages to npm and tags `v0.3.0`
- [ ] Confirm `npx openhop init` on a fresh machine installs the broadened skill description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new ai_agent and browser node types and a set of validated showcase example flows.

* **Bug Fixes**
  * Refined OpenHop skill trigger routing to prioritize explicit diagram/visualization/walkthrough verbs and avoid unintended activations.
  * Optimized Web INSPECT panel docking—defaults bottom on narrow viewports and right on desktop.

* **Documentation**
  * Changelog updated with v0.3.0 release notes and reorganized trigger examples.

* **Chores**
  * Version bumped to 0.3.0 across packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/145)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->