### PR TITLE
chore: release 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-06-18
+
+### Changed
+
+- README and `skills/openhop/SKILL.md`: reframe product positioning as interactive diagrams (play, pause, step-through) rather than animated ones (#185).
+- `skills/openhop/SKILL.md`: streamline authoring guidance — revised flow-creation phases, removed redundant validation/examples sections, clarified CLI install steps.
+
+### Dependencies
+
+- Production: `undici` 7.25.0 → 7.28.0 (#183).
+- Dev: `js-yaml` 4.1.1 → 4.2.0 (#184); Vitest / ESLint / TypeScript toolchain bumps (#182).
+
 ## [0.3.3] - 2026-05-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -420,6 +420,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -437,6 +438,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -454,6 +456,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -471,6 +474,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -488,6 +492,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -505,6 +510,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -522,6 +528,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -539,6 +546,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -556,6 +564,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -573,6 +582,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -590,6 +600,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -607,6 +618,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -624,6 +636,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -641,6 +654,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -658,6 +672,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -675,6 +690,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -692,6 +708,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -709,6 +726,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -726,6 +744,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -743,6 +762,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -760,6 +780,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -777,6 +798,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -794,6 +816,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -811,6 +834,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -828,6 +852,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -845,6 +870,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5633,13 +5659,13 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.5.0",
         "@fastify/static": "^9.1.3",
-        "@openhop/server": "0.3.4",
-        "@openhop/web": "0.3.4",
+        "@openhop/server": "0.3.5",
+        "@openhop/web": "0.3.5",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
         "yaml": "^2.9.0",
@@ -5971,7 +5997,7 @@
     },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
@@ -6652,7 +6678,7 @@
     },
     "packages/web": {
       "name": "@openhop/web",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -46,8 +46,8 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.5.0",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.3.4",
-    "@openhop/web": "0.3.4",
+    "@openhop/server": "0.3.5",
+    "@openhop/web": "0.3.5",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",
     "yaml": "^2.9.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/web",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "OpenHop web UI. Prebuilt static assets — animated data-flow renderer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Bump `@openhop/server`, `@openhop/web`, and `openhop` (CLI) from **0.3.4 → 0.3.5** in lockstep.
- Refresh `package-lock.json` and add a `[0.3.5]` changelog entry covering merged work since #181.

## What's in this release

- **Docs / skill (CLI tarball):** interactive-diagram positioning in README + SKILL (#185); SKILL authoring cleanup (flow-creation phases, removed redundant sections).
- **Dependencies:** `undici` (#183), `js-yaml` (#184), Vitest/ESLint/TS toolchain (#182).
- **@openhop/server / @openhop/web:** lockstep version bump only — no package-level behavior changes this release.

## Test plan

- [ ] CI green (`format:check`, lint, tests)
- [ ] `openhop --version` reports `0.3.5` after `npm run build -w @openhop/cli`
- [ ] Publish workflow tags all three npm packages together on merge