### PR TITLE
chore: release 0.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5645,13 +5645,13 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.5.0",
         "@fastify/static": "^9.1.3",
-        "@openhop/server": "0.3.3",
-        "@openhop/web": "0.3.3",
+        "@openhop/server": "0.3.4",
+        "@openhop/web": "0.3.4",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
         "yaml": "^2.9.0",
@@ -5983,7 +5983,7 @@
     },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
@@ -6664,7 +6664,7 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -46,8 +46,8 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.5.0",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.3.3",
-    "@openhop/web": "0.3.3",
+    "@openhop/server": "0.3.4",
+    "@openhop/web": "0.3.4",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.9.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- bump publishable packages from `0.3.3` to `0.3.4`
- update the CLI pins for `@openhop/server` and `@openhop/web` to `0.3.4`
- refresh `package-lock.json`

## Why

The publish workflow only publishes package versions that are not already on npm. PR #180 merged dependency fixes, but `0.3.3` was already published, so this version bump lets the workflow publish fresh npm tarballs.

## Validation

- `npm install --package-lock-only`
- `npm ci`
- `npm run format:check`
- `npm run build --workspaces --if-present`
- `node packages/cli/dist/index.js --version` -> `0.3.4`
- confirmed `openhop@0.3.4`, `@openhop/server@0.3.4`, and `@openhop/web@0.3.4` are not currently on npm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.3.4 for CLI, Server, and Web packages.
  * Synchronized internal package dependencies to ensure consistency across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->