### PR TITLE
ci(publish): use npx for npm publish, drop broken in-place npm self-upgrade

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,23 +42,16 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: npm
 
-      # OIDC trusted publishing needs npm >= 11.5.1; Node 22 LTS bundles
-      # npm 10.x, so upgrade globally before `npm ci` so all later npm
-      # invocations (including publish) use the new version.
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@^11.5.1
-
       - run: npm ci
 
       # Preflight for OIDC trusted publishing. There is no long-lived
       # NPM_TOKEN anymore — each run mints a short-lived OIDC token from
-      # GitHub, which npm exchanges with the registry. The two things that
-      # can break:
-      #   1. The workflow lost `permissions: id-token: write` (no OIDC
-      #      endpoint exposed -> ACTIONS_ID_TOKEN_REQUEST_URL is unset).
-      #   2. npm CLI is too old to know how to do the exchange.
-      # Both surface here, instead of as an opaque registry rejection
-      # halfway through a publish.
+      # GitHub, which npm exchanges with the registry. The one thing that
+      # can break unannounced is the workflow losing `id-token: write`
+      # permission (ACTIONS_ID_TOKEN_REQUEST_URL becomes unset). The npm
+      # version requirement (>=11.5.1) is enforced at the publish step
+      # itself via the `npx -y npm@^11.5.1` specifier, so it does not
+      # need a separate preflight check here.
       #
       # To (re)configure the npm side: npmjs.com -> each package
       # (@openhop/server, @openhop/web, openhop) -> Settings -> Trusted
@@ -70,14 +63,7 @@ jobs:
             echo "::error::OIDC unavailable — workflow is missing 'permissions: id-token: write'."
             exit 1
           fi
-          npm_version=$(npm --version)
-          # `sort -V -C` returns success iff the input is already version-sorted,
-          # so feeding "11.5.1\n$npm_version" succeeds iff $npm_version >= 11.5.1.
-          if ! printf '%s\n' "11.5.1" "$npm_version" | sort -V -C; then
-            echo "::error::npm $npm_version is too old for OIDC trusted publishing — need >=11.5.1."
-            exit 1
-          fi
-          echo "::notice::OIDC ready, npm $npm_version"
+          echo "::notice::OIDC permission ready"
 
       - name: Resolve target versions
         id: versions
@@ -124,28 +110,37 @@ jobs:
         id: publish_server
         if: steps.server_status.outputs.publish == 'true'
         working-directory: packages/server
-        # No env: OIDC handles auth via id-token. npm >=11.5.1 also
-        # auto-attaches a signed provenance attestation on trusted-publishing
-        # runs — no --provenance flag needed.
-        run: npm publish --access public
+        # No env: OIDC handles auth via id-token. We invoke npm via
+        # `npx -y npm@^11.5.1` so we get an OIDC-capable npm without
+        # globally upgrading the system one (the in-place upgrade has a
+        # well-known MODULE_NOT_FOUND bug with arborist/promise-retry).
+        # `-y` accepts the install prompt; npx caches after the first
+        # call so the next two publish steps reuse it.
+        run: npx -y npm@^11.5.1 publish --access public
 
       - name: Publish @openhop/web
         id: publish_web
         if: steps.web_status.outputs.publish == 'true'
         working-directory: packages/web
-        # No env: OIDC handles auth via id-token. npm >=11.5.1 also
-        # auto-attaches a signed provenance attestation on trusted-publishing
-        # runs — no --provenance flag needed.
-        run: npm publish --access public
+        # No env: OIDC handles auth via id-token. We invoke npm via
+        # `npx -y npm@^11.5.1` so we get an OIDC-capable npm without
+        # globally upgrading the system one (the in-place upgrade has a
+        # well-known MODULE_NOT_FOUND bug with arborist/promise-retry).
+        # `-y` accepts the install prompt; npx caches after the first
+        # call so the next two publish steps reuse it.
+        run: npx -y npm@^11.5.1 publish --access public
 
       - name: Publish openhop CLI
         id: publish_cli
         if: steps.cli_status.outputs.publish == 'true'
         working-directory: packages/cli
-        # No env: OIDC handles auth via id-token. npm >=11.5.1 also
-        # auto-attaches a signed provenance attestation on trusted-publishing
-        # runs — no --provenance flag needed.
-        run: npm publish --access public
+        # No env: OIDC handles auth via id-token. We invoke npm via
+        # `npx -y npm@^11.5.1` so we get an OIDC-capable npm without
+        # globally upgrading the system one (the in-place upgrade has a
+        # well-known MODULE_NOT_FOUND bug with arborist/promise-retry).
+        # `-y` accepts the install prompt; npx caches after the first
+        # call so the next two publish steps reuse it.
+        run: npx -y npm@^11.5.1 publish --access public
 
       # Tag + GitHub Release whenever ANY publish happened. Tag scheme
       # branches on what actually shipped so a one-package bump can't


### PR DESCRIPTION
## Follow-up to #162

The OIDC migration landed but the first publish run [25986313074](https://github.com/naorsabag/openhop/actions/runs/25986313074) failed at the new \`Upgrade npm for OIDC trusted publishing\` step:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
\`\`\`

This is the well-known npm in-place self-upgrade bug — \`npm install -g npm\` replaces \`/opt/hostedtoolcache/.../node_modules/npm/\` while npm is still executing out of it, so arborist's mid-flight \`require('promise-retry')\` blows up as the file is overwritten. Hits any major-version self-upgrade on GHA's Ubuntu runners; not specific to the \`^11.5.1\` pin.

## Fix

Don't upgrade the system npm at all. Invoke npm 11.5.1+ via \`npx -y npm@^11.5.1\` from each publish step. npx fetches npm 11.x into its cache and runs it as a one-shot — the system npm 10.x stays untouched, so the in-place self-clobber is impossible. npx caches between invocations, so the three publish steps share the same downloaded npm.

The OIDC preflight no longer checks the system npm version (the \`npx\` specifier enforces \`>=11.5.1\` at the point of use); it just verifies \`id-token: write\` is granted.

## Why npx and not Node 24

Considered bumping the publish workflow to Node 24 (which bundles npm 11.x). Rejected to keep the publish runtime aligned with the test/CI workflows (Node 22). Publishing on a Node version different from CI introduces a \"we test on X but ship from Y\" gap that npx neatly avoids — and the published artifacts are byte-identical either way (esbuild has no \`--target\` flag, tsc respects \`tsconfig\`, no \`engines\` field).

## Test plan

- [ ] Merge.
- [ ] Re-run the publish workflow via \`workflow_dispatch\` (or push an empty bump). Expect: \`Verify OIDC trusted publishing is wired up\` passes; each publish step downloads npm 11.x via npx, exchanges the GitHub OIDC token, and publishes \`0.3.3\` for server / web / cli.
- [ ] Confirm \`0.3.3\` lands on https://www.npmjs.com/package/@openhop/server, /@openhop/web, /openhop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the package publishing workflow to use a pinned npm version during each publish step, improving reliability and consistency of the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->