### PR TITLE
chore: bump @openhop/server @openhop/web openhop to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-05-17
+
 ### Added
 
 - Local app (`packages/web/src/App.tsx`): "Share" button in the header that copies a self-contained share URL of the currently-loaded flow to the clipboard. The URL points at the public Pages playground (`https://naorsabag.github.io/openhop/#<encoded>`), reusing the same v1 fragment format the playground already decodes — so a link copied from `npm run dev` opens cleanly for anyone offsite without needing a local server. New `buildPagesShareUrl` helper in `lib/share-url.ts` centralizes the destination so future renames stay in one place.
+- Claude Code plugin bundle (`.claude-plugin/` + `commands/`): OpenHop now ships as a single-plugin marketplace from `naorsabag/openhop` directly. Install with `/plugin marketplace add naorsabag/openhop` then `/plugin install openhop@openhop`. Three slash commands ship inside: `/openhop:openhop-flow <prompt>`, `/openhop:openhop-list`, and `/openhop:openhop-preview <path> [--push]`. The skill itself stays at `skills/openhop/SKILL.md` and is auto-discovered — these files are repository-level only and are not bundled into the npm tarballs.
+- Pages playground SEO (`packages/web/`): crawler- and AI-search-friendly head/body for the GitHub Pages deploy. `index.html` now ships a descriptive `<title>`, meta description, Open Graph + Twitter Card tags, `<link rel="canonical">`, schema.org JSON-LD, and static landing content for the initial crawl pass. New `public/robots.txt` and `public/sitemap.xml`. `public/social-preview.png` is copied from `.github/` so Vite emits it under the Pages base path and the OG/Twitter cards resolve.
 
 ## [0.3.2] - 2026-05-15
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7716,13 +7716,13 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.4.4",
         "@fastify/static": "^9.1.3",
-        "@openhop/server": "0.3.2",
-        "@openhop/web": "0.3.2",
+        "@openhop/server": "0.3.3",
+        "@openhop/web": "0.3.3",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
         "yaml": "^2.8.4",
@@ -8202,7 +8202,7 @@
     },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
@@ -8721,7 +8721,7 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -46,8 +46,8 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.3.2",
-    "@openhop/web": "0.3.2",
+    "@openhop/server": "0.3.3",
+    "@openhop/web": "0.3.3",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.8.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release covering everything merged since 0.3.2.

**Versions:**
- `@openhop/server`  0.3.2 → 0.3.3
- `@openhop/web`     0.3.2 → 0.3.3
- `openhop` (CLI)    0.3.2 → 0.3.3

**What's in this release**

- **`@openhop/web`** picks up two unrelated user-facing additions:
  - **#160** — new **Share** button in the local-app header that copies a self-contained Pages-playground URL (`https://naorsabag.github.io/openhop/#<encoded>`) of the current flow to the clipboard. New `buildPagesShareUrl` helper centralises the destination.
  - **#157** — Pages SEO / AI-search wiring: `robots.txt`, `sitemap.xml`, `social-preview.png`, Open Graph / Twitter Card meta, schema.org JSON-LD, and crawler-visible static landing content in `index.html`. Closes the gaps Google's AI Optimization Guide flagged on `https://naorsabag.github.io/openhop/`.
- **`openhop` (CLI)** is bumped to keep the `@openhop/server` / `@openhop/web` deps in lockstep with the other published packages. `skills/` payload is unchanged this release.
- **`@openhop/server`** has no behavioural delta — bump is lockstep-only so the version-diff publisher tags all three together.

Repository-only (not in any npm tarball, but worth flagging because the install instructions are user-facing):
- **#158** — single-plugin Claude Code marketplace shipped under `.claude-plugin/` + `commands/`. Install with:
  ```
  /plugin marketplace add naorsabag/openhop
  /plugin install openhop@openhop
  ```
  Ships three slash commands (`/openhop:openhop-flow`, `/openhop:openhop-list`, `/openhop:openhop-preview`). The skill stays at `skills/openhop/SKILL.md` and is auto-discovered.

No breaking changes — additive only.

**Commits since v0.3.2**

- 4742214 feat(web): share button in local app header (#160)
- 05ce55d feat(plugin): add Claude Code plugin bundle to monorepo (#158)
- 9408950 seo(pages): wire crawler-visible head/body + robots/sitemap for AI search (#157)

## Test plan

- [x] `npm --workspace packages/web run build` — clean
- [x] `npm --workspace packages/server run build` — clean
- [x] `npm --workspace packages/cli run build` — clean
- [x] `npm --workspace packages/web test` — 48/48 pass
- [x] `npm --workspace packages/server test` — 20/20 pass
- [x] `npx prettier --check` on touched files — clean
- [ ] CI green
- [ ] After merge: tag `v0.3.3`, publish `@openhop/server`, `@openhop/web`, `openhop` to npm
- [ ] `npx openhop@0.3.3 demo` — open the local app, click **Share** on a seeded flow → URL pastes into a fresh browser tab and the playground renders the same flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)