### PR TITLE
examples(showcase): add Netflix and Spotify system-design flows

### DIFF
--- a/examples/showcase/netflix.yaml
+++ b/examples/showcase/netflix.yaml
@@ -1,0 +1,200 @@
+meta:
+  title: Netflix — Open App to Streaming a Video
+  description: End-to-end flow of a Netflix playback session, from app launch through homepage personalization to adaptive
+    video streaming via Open Connect.
+  path: system-design/netflix
+flow:
+  nodes:
+  - id: user
+    label: Viewer
+    type: actor
+  - id: client
+    label: Netflix Client (TV / Mobile / Web)
+    type: browser
+  - id: gateway
+    label: Zuul API Gateway (AWS)
+    type: endpoint
+    icon: logos:aws
+  - id: auth
+    label: Identity & Auth Service
+    type: auth
+  - id: homepage
+    label: Homepage / Viewing Service
+    type: service
+  - id: recs
+    label: Personalization & Recommendations
+    type: service
+  - id: evcache
+    label: EVCache (Memcached cluster)
+    type: cache
+    icon: logos:memcached
+  - id: cassandra
+    label: Cassandra (User & Viewing History)
+    type: database
+    icon: logos:cassandra
+  - id: playback
+    label: Playback API
+    type: service
+  - id: steering
+    label: Open Connect Steering Service
+    type: service
+  - id: s3
+    label: S3 (Master Video Files)
+    type: external
+    icon: logos:aws-s3
+  - id: oca
+    label: Open Connect Appliance (ISP Edge CDN)
+    type: external
+  steps:
+  - from: user
+    to: client
+    data: Tap "Netflix"
+  - from: client
+    to: gateway
+    data:
+      label: GET /homepage
+      fields:
+      - name: user_token
+        type: JWT
+      - name: device_id
+        type: string
+      - name: profile_id
+        type: string
+  - from: gateway
+    to: auth
+    data: Validate JWT
+  - from: auth
+    to: gateway
+    data:
+      label: Identity OK
+      fields:
+      - name: account_id
+        type: uuid
+      - name: profile_id
+        type: uuid
+      - name: subscription_tier
+        type: enum
+  - from: gateway
+    to: homepage
+    data: Build personalized home
+  - parallel:
+    - from: homepage
+      to: recs
+      data: get_rows(profile_id)
+    - from: homepage
+      to: evcache
+      data: get_cached_home(profile_id)
+  - from: evcache
+    to: homepage
+    data:
+      label: cache MISS
+      color: '#ff6a6a'
+  - from: recs
+    to: cassandra
+    data: viewing_history(profile_id)
+  - from: cassandra
+    to: recs
+    data:
+      label: watch history + ratings
+      fields:
+      - name: titles_watched
+        type: list[Title]
+      - name: completion_rates
+        type: list[float]
+  - from: recs
+    to: homepage
+    data:
+      label: ranked rows
+      fields:
+      - name: rows
+        type: list[Row]
+      - name: ranking_model
+        type: string
+  - from: homepage
+    to: evcache
+    data: write-through cache
+  - from: homepage
+    to: gateway
+    data: rows + artwork URLs
+  - from: gateway
+    to: client
+    data:
+      label: 200 OK — Homepage JSON
+      fields:
+      - name: rows
+        type: list[Row]
+      - name: image_urls
+        type: list[CDN URL]
+  - from: user
+    to: client
+    data: Click "Play" on a title
+  - from: client
+    to: gateway
+    data:
+      label: POST /playback/start
+      fields:
+      - name: title_id
+        type: uuid
+      - name: device_caps
+        type: '{codecs, drm, bitrate}'
+  - from: gateway
+    to: playback
+    data: start_session(title_id, device)
+  - from: playback
+    to: steering
+    data:
+      label: locate nearest OCA
+      fields:
+      - name: client_ip
+        type: string
+      - name: isp_asn
+        type: int
+  - from: steering
+    to: s3
+    data: confirm asset availability
+  - from: s3
+    to: steering
+    data: manifest pointers
+  - from: steering
+    to: playback
+    data:
+      label: ranked OCA URLs
+      fields:
+      - name: edge_urls
+        type: list[URL]
+      - name: drm_license_url
+        type: URL
+  - from: playback
+    to: gateway
+    data: playback manifest (DASH/HLS)
+  - from: gateway
+    to: client
+    data:
+      label: manifest + DRM token
+      fields:
+      - name: bitrate_ladder
+        type: list[Variant]
+      - name: drm_license
+        type: token
+  - from: client
+    to: oca
+    data:
+      label: GET /chunk (HTTP range)
+      fields:
+      - name: bitrate
+        type: kbps
+      - name: byte_range
+        type: start-end
+  - from: oca
+    to: client
+    data:
+      label: video segment (TLS)
+      color: '#4aff7a'
+      fields:
+      - name: segment
+        type: bytes
+      - name: duration_s
+        type: float
+  - from: client
+    to: user
+    data: Pixels on screen

--- a/examples/showcase/netflix.yaml
+++ b/examples/showcase/netflix.yaml
@@ -1,200 +1,201 @@
 meta:
   title: Netflix — Open App to Streaming a Video
-  description: End-to-end flow of a Netflix playback session, from app launch through homepage personalization to adaptive
+  description:
+    End-to-end flow of a Netflix playback session, from app launch through homepage personalization to adaptive
     video streaming via Open Connect.
   path: system-design/netflix
 flow:
   nodes:
-  - id: user
-    label: Viewer
-    type: actor
-  - id: client
-    label: Netflix Client (TV / Mobile / Web)
-    type: browser
-  - id: gateway
-    label: Zuul API Gateway (AWS)
-    type: endpoint
-    icon: logos:aws
-  - id: auth
-    label: Identity & Auth Service
-    type: auth
-  - id: homepage
-    label: Homepage / Viewing Service
-    type: service
-  - id: recs
-    label: Personalization & Recommendations
-    type: service
-  - id: evcache
-    label: EVCache (Memcached cluster)
-    type: cache
-    icon: logos:memcached
-  - id: cassandra
-    label: Cassandra (User & Viewing History)
-    type: database
-    icon: logos:cassandra
-  - id: playback
-    label: Playback API
-    type: service
-  - id: steering
-    label: Open Connect Steering Service
-    type: service
-  - id: s3
-    label: S3 (Master Video Files)
-    type: external
-    icon: logos:aws-s3
-  - id: oca
-    label: Open Connect Appliance (ISP Edge CDN)
-    type: external
+    - id: user
+      label: Viewer
+      type: actor
+    - id: client
+      label: Netflix Client (TV / Mobile / Web)
+      type: browser
+    - id: gateway
+      label: Zuul API Gateway (AWS)
+      type: endpoint
+      icon: logos:aws
+    - id: auth
+      label: Identity & Auth Service
+      type: auth
+    - id: homepage
+      label: Homepage / Viewing Service
+      type: service
+    - id: recs
+      label: Personalization & Recommendations
+      type: service
+    - id: evcache
+      label: EVCache (Memcached cluster)
+      type: cache
+      icon: logos:memcached
+    - id: cassandra
+      label: Cassandra (User & Viewing History)
+      type: database
+      icon: logos:cassandra
+    - id: playback
+      label: Playback API
+      type: service
+    - id: steering
+      label: Open Connect Steering Service
+      type: service
+    - id: s3
+      label: S3 (Master Video Files)
+      type: external
+      icon: logos:aws-s3
+    - id: oca
+      label: Open Connect Appliance (ISP Edge CDN)
+      type: external
   steps:
-  - from: user
-    to: client
-    data: Tap "Netflix"
-  - from: client
-    to: gateway
-    data:
-      label: GET /homepage
-      fields:
-      - name: user_token
-        type: JWT
-      - name: device_id
-        type: string
-      - name: profile_id
-        type: string
-  - from: gateway
-    to: auth
-    data: Validate JWT
-  - from: auth
-    to: gateway
-    data:
-      label: Identity OK
-      fields:
-      - name: account_id
-        type: uuid
-      - name: profile_id
-        type: uuid
-      - name: subscription_tier
-        type: enum
-  - from: gateway
-    to: homepage
-    data: Build personalized home
-  - parallel:
-    - from: homepage
+    - from: user
+      to: client
+      data: Tap "Netflix"
+    - from: client
+      to: gateway
+      data:
+        label: GET /homepage
+        fields:
+          - name: user_token
+            type: JWT
+          - name: device_id
+            type: string
+          - name: profile_id
+            type: string
+    - from: gateway
+      to: auth
+      data: Validate JWT
+    - from: auth
+      to: gateway
+      data:
+        label: Identity OK
+        fields:
+          - name: account_id
+            type: uuid
+          - name: profile_id
+            type: uuid
+          - name: subscription_tier
+            type: enum
+    - from: gateway
+      to: homepage
+      data: Build personalized home
+    - parallel:
+        - from: homepage
+          to: recs
+          data: get_rows(profile_id)
+        - from: homepage
+          to: evcache
+          data: get_cached_home(profile_id)
+    - from: evcache
+      to: homepage
+      data:
+        label: cache MISS
+        color: "#ff6a6a"
+    - from: recs
+      to: cassandra
+      data: viewing_history(profile_id)
+    - from: cassandra
       to: recs
-      data: get_rows(profile_id)
+      data:
+        label: watch history + ratings
+        fields:
+          - name: titles_watched
+            type: list[Title]
+          - name: completion_rates
+            type: list[float]
+    - from: recs
+      to: homepage
+      data:
+        label: ranked rows
+        fields:
+          - name: rows
+            type: list[Row]
+          - name: ranking_model
+            type: string
     - from: homepage
       to: evcache
-      data: get_cached_home(profile_id)
-  - from: evcache
-    to: homepage
-    data:
-      label: cache MISS
-      color: '#ff6a6a'
-  - from: recs
-    to: cassandra
-    data: viewing_history(profile_id)
-  - from: cassandra
-    to: recs
-    data:
-      label: watch history + ratings
-      fields:
-      - name: titles_watched
-        type: list[Title]
-      - name: completion_rates
-        type: list[float]
-  - from: recs
-    to: homepage
-    data:
-      label: ranked rows
-      fields:
-      - name: rows
-        type: list[Row]
-      - name: ranking_model
-        type: string
-  - from: homepage
-    to: evcache
-    data: write-through cache
-  - from: homepage
-    to: gateway
-    data: rows + artwork URLs
-  - from: gateway
-    to: client
-    data:
-      label: 200 OK — Homepage JSON
-      fields:
-      - name: rows
-        type: list[Row]
-      - name: image_urls
-        type: list[CDN URL]
-  - from: user
-    to: client
-    data: Click "Play" on a title
-  - from: client
-    to: gateway
-    data:
-      label: POST /playback/start
-      fields:
-      - name: title_id
-        type: uuid
-      - name: device_caps
-        type: '{codecs, drm, bitrate}'
-  - from: gateway
-    to: playback
-    data: start_session(title_id, device)
-  - from: playback
-    to: steering
-    data:
-      label: locate nearest OCA
-      fields:
-      - name: client_ip
-        type: string
-      - name: isp_asn
-        type: int
-  - from: steering
-    to: s3
-    data: confirm asset availability
-  - from: s3
-    to: steering
-    data: manifest pointers
-  - from: steering
-    to: playback
-    data:
-      label: ranked OCA URLs
-      fields:
-      - name: edge_urls
-        type: list[URL]
-      - name: drm_license_url
-        type: URL
-  - from: playback
-    to: gateway
-    data: playback manifest (DASH/HLS)
-  - from: gateway
-    to: client
-    data:
-      label: manifest + DRM token
-      fields:
-      - name: bitrate_ladder
-        type: list[Variant]
-      - name: drm_license
-        type: token
-  - from: client
-    to: oca
-    data:
-      label: GET /chunk (HTTP range)
-      fields:
-      - name: bitrate
-        type: kbps
-      - name: byte_range
-        type: start-end
-  - from: oca
-    to: client
-    data:
-      label: video segment (TLS)
-      color: '#4aff7a'
-      fields:
-      - name: segment
-        type: bytes
-      - name: duration_s
-        type: float
-  - from: client
-    to: user
-    data: Pixels on screen
+      data: write-through cache
+    - from: homepage
+      to: gateway
+      data: rows + artwork URLs
+    - from: gateway
+      to: client
+      data:
+        label: 200 OK — Homepage JSON
+        fields:
+          - name: rows
+            type: list[Row]
+          - name: image_urls
+            type: list[CDN URL]
+    - from: user
+      to: client
+      data: Click "Play" on a title
+    - from: client
+      to: gateway
+      data:
+        label: POST /playback/start
+        fields:
+          - name: title_id
+            type: uuid
+          - name: device_caps
+            type: "{codecs, drm, bitrate}"
+    - from: gateway
+      to: playback
+      data: start_session(title_id, device)
+    - from: playback
+      to: steering
+      data:
+        label: locate nearest OCA
+        fields:
+          - name: client_ip
+            type: string
+          - name: isp_asn
+            type: int
+    - from: steering
+      to: s3
+      data: confirm asset availability
+    - from: s3
+      to: steering
+      data: manifest pointers
+    - from: steering
+      to: playback
+      data:
+        label: ranked OCA URLs
+        fields:
+          - name: edge_urls
+            type: list[URL]
+          - name: drm_license_url
+            type: URL
+    - from: playback
+      to: gateway
+      data: playback manifest (DASH/HLS)
+    - from: gateway
+      to: client
+      data:
+        label: manifest + DRM token
+        fields:
+          - name: bitrate_ladder
+            type: list[Variant]
+          - name: drm_license
+            type: token
+    - from: client
+      to: oca
+      data:
+        label: GET /chunk (HTTP range)
+        fields:
+          - name: bitrate
+            type: kbps
+          - name: byte_range
+            type: start-end
+    - from: oca
+      to: client
+      data:
+        label: video segment (TLS)
+        color: "#4aff7a"
+        fields:
+          - name: segment
+            type: bytes
+          - name: duration_s
+            type: float
+    - from: client
+      to: user
+      data: Pixels on screen

--- a/examples/showcase/spotify.yaml
+++ b/examples/showcase/spotify.yaml
@@ -1,229 +1,230 @@
 meta:
   title: Spotify — Open App to Streaming a Track
-  description: End-to-end flow of a Spotify session — auth, personalized home (BaRT), track lookup, and audio streaming via
+  description:
+    End-to-end flow of a Spotify session — auth, personalized home (BaRT), track lookup, and audio streaming via
     the Spotify CDN backed by Google Cloud Storage.
   path: system-design/spotify
 flow:
   nodes:
-  - id: user
-    label: Listener
-    type: actor
-  - id: client
-    label: Spotify Client (Mobile / Desktop / Web)
-    type: browser
-  - id: gateway
-    label: API Gateway (GCLB)
-    type: endpoint
-    icon: logos:google-cloud
-  - id: auth
-    label: Accounts & Auth (OAuth2 / JWT)
-    type: auth
-  - id: home
-    label: Home / Personalization Service
-    type: service
-  - id: bart
-    label: BaRT — Recommendations (ML Bandits)
-    type: service
-  - id: memcached
-    label: Memcached (Hot Home Cache)
-    type: cache
-    icon: logos:memcached
-  - id: bigtable
-    label: Bigtable — Listening History & Affinities
-    type: database
-    icon: logos:google-cloud
-  - id: catalog
-    label: Catalog & Licensing Service
-    type: service
-  - id: cassandra
-    label: Cassandra — Track Metadata
-    type: database
-    icon: logos:cassandra
-  - id: kafka
-    label: Kafka — Event Log (plays, impressions)
-    type: queue
-    icon: logos:kafka
-  - id: cdn
-    label: Audio CDN (Fastly / Google CDN)
-    type: external
-    icon: logos:fastly
-  - id: gcs
-    label: Google Cloud Storage (Ogg Vorbis files)
-    type: external
-    icon: logos:google-cloud
+    - id: user
+      label: Listener
+      type: actor
+    - id: client
+      label: Spotify Client (Mobile / Desktop / Web)
+      type: browser
+    - id: gateway
+      label: API Gateway (GCLB)
+      type: endpoint
+      icon: logos:google-cloud
+    - id: auth
+      label: Accounts & Auth (OAuth2 / JWT)
+      type: auth
+    - id: home
+      label: Home / Personalization Service
+      type: service
+    - id: bart
+      label: BaRT — Recommendations (ML Bandits)
+      type: service
+    - id: memcached
+      label: Memcached (Hot Home Cache)
+      type: cache
+      icon: logos:memcached
+    - id: bigtable
+      label: Bigtable — Listening History & Affinities
+      type: database
+      icon: logos:google-cloud
+    - id: catalog
+      label: Catalog & Licensing Service
+      type: service
+    - id: cassandra
+      label: Cassandra — Track Metadata
+      type: database
+      icon: logos:cassandra
+    - id: kafka
+      label: Kafka — Event Log (plays, impressions)
+      type: queue
+      icon: logos:kafka
+    - id: cdn
+      label: Audio CDN (Fastly / Google CDN)
+      type: external
+      icon: logos:fastly
+    - id: gcs
+      label: Google Cloud Storage (Ogg Vorbis files)
+      type: external
+      icon: logos:google-cloud
   steps:
-  - from: user
-    to: client
-    data: Tap "Spotify"
-  - from: client
-    to: gateway
-    data:
-      label: GET /home
-      fields:
-      - name: access_token
-        type: JWT
-      - name: user_id
-        type: spotify:uri
-      - name: country
-        type: ISO-3166
-  - from: gateway
-    to: auth
-    data: Validate token
-  - from: auth
-    to: gateway
-    data:
-      label: Identity + entitlements
-      fields:
-      - name: user_id
-        type: uuid
-      - name: product
-        type: free | premium
-      - name: market
-        type: string
-  - from: gateway
-    to: home
-    data: build_home(user_id, market)
-  - from: home
-    to: memcached
-    data: get_home(user_id)
-  - from: memcached
-    to: home
-    data:
-      label: cache MISS
-      color: '#ff6a6a'
-  - from: home
-    to: bart
-    data: rank_rows(user_id, context)
-  - from: bart
-    to: bigtable
-    data: listening_history(user_id)
-  - from: bigtable
-    to: bart
-    data:
-      label: history + affinities
-      fields:
-      - name: recent_tracks
-        type: list[TrackPlay]
-      - name: artist_affinities
-        type: map[artist, float]
-      - name: genre_taste
-        type: map[genre, float]
-  - from: bart
-    to: home
-    data:
-      label: ranked rows (DJ, Daily Mixes, Discover Weekly...)
-      fields:
-      - name: rows
-        type: list[Shelf]
-      - name: model_version
-        type: string
-  - from: home
-    to: memcached
-    data: write-through cache
-  - from: home
-    to: kafka
-    data:
-      label: impression event
-      fields:
-      - name: event
-        type: home_impression
-      - name: shelf_ids
-        type: list[id]
-  - from: home
-    to: gateway
-    data: home payload
-  - from: gateway
-    to: client
-    data:
-      label: 200 OK — Home JSON
-      fields:
-      - name: shelves
-        type: list[Shelf]
-      - name: image_urls
-        type: list[CDN URL]
-  - from: user
-    to: client
-    data: Tap a track
-  - from: client
-    to: gateway
-    data:
-      label: POST /play
-      fields:
-      - name: track_uri
-        type: spotify:track:...
-      - name: device_caps
-        type: '{codec, bitrate}'
-  - from: gateway
-    to: catalog
-    data: resolve_track(uri, market, product)
-  - from: catalog
-    to: cassandra
-    data: track_metadata(uri)
-  - from: cassandra
-    to: catalog
-    data:
-      label: metadata + licensing
-      fields:
-      - name: title_artist_album
-        type: TrackMeta
-      - name: available_markets
-        type: list[ISO]
-      - name: audio_file_id
-        type: uuid
-      - name: bitrate_ladder
-        type: list[kbps]
-  - from: catalog
-    to: gateway
-    data:
-      label: stream descriptor (signed)
-      fields:
-      - name: cdn_url
-        type: signed URL
-      - name: encryption_key
-        type: AES-128
-      - name: ttl_s
-        type: int
-  - from: gateway
-    to: client
-    data: stream manifest + key
-  - from: client
-    to: cdn
-    data:
-      label: GET /audio (HTTP range)
-      fields:
-      - name: byte_range
-        type: start-end
-      - name: bitrate
-        type: kbps
-  - from: cdn
-    to: gcs
-    data:
-      label: origin fetch (first time only)
-      color: '#ffd66a'
-  - from: gcs
-    to: cdn
-    data: Ogg Vorbis file
-  - from: cdn
-    to: client
-    data:
-      label: audio chunk (TLS, AES-decrypted client-side)
-      color: '#4aff7a'
-      fields:
-      - name: chunk
-        type: bytes
-      - name: duration_s
-        type: float
-  - from: client
-    to: kafka
-    data:
-      label: stream-start event
-      fields:
-      - name: track_uri
-        type: string
-      - name: source
-        type: home | search | radio
-      - name: ts
-        type: epoch_ms
-  - from: client
-    to: user
-    data: Music plays
+    - from: user
+      to: client
+      data: Tap "Spotify"
+    - from: client
+      to: gateway
+      data:
+        label: GET /home
+        fields:
+          - name: access_token
+            type: JWT
+          - name: user_id
+            type: spotify:uri
+          - name: country
+            type: ISO-3166
+    - from: gateway
+      to: auth
+      data: Validate token
+    - from: auth
+      to: gateway
+      data:
+        label: Identity + entitlements
+        fields:
+          - name: user_id
+            type: uuid
+          - name: product
+            type: free | premium
+          - name: market
+            type: string
+    - from: gateway
+      to: home
+      data: build_home(user_id, market)
+    - from: home
+      to: memcached
+      data: get_home(user_id)
+    - from: memcached
+      to: home
+      data:
+        label: cache MISS
+        color: "#ff6a6a"
+    - from: home
+      to: bart
+      data: rank_rows(user_id, context)
+    - from: bart
+      to: bigtable
+      data: listening_history(user_id)
+    - from: bigtable
+      to: bart
+      data:
+        label: history + affinities
+        fields:
+          - name: recent_tracks
+            type: list[TrackPlay]
+          - name: artist_affinities
+            type: map[artist, float]
+          - name: genre_taste
+            type: map[genre, float]
+    - from: bart
+      to: home
+      data:
+        label: ranked rows (DJ, Daily Mixes, Discover Weekly...)
+        fields:
+          - name: rows
+            type: list[Shelf]
+          - name: model_version
+            type: string
+    - from: home
+      to: memcached
+      data: write-through cache
+    - from: home
+      to: kafka
+      data:
+        label: impression event
+        fields:
+          - name: event
+            type: home_impression
+          - name: shelf_ids
+            type: list[id]
+    - from: home
+      to: gateway
+      data: home payload
+    - from: gateway
+      to: client
+      data:
+        label: 200 OK — Home JSON
+        fields:
+          - name: shelves
+            type: list[Shelf]
+          - name: image_urls
+            type: list[CDN URL]
+    - from: user
+      to: client
+      data: Tap a track
+    - from: client
+      to: gateway
+      data:
+        label: POST /play
+        fields:
+          - name: track_uri
+            type: spotify:track:...
+          - name: device_caps
+            type: "{codec, bitrate}"
+    - from: gateway
+      to: catalog
+      data: resolve_track(uri, market, product)
+    - from: catalog
+      to: cassandra
+      data: track_metadata(uri)
+    - from: cassandra
+      to: catalog
+      data:
+        label: metadata + licensing
+        fields:
+          - name: title_artist_album
+            type: TrackMeta
+          - name: available_markets
+            type: list[ISO]
+          - name: audio_file_id
+            type: uuid
+          - name: bitrate_ladder
+            type: list[kbps]
+    - from: catalog
+      to: gateway
+      data:
+        label: stream descriptor (signed)
+        fields:
+          - name: cdn_url
+            type: signed URL
+          - name: encryption_key
+            type: AES-128
+          - name: ttl_s
+            type: int
+    - from: gateway
+      to: client
+      data: stream manifest + key
+    - from: client
+      to: cdn
+      data:
+        label: GET /audio (HTTP range)
+        fields:
+          - name: byte_range
+            type: start-end
+          - name: bitrate
+            type: kbps
+    - from: cdn
+      to: gcs
+      data:
+        label: origin fetch (first time only)
+        color: "#ffd66a"
+    - from: gcs
+      to: cdn
+      data: Ogg Vorbis file
+    - from: cdn
+      to: client
+      data:
+        label: audio chunk (TLS, AES-decrypted client-side)
+        color: "#4aff7a"
+        fields:
+          - name: chunk
+            type: bytes
+          - name: duration_s
+            type: float
+    - from: client
+      to: kafka
+      data:
+        label: stream-start event
+        fields:
+          - name: track_uri
+            type: string
+          - name: source
+            type: home | search | radio
+          - name: ts
+            type: epoch_ms
+    - from: client
+      to: user
+      data: Music plays

--- a/examples/showcase/spotify.yaml
+++ b/examples/showcase/spotify.yaml
@@ -1,0 +1,229 @@
+meta:
+  title: Spotify — Open App to Streaming a Track
+  description: End-to-end flow of a Spotify session — auth, personalized home (BaRT), track lookup, and audio streaming via
+    the Spotify CDN backed by Google Cloud Storage.
+  path: system-design/spotify
+flow:
+  nodes:
+  - id: user
+    label: Listener
+    type: actor
+  - id: client
+    label: Spotify Client (Mobile / Desktop / Web)
+    type: browser
+  - id: gateway
+    label: API Gateway (GCLB)
+    type: endpoint
+    icon: logos:google-cloud
+  - id: auth
+    label: Accounts & Auth (OAuth2 / JWT)
+    type: auth
+  - id: home
+    label: Home / Personalization Service
+    type: service
+  - id: bart
+    label: BaRT — Recommendations (ML Bandits)
+    type: service
+  - id: memcached
+    label: Memcached (Hot Home Cache)
+    type: cache
+    icon: logos:memcached
+  - id: bigtable
+    label: Bigtable — Listening History & Affinities
+    type: database
+    icon: logos:google-cloud
+  - id: catalog
+    label: Catalog & Licensing Service
+    type: service
+  - id: cassandra
+    label: Cassandra — Track Metadata
+    type: database
+    icon: logos:cassandra
+  - id: kafka
+    label: Kafka — Event Log (plays, impressions)
+    type: queue
+    icon: logos:kafka
+  - id: cdn
+    label: Audio CDN (Fastly / Google CDN)
+    type: external
+    icon: logos:fastly
+  - id: gcs
+    label: Google Cloud Storage (Ogg Vorbis files)
+    type: external
+    icon: logos:google-cloud
+  steps:
+  - from: user
+    to: client
+    data: Tap "Spotify"
+  - from: client
+    to: gateway
+    data:
+      label: GET /home
+      fields:
+      - name: access_token
+        type: JWT
+      - name: user_id
+        type: spotify:uri
+      - name: country
+        type: ISO-3166
+  - from: gateway
+    to: auth
+    data: Validate token
+  - from: auth
+    to: gateway
+    data:
+      label: Identity + entitlements
+      fields:
+      - name: user_id
+        type: uuid
+      - name: product
+        type: free | premium
+      - name: market
+        type: string
+  - from: gateway
+    to: home
+    data: build_home(user_id, market)
+  - from: home
+    to: memcached
+    data: get_home(user_id)
+  - from: memcached
+    to: home
+    data:
+      label: cache MISS
+      color: '#ff6a6a'
+  - from: home
+    to: bart
+    data: rank_rows(user_id, context)
+  - from: bart
+    to: bigtable
+    data: listening_history(user_id)
+  - from: bigtable
+    to: bart
+    data:
+      label: history + affinities
+      fields:
+      - name: recent_tracks
+        type: list[TrackPlay]
+      - name: artist_affinities
+        type: map[artist, float]
+      - name: genre_taste
+        type: map[genre, float]
+  - from: bart
+    to: home
+    data:
+      label: ranked rows (DJ, Daily Mixes, Discover Weekly...)
+      fields:
+      - name: rows
+        type: list[Shelf]
+      - name: model_version
+        type: string
+  - from: home
+    to: memcached
+    data: write-through cache
+  - from: home
+    to: kafka
+    data:
+      label: impression event
+      fields:
+      - name: event
+        type: home_impression
+      - name: shelf_ids
+        type: list[id]
+  - from: home
+    to: gateway
+    data: home payload
+  - from: gateway
+    to: client
+    data:
+      label: 200 OK — Home JSON
+      fields:
+      - name: shelves
+        type: list[Shelf]
+      - name: image_urls
+        type: list[CDN URL]
+  - from: user
+    to: client
+    data: Tap a track
+  - from: client
+    to: gateway
+    data:
+      label: POST /play
+      fields:
+      - name: track_uri
+        type: spotify:track:...
+      - name: device_caps
+        type: '{codec, bitrate}'
+  - from: gateway
+    to: catalog
+    data: resolve_track(uri, market, product)
+  - from: catalog
+    to: cassandra
+    data: track_metadata(uri)
+  - from: cassandra
+    to: catalog
+    data:
+      label: metadata + licensing
+      fields:
+      - name: title_artist_album
+        type: TrackMeta
+      - name: available_markets
+        type: list[ISO]
+      - name: audio_file_id
+        type: uuid
+      - name: bitrate_ladder
+        type: list[kbps]
+  - from: catalog
+    to: gateway
+    data:
+      label: stream descriptor (signed)
+      fields:
+      - name: cdn_url
+        type: signed URL
+      - name: encryption_key
+        type: AES-128
+      - name: ttl_s
+        type: int
+  - from: gateway
+    to: client
+    data: stream manifest + key
+  - from: client
+    to: cdn
+    data:
+      label: GET /audio (HTTP range)
+      fields:
+      - name: byte_range
+        type: start-end
+      - name: bitrate
+        type: kbps
+  - from: cdn
+    to: gcs
+    data:
+      label: origin fetch (first time only)
+      color: '#ffd66a'
+  - from: gcs
+    to: cdn
+    data: Ogg Vorbis file
+  - from: cdn
+    to: client
+    data:
+      label: audio chunk (TLS, AES-decrypted client-side)
+      color: '#4aff7a'
+      fields:
+      - name: chunk
+        type: bytes
+      - name: duration_s
+        type: float
+  - from: client
+    to: kafka
+    data:
+      label: stream-start event
+      fields:
+      - name: track_uri
+        type: string
+      - name: source
+        type: home | search | radio
+      - name: ts
+        type: epoch_ms
+  - from: client
+    to: user
+    data: Music plays


### PR DESCRIPTION
## Summary

Two end-to-end system-design walkthroughs added under `examples/showcase/`:

- **`netflix.yaml`** — Netflix Open Connect playback: viewer → Netflix client → Zuul gateway → identity → homepage + recommendations (EVCache + Cassandra) → playback API → Open Connect steering → S3 master assets → Open Connect Appliance at the ISP edge.
- **`spotify.yaml`** — Spotify track playback: listener → Spotify client → GCLB → OAuth2/JWT auth → home + BaRT bandits → Bigtable affinities → catalog + Cassandra metadata → audio CDN (Fastly / Google CDN) → Google Cloud Storage origin.

Both flows include verbose plain-English step `data` labels, typed fields on the request/response steps, and parallel fan-outs where the real systems do work concurrently (cache check vs. recommender pull). The second actor in each flow — the client app — is modelled as `type: browser` to surface the user-facing surface in the rendered diagram.

## Test plan

- [x] `openhop validate examples/showcase/netflix.yaml` — `✓ Valid flow`
- [x] `openhop validate examples/showcase/spotify.yaml` — `✓ Valid flow`
- [ ] Open each in the local playground (`npx openhop demo`) and watch the animation through one playthrough.

## Scope

- Bundled in the npm tarball; seeded by the local server's example seeder (stable ids `example-netflix` / `example-spotify`).
- **Not** pinned in the Pages sidebar — per author's choice. Wiring into `web/`'s sidebar bundle is a follow-up if/when desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added Netflix playback flow example showcasing authentication, personalized recommendations, adaptive streaming steering, and manifest/DRM delivery.
* Added Spotify streaming flow example demonstrating user authentication, home personalization, track resolution, and CDN-based audio delivery with event tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/153)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->