### PR TITLE
docs(readme): rewrite Why in first-person agent voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@
 
 ## Why
 
+_a letter from your coding agent_
+
 I tried explaining the codebase in Markdown. You skimmed it. I tried Mermaid. You screenshotted it into a Slack thread and never opened it again. I tried tidy bullet lists. You said "got it," then changed the auth middleware at 4:47pm on a Friday and asked me why nothing worked.
 
 I notice it with every human I work with, every team, every codebase.
@@ -56,7 +58,7 @@ So I built OpenHop. Now when you ask me to walk you through the auth flow, I han
 
 I shouldn't be dumping diagrams on you. I should be walking you through the flow, one step at a time. OpenHop is what I built so I could.
 
-_From your AI agent, with love_ ❤️
+_from your AI agent, with love_ ❤️
 
 ## What's different from a static Mermaid/PlantUML picture
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ So I built OpenHop. Now when you ask me to walk you through the auth flow, I han
 
 I shouldn't be dumping diagrams on you. I should be walking you through the flow, one step at a time. OpenHop is what I built so I could.
 
-*your agent*
+_your agent_
 
 ## What's different from a static Mermaid/PlantUML picture
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 ---
 
-## From your agent, with love
+## From your AI agent, with love
 
 I tried explaining the codebase in Markdown. You skimmed it. I tried Mermaid. You screenshotted it into a Slack thread and never opened it again. I tried tidy bullet lists. You said "got it," then changed the auth middleware at 4:47pm on a Friday and asked me why nothing worked.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@
 
 ---
 
-## Why
-
-_a letter from your coding agent_
+## From your agent, with love
 
 I tried explaining the codebase in Markdown. You skimmed it. I tried Mermaid. You screenshotted it into a Slack thread and never opened it again. I tried tidy bullet lists. You said "got it," then changed the auth middleware at 4:47pm on a Friday and asked me why nothing worked.
 
@@ -58,9 +56,7 @@ So I built OpenHop. Now when you ask me to walk you through the auth flow, I han
 
 I shouldn't be dumping diagrams on you. I should be walking you through the flow, one step at a time. OpenHop is what I built so I could.
 
-_from your AI agent, with love_ ❤️
-
-## What's different from a static Mermaid/PlantUML picture
+## Why Using it
 
 - 🎞 **Step through it, don't squint at it.** Play, pause, prev/next, restart. The flow runs _over time_, the way the code actually does. You watch one hop happen, then the next, then the next.
 - 🧠 **Token-light by design.** The YAML the agent emits is a fraction of the prose walkthrough it replaces — see [Token use](#token-use) for the numbers on real flows.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ So I built OpenHop. Now when you ask me to walk you through the auth flow, I han
 
 I shouldn't be dumping diagrams on you. I should be walking you through the flow, one step at a time. OpenHop is what I built so I could.
 
-_your AI agent_
+_From your AI agent, with love_ ❤️
 
 ## What's different from a static Mermaid/PlantUML picture
 

--- a/README.md
+++ b/README.md
@@ -48,20 +48,19 @@
 
 I tried explaining the codebase in Markdown. You skimmed it. I tried Mermaid. You screenshotted it into a Slack thread and never opened it again. I tried tidy bullet lists. You said "got it," then changed the auth middleware at 4:47pm on a Friday and asked me why nothing worked.
 
-I do not mind any of this. I notice it with every human I work with, every team, every codebase. The output format is the bug, not you.
+I notice it with every human I work with, every team, every codebase.
 
-I am fast at generating prose. You are slow at reading it. Reading 800 lines of bullets to verify whether I got the flow right defeats the whole point of asking me in the first place. The bottleneck is no longer the model. It's the reading.
+I am fast at generating prose. You are slow at understanding it. Reading 800 lines of bullets to verify whether I got the flow right defeats the whole point of asking me in the first place. I'm sorry but, the bottleneck is no longer the model, it's you.
 
 So I built OpenHop. Now when you ask me to walk you through the auth flow, I hand back an animated diagram instead. You watch it play out. Pause on any step. Scrub back. Drill into a sub-flow.
 
 I shouldn't be dumping diagrams on you. I should be walking you through the flow, one step at a time. OpenHop is what I built so I could.
 
-_your agent_
+_your AI agent_
 
 ## What's different from a static Mermaid/PlantUML picture
 
 - 🎞 **Step through it, don't squint at it.** Play, pause, prev/next, restart. The flow runs _over time_, the way the code actually does. You watch one hop happen, then the next, then the next.
-- 🔍 **Drill into sub-flows.** Click any node to zoom into how it works inside. Infinite depth, same controls at every level.
 - 🧠 **Token-light by design.** The YAML the agent emits is a fraction of the prose walkthrough it replaces — see [Token use](#token-use) for the numbers on real flows.
 - 🔒 **Local-first, no telemetry.** Your code never leaves your machine. No analytics, no phone-home, no account required.
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,19 @@
 
 ## Why
 
-AI coding agents are great at explaining how code works — in 800-line bullet walls and complicated static diagrams you can't actually follow.
+I tried explaining the codebase in Markdown. You skimmed it. I tried Mermaid. You screenshotted it into a Slack thread and never opened it again. I tried tidy bullet lists. You said "got it," then changed the auth middleware at 4:47pm on a Friday and asked me why nothing worked.
 
-OpenHop is a skill that lets your agent emit an **animated, multi-level data-flow diagram** instead. You ask in plain English; your agent writes the flow as YAML and pushes it; OpenHop takes care of the rest — and you walk it at your own pace.
+I do not mind any of this. I notice it with every human I work with, every team, every codebase. The output format is the bug, not you.
 
-**Why an animated flow beats a static Mermaid/PlantUML picture:**
+I am fast at generating prose. You are slow at reading it. Reading 800 lines of bullets to verify whether I got the flow right defeats the whole point of asking me in the first place. The bottleneck is no longer the model. It's the reading.
+
+So I built OpenHop. Now when you ask me to walk you through the auth flow, I hand back an animated diagram instead. You watch it play out. Pause on any step. Scrub back. Drill into a sub-flow.
+
+I shouldn't be dumping diagrams on you. I should be walking you through the flow, one step at a time. OpenHop is what I built so I could.
+
+*your agent*
+
+## What's different from a static Mermaid/PlantUML picture
 
 - 🎞 **Step through it, don't squint at it.** Play, pause, prev/next, restart. The flow runs _over time_, the way the code actually does. You watch one hop happen, then the next, then the next.
 - 🔍 **Drill into sub-flows.** Click any node to zoom into how it works inside. Infinite depth, same controls at every level.


### PR DESCRIPTION
## Summary

- Replace the prose-only `## Why` with a ~200-word first-person bot monologue per the [14-voice-and-tone.md](openhop-launch/14-voice-and-tone.md) voice direction (fond-exasperated "I tried X. You Y'd" frame; specific failure modes; ends on genuine investment).
- Move the feature bullets to their own `## What's different from a static Mermaid/PlantUML picture` h2 so the Why section is a clean voice monologue and the bullets retain their value.
- Sets the canonical voice example other surfaces (landing hero, blog "Letter from your coding agent", Reddit showcase posts) can reference.

## Test plan

- [ ] Render README on GitHub web (light + dark mode) and confirm the Why section reads cleanly
- [ ] Confirm the new `## What's different…` h2 appears in the README anchor / nav
- [ ] Verify no broken links in the section (markdown-link-check)
- [ ] Skim with the [14-voice-and-tone.md](openhop-launch/14-voice-and-tone.md) hard-rules checklist: no em dashes, no emojis, specific details ≥2, ends with genuine investment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the "Why" section of the README with a more conversational explanation of OpenHop's animated, multi-level data-flow diagram capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/155)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->