### PR TITLE
fix(readme): add blank line after "## How it works" heading (unblocks CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ openhop remove <flow-id>             # delete a flow
 Flags: `-p, --port <port>` (serve), `-s, --server <url>` (all others).
 
 ## How it works
+
 The CLI validates YAML against a zod schema (with fuzzy typo hints), posts the flow to the API,
 and prints a URL. The web UI subscribes and animates data pixels along the edges.
 


### PR DESCRIPTION
## Summary

One-character fix to `README.md` — adds the blank line Prettier requires between the `## How it works` heading and the paragraph that follows. Master has been failing `npm run format:check` since commit b98bead landed direct to master without running Prettier, and every open PR's CI has inherited that failure.

## Verification

```
$ npx prettier --check README.md
Checking formatting...
All matched files use Prettier code style\!
```

## Impact

Unblocks CI on all open PRs (including #150 and #151) on their next run — no rebase needed; PR CI runs against a merge with master and will pick up this fix automatically once merged.