### PR TITLE
feat(pages): pin Netflix and Spotify in the Pages sidebar

### DIFF
--- a/packages/web/src/lib/example-flows.ts
+++ b/packages/web/src/lib/example-flows.ts
@@ -23,6 +23,8 @@ import showcaseVercelAiSdk from '../../../../examples/showcase/vercel-ai-sdk.yam
 import showcaseBrowserUse from '../../../../examples/showcase/browser-use.yaml?raw'
 import showcaseAuthjsOauth from '../../../../examples/showcase/authjs-oauth.yaml?raw'
 import showcaseOpenclaw from '../../../../examples/showcase/openclaw.yaml?raw'
+import showcaseNetflix from '../../../../examples/showcase/netflix.yaml?raw'
+import showcaseSpotify from '../../../../examples/showcase/spotify.yaml?raw'
 
 export interface ExampleFlow {
   id: string
@@ -124,5 +126,19 @@ export const EXAMPLE_FLOWS: ExampleFlow[] = [
     description: 'Agent loop — prompt → skill router → tool → tool response → reply.',
     path: SHOWCASE,
     yaml: showcaseOpenclaw,
+  },
+  {
+    id: 'showcase-netflix',
+    title: 'Netflix',
+    description: 'Open App → home → playback → Open Connect CDN at the ISP edge.',
+    path: SHOWCASE,
+    yaml: showcaseNetflix,
+  },
+  {
+    id: 'showcase-spotify',
+    title: 'Spotify',
+    description: 'Open App → BaRT recommendations → catalog → audio CDN backed by GCS.',
+    path: SHOWCASE,
+    yaml: showcaseSpotify,
   },
 ]


### PR DESCRIPTION
## Summary

Follow-up to #153. The two showcase YAMLs landed in `examples/showcase/` but weren't pinned in the Pages bundle, so they didn't appear at https://naorsabag.github.io/openhop/.

Adds the two missing `?raw` imports and `EXAMPLE_FLOWS` entries to `packages/web/src/lib/example-flows.ts`:

- `showcase-netflix` — "Netflix"
- `showcase-spotify` — "Spotify"

Both sit at the end of the showcase block, after `OpenClaw`.

## Test plan

- [x] `npm run typecheck` (web) — pass
- [x] `npm run lint` (web) — pass (pre-existing warnings only)
- [x] `prettier --check` — clean
- [x] `npm run build` (web) — ✓ built in 6.67s
- [ ] After deploy, verify both flows appear in the sidebar at https://naorsabag.github.io/openhop/

🤖 Generated with [Claude Code](https://claude.com/claude-code)