### PR TITLE
chore: bump openhop to 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-06-19
+
+### Changed
+
+- `skills/openhop/SKILL.md`: add Definition of Done so agents complete Phases 1–4 before returning a flow URL; prefer colorful `logos:` / `twemoji:` icons over white `simple-icons`; include sub-flows and `fields` in the first push when relevant (#187).
+
 ## [0.3.5] - 2026-06-18
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -5659,7 +5659,7 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.5.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump `openhop` CLI from 0.3.5 → 0.3.6
- Document the #187 skill updates in CHANGELOG

Only the CLI package version changes — `@openhop/server` and `@openhop/web` are unchanged. The skill ships via the CLI tarball (`prepack` copies `skills/`).

## Test plan
- [ ] CI passes (`format:check`, build & test)
- [ ] After merge, `publish.yml` publishes `openhop@0.3.6` to npm
- [ ] `npx openhop@0.3.6 init` installs the updated skill