### PR TITLE
chore: bump @openhop/server @openhop/web openhop to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-13
+
 ### Added
 
 - `examples/node-icons.yaml`: small focused flow demonstrating Iconify brand-icon overlays on top of pixel sprites (Postgres, Redis, RabbitMQ, SendGrid).
 - Server: on first startup, the bundled `examples/` and `examples/showcase/` flows are seeded into the disk-backed store with stable `example-<basename>` ids. Repeat starts update the seeded copies in place; user-authored flows (random nanoids) are untouched. The npm tarball now ships the `examples/` tree (`@openhop/server` `files` field + prepack copy) so `npx openhop demo` populates the sidebar on a brand-new machine.
-- Pages playground: sidebar now bundles the showcase flows and the focused feature demos (node-icons, parallel, sub-flows, create-destroy, ai-browsing-agent). The earlier general-purpose examples (simple-crud, auth-flow, order-flow, self-loops, type-variants) remain in the repo and are still seeded by the local server — they're just not pinned in the Pages sidebar anymore.
+- Pages playground: sidebar now bundles the showcase flows and the focused feature demos (node-icons, parallel, sub-flows, create-destroy). The self-referential `openhop` showcase is the default landing flow when a visitor opens `https://naorsabag.github.io/openhop/` with no URL hash. The earlier general-purpose examples (simple-crud, auth-flow, order-flow, self-loops, type-variants) remain in the repo and are still seeded by the local server — they're just not pinned in the Pages sidebar anymore.
+
+### Changed
+
+- README "How it works": the mermaid diagram is replaced by a screenshot of the rendered openhop showcase flow (sprites + edges including the new `ai_agent` and `browser` nodes). The image hyperlinks to the Pages playground so readers can watch it animate live.
+- `examples/showcase/openhop.yaml` `meta.title`: `OpenHop, visualized in OpenHop` → `openhop`.
+
+### Removed
+
+- `examples/ai-browsing-agent.yaml`: the two new node types (`ai_agent`, `browser`) are already exercised by `examples/showcase/openhop.yaml` and `examples/showcase/browser-use.yaml`; the standalone narrative example was duplicative.
 
 ## [0.3.0] - 2026-05-12
 
@@ -93,7 +104,8 @@ Initial public release.
 - GitHub Actions CI: lint, format check, typecheck, build, test, coverage, npm audit, gitleaks, CodeQL.
 - Issue and pull request templates; Dependabot configuration.
 
-[Unreleased]: https://github.com/naorsabag/OpenHop/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/naorsabag/OpenHop/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/naorsabag/OpenHop/releases/tag/v0.3.1
 [0.3.0]: https://github.com/naorsabag/OpenHop/releases/tag/v0.3.0
 [0.2.0]: https://github.com/naorsabag/OpenHop/releases/tag/v0.2.0
 [0.1.0]: https://github.com/naorsabag/OpenHop/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -7716,13 +7716,13 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.4.4",
         "@fastify/static": "^9.1.3",
-        "@openhop/server": "0.3.0",
-        "@openhop/web": "0.3.0",
+        "@openhop/server": "0.3.1",
+        "@openhop/web": "0.3.1",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
         "yaml": "^2.8.4",
@@ -8202,7 +8202,7 @@
     },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
@@ -8721,7 +8721,7 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -46,8 +46,8 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.3.0",
-    "@openhop/web": "0.3.0",
+    "@openhop/server": "0.3.1",
+    "@openhop/web": "0.3.1",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release for the first-run-seeding work merged in #147.

**Versions:**
- `@openhop/server`  0.3.0 → 0.3.1
- `@openhop/web`     0.3.0 → 0.3.1
- `openhop` (CLI)    0.3.0 → 0.3.1

**What's actually in 0.3.1:**
- `@openhop/server`: startup now seeds every flow under `examples/` and `examples/showcase/` (stable `example-<basename>` ids; user-authored flows untouched). The npm tarball now ships the examples tree (`files` field + prepack copy), so `npx openhop demo` works out of the box on a brand-new machine.
- `@openhop/web`: Pages bundle swaps its sidebar to feature the showcase flows + focused feature demos. The general-purpose examples are still seeded by the local server.
- CLI bump only to keep `@openhop/server` / `@openhop/web` peer-dep pins in lockstep.

No breaking changes — additive only. Hence patch, not minor.

## Test plan

- [x] Local typecheck + format check clean
- [x] CHANGELOG `[Unreleased]` rolled into `[0.3.1] - 2026-05-13`, version-comparison link added
- [x] package-lock.json regenerated via `npm install --package-lock-only`
- [ ] Wait for CI to confirm tests / build / coverage still green at the new version pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.3.1 across all packages and updated the changelog/release links.
* **Added**
  * Updated bundled demo and sidebar contents.
* **Changed**
  * Updated Pages playground default landing flow and README “How it works” diagram now links to a screenshot.
  * Adjusted an example showcase title.
* **Removed**
  * Removed a standalone narrative that is now covered by showcase flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/148)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->