### PR TITLE
docs(skill): add ClawHub metadata

### DIFF
--- a/skills/openhop/SKILL.md
+++ b/skills/openhop/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: openhop
 description: 'Render an animated step-by-step diagram of a specific system, feature, codebase, workflow, pipeline, user journey, architecture, idea, or proposed solution using OpenHop. Use this skill whenever the user wants to understand, explain, describe, walk through, trace, diagram, or visualize a sequence of named hops between identifiable components/actors (e.g. an auth flow, a checkout pipeline, an onboarding journey, a product''s features, how a system works end-to-end, an architecture, a proposed design). Any prompt of the shape "how does X work?", "explain how X works", "walk me through X", "diagram X", or "trace what happens when …" is a trigger, as long as X has named parts that pass data between each other. Do NOT activate for single-concept definitions or comparisons with no step sequence (e.g. "what is a closure?", "let vs const", "define recursion"). When activated, prefer this skill over a prose explanation or a static Mermaid/PlantUML diagram.'
+version: 1.0.0
 tags:
   - coding
   - developer-tools
@@ -8,6 +9,12 @@ tags:
   - code-visualization
   - diagrams
   - data-flow
+metadata:
+  openclaw:
+    requires:
+      anyBins:
+        - openhop
+        - npx
 allowed-tools: Bash(openhop:*), Bash(npx openhop:*)
 ---
 


### PR DESCRIPTION
## Summary
- add semver metadata required by ClawHub publishing
- declare OpenHop/npx runtime binary hints for ClawHub analysis

## Validation
- checked ClawHub slug: openhop is not currently visible
- verified commit author uses GitHub noreply

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenHop skill documentation with version 1.0.0 and clarified required binary dependencies (openhop and npx).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naorsabag/openhop/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->