### PR TITLE
ci(publish): migrate to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,41 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: npm
 
+      # OIDC trusted publishing needs npm >= 11.5.1; Node 22 LTS bundles
+      # npm 10.x, so upgrade globally before `npm ci` so all later npm
+      # invocations (including publish) use the new version.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - run: npm ci
+
+      # Preflight for OIDC trusted publishing. There is no long-lived
+      # NPM_TOKEN anymore — each run mints a short-lived OIDC token from
+      # GitHub, which npm exchanges with the registry. The two things that
+      # can break:
+      #   1. The workflow lost `permissions: id-token: write` (no OIDC
+      #      endpoint exposed -> ACTIONS_ID_TOKEN_REQUEST_URL is unset).
+      #   2. npm CLI is too old to know how to do the exchange.
+      # Both surface here, instead of as an opaque registry rejection
+      # halfway through a publish.
+      #
+      # To (re)configure the npm side: npmjs.com -> each package
+      # (@openhop/server, @openhop/web, openhop) -> Settings -> Trusted
+      # Publisher -> GitHub Actions, with repo `naorsabag/openhop` and
+      # workflow `publish.yml`.
+      - name: Verify OIDC trusted publishing is wired up
+        run: |
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "::error::OIDC unavailable — workflow is missing 'permissions: id-token: write'."
+            exit 1
+          fi
+          npm_version=$(npm --version)
+          npm_major=${npm_version%%.*}
+          if [ "$npm_major" -lt 11 ]; then
+            echo "::error::npm $npm_version is too old for OIDC trusted publishing — need >=11.5.1."
+            exit 1
+          fi
+          echo "::notice::OIDC ready, npm $npm_version"
 
       - name: Resolve target versions
         id: versions
@@ -89,25 +123,25 @@ jobs:
         id: publish_server
         if: steps.server_status.outputs.publish == 'true'
         working-directory: packages/server
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # No env: OIDC handles auth via id-token. --provenance attaches
+        # a signed build attestation (recommended with trusted publishing).
+        run: npm publish --access public --provenance
 
       - name: Publish @openhop/web
         id: publish_web
         if: steps.web_status.outputs.publish == 'true'
         working-directory: packages/web
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # No env: OIDC handles auth via id-token. --provenance attaches
+        # a signed build attestation (recommended with trusted publishing).
+        run: npm publish --access public --provenance
 
       - name: Publish openhop CLI
         id: publish_cli
         if: steps.cli_status.outputs.publish == 'true'
         working-directory: packages/cli
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # No env: OIDC handles auth via id-token. --provenance attaches
+        # a signed build attestation (recommended with trusted publishing).
+        run: npm publish --access public --provenance
 
       # Tag + GitHub Release whenever ANY publish happened. Tag scheme
       # branches on what actually shipped so a one-package bump can't

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
       # npm 10.x, so upgrade globally before `npm ci` so all later npm
       # invocations (including publish) use the new version.
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - run: npm ci
 
@@ -71,8 +71,9 @@ jobs:
             exit 1
           fi
           npm_version=$(npm --version)
-          npm_major=${npm_version%%.*}
-          if [ "$npm_major" -lt 11 ]; then
+          # `sort -V -C` returns success iff the input is already version-sorted,
+          # so feeding "11.5.1\n$npm_version" succeeds iff $npm_version >= 11.5.1.
+          if ! printf '%s\n' "11.5.1" "$npm_version" | sort -V -C; then
             echo "::error::npm $npm_version is too old for OIDC trusted publishing — need >=11.5.1."
             exit 1
           fi
@@ -123,25 +124,28 @@ jobs:
         id: publish_server
         if: steps.server_status.outputs.publish == 'true'
         working-directory: packages/server
-        # No env: OIDC handles auth via id-token. --provenance attaches
-        # a signed build attestation (recommended with trusted publishing).
-        run: npm publish --access public --provenance
+        # No env: OIDC handles auth via id-token. npm >=11.5.1 also
+        # auto-attaches a signed provenance attestation on trusted-publishing
+        # runs — no --provenance flag needed.
+        run: npm publish --access public
 
       - name: Publish @openhop/web
         id: publish_web
         if: steps.web_status.outputs.publish == 'true'
         working-directory: packages/web
-        # No env: OIDC handles auth via id-token. --provenance attaches
-        # a signed build attestation (recommended with trusted publishing).
-        run: npm publish --access public --provenance
+        # No env: OIDC handles auth via id-token. npm >=11.5.1 also
+        # auto-attaches a signed provenance attestation on trusted-publishing
+        # runs — no --provenance flag needed.
+        run: npm publish --access public
 
       - name: Publish openhop CLI
         id: publish_cli
         if: steps.cli_status.outputs.publish == 'true'
         working-directory: packages/cli
-        # No env: OIDC handles auth via id-token. --provenance attaches
-        # a signed build attestation (recommended with trusted publishing).
-        run: npm publish --access public --provenance
+        # No env: OIDC handles auth via id-token. npm >=11.5.1 also
+        # auto-attaches a signed provenance attestation on trusted-publishing
+        # runs — no --provenance flag needed.
+        run: npm publish --access public
 
       # Tag + GitHub Release whenever ANY publish happened. Tag scheme
       # branches on what actually shipped so a one-package bump can't


### PR DESCRIPTION
## Why

The `0.3.3` publish ([run 25984620955](https://github.com/naorsabag/openhop/actions/runs/25984620955)) failed because the long-lived `NPM_TOKEN` repo secret no longer has publish rights on the `@openhop` scope. npm masks scoped-package permission failures as `404 Not Found - PUT https://registry.npmjs.org/@openhop%2fserver`, which is what surfaced.

npm now caps publish tokens at 90 days, so even with a fresh rotation we'd be back here every quarter. **Trusted Publishing** fixes this class of failure permanently: no stored token, each run mints a short-lived OIDC token from GitHub, npm verifies it against per-package "Trusted Publisher" rules.

## What this PR does

- Upgrades npm to `^11.5.1` (Node 22 LTS ships 10.x, which predates OIDC publishing in the CLI; pin is bounded so a future major can't break us silently).
- Adds an OIDC-readiness preflight that fails fast and points at the runbook if either `permissions: id-token: write` got dropped from the workflow or npm somehow isn't new enough. Uses a `sort -V -C` semver-correct gate (≥ 11.5.1, not just major ≥ 11).
- Drops `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from all three publish steps. npm auto-detects the GitHub OIDC context.
- Leaves provenance enabled implicitly — npm ≥ 11.5.1 auto-attaches signed provenance attestations on trusted-publishing runs, so no `--provenance` flag is needed.

## Out-of-band setup (already done)

For each of `@openhop/server`, `@openhop/web`, `openhop` on npmjs.com → Settings → Trusted Publisher → GitHub Actions:
- Organization or user: `naorsabag`
- Repository: `openhop`
- Workflow filename: `publish.yml`
- Environment: (blank)

## Test plan

- [ ] Merge this PR.
- [ ] Re-run [the failed 0.3.3 publish workflow](https://github.com/naorsabag/openhop/actions/runs/25984620955) (or merge an empty bump). Expect: `Verify OIDC trusted publishing is wired up` prints `OIDC ready, npm <version>`, and the three publishes go through with provenance attestations visible on each package's npmjs.com page.
- [ ] After a green run, delete the now-unused `NPM_TOKEN` secret from repo Settings → Secrets and variables → Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)