### PR TITLE
chore: bump @openhop/server @openhop/web openhop to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-15
+
+### Added
+
+- `examples/showcase/netflix.yaml` and `examples/showcase/spotify.yaml`: two new hand-authored system-design flows joining the showcase set. Both ship inside the `@openhop/server` npm tarball and are seeded on first startup alongside the existing showcase flows.
+- Pages playground sidebar: Netflix and Spotify pinned next to the existing showcase entries so visitors land on them directly from `https://naorsabag.github.io/openhop/`.
+
+### Changed
+
+- README "How it works": minor structural cleanup (HTML refactor, blank line after the heading) and a first-person agent-voice rewrite of the Why section. No package-level behavior change — repository docs only.
+- `skills/openhop/SKILL.md`: trigger description broadened so the gate fires on architecture / idea / proposed-solution prompts in addition to systems and code. Ships with the CLI tarball via `prepack`.
+
 ## [0.3.1] - 2026-05-13
 
 ### Added
@@ -104,7 +116,8 @@ Initial public release.
 - GitHub Actions CI: lint, format check, typecheck, build, test, coverage, npm audit, gitleaks, CodeQL.
 - Issue and pull request templates; Dependabot configuration.
 
-[Unreleased]: https://github.com/naorsabag/OpenHop/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/naorsabag/OpenHop/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/naorsabag/OpenHop/releases/tag/v0.3.2
 [0.3.1]: https://github.com/naorsabag/OpenHop/releases/tag/v0.3.1
 [0.3.0]: https://github.com/naorsabag/OpenHop/releases/tag/v0.3.0
 [0.2.0]: https://github.com/naorsabag/OpenHop/releases/tag/v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -7716,13 +7716,13 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.4.4",
         "@fastify/static": "^9.1.3",
-        "@openhop/server": "0.3.1",
-        "@openhop/web": "0.3.1",
+        "@openhop/server": "0.3.2",
+        "@openhop/web": "0.3.2",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
         "yaml": "^2.8.4",
@@ -8202,7 +8202,7 @@
     },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
@@ -8721,7 +8721,7 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -46,8 +46,8 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.3.1",
-    "@openhop/web": "0.3.1",
+    "@openhop/server": "0.3.2",
+    "@openhop/web": "0.3.2",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release for the two new showcase flows (#153, #154) plus the README + skill polish merged since 0.3.1.

**Versions:**
- `@openhop/server`  0.3.1 → 0.3.2
- `@openhop/web`     0.3.1 → 0.3.2
- `openhop` (CLI)    0.3.1 → 0.3.2

**What's in this release**

- **`@openhop/server`** ships two new showcase yamls (`examples/showcase/netflix.yaml`, `examples/showcase/spotify.yaml`) inside its `examples/` tree, so they get seeded on first startup alongside the existing showcase set.
- **`@openhop/web`** Pages sidebar pins Netflix + Spotify next to the rest of the showcase entries.
- **`openhop` (CLI)** picks up the broadened skill description (`skills/openhop/SKILL.md` — trigger gate now covers architecture / idea / proposed-solution prompts) via `prepack`, and keeps `@openhop/server` / `@openhop/web` deps in lockstep.

No breaking changes — additive only.

**Commits since v0.3.1**

- 00a6bff feat(pages): pin Netflix and Spotify in the Pages sidebar (#154)
- 3d97dae examples(showcase): add Netflix and Spotify system-design flows (#153)
- 448d28f docs(contributing): require AI agents to tag commits with [bot-tag-7f3a] (#151)
- 8447b98 docs(skill): broaden description so the trigger gate is generic (#150)
- 86ac980 fix(readme): add blank line after "## How it works" heading (#152)
- b98bead Refactor README.md by cleaning up HTML structure
- 1ae4b4e docs(readme): rewrite Why in first-person agent voice (#155)

## Test plan

- [ ] CI green
- [ ] After merge: tag `v0.3.2`, publish `@openhop/server`, `@openhop/web`, `openhop` to npm
- [ ] `npx openhop@0.3.2 demo` shows netflix + spotify in the seeded sidebar on a fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)