### PR TITLE
fix(server): block path traversal in flow IDs and tighten CORS

### DIFF
--- a/packages/server/src/flow-id.ts
+++ b/packages/server/src/flow-id.ts
@@ -1,0 +1,17 @@
+/** Matches nanoid-generated IDs and seeded `example-*` flow names. */
+export const FLOW_ID_PATTERN = /^[A-Za-z0-9_-]+$/
+
+export const FLOW_ID_JSON_PATTERN = '^[A-Za-z0-9_-]+$'
+
+export class InvalidFlowIdError extends Error {
+  constructor(id: string) {
+    super(`Invalid flow id: ${id}`)
+    this.name = 'InvalidFlowIdError'
+  }
+}
+
+export function assertValidFlowId(id: string): void {
+  if (!FLOW_ID_PATTERN.test(id)) {
+    throw new InvalidFlowIdError(id)
+  }
+}

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import { buildApp } from './index.js'
+
+describe('CORS', () => {
+  let app: FastifyInstance
+
+  beforeEach(async () => {
+    app = await buildApp({ logger: false })
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('allows loopback browser origins', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/health',
+      headers: { origin: 'http://localhost:8788' },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['access-control-allow-origin']).toBe('http://localhost:8788')
+  })
+
+  it('blocks arbitrary web origins', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/health',
+      headers: { origin: 'https://evil.example' },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['access-control-allow-origin']).toBeUndefined()
+  })
+})

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,27 @@ import { flowRoutes } from './routes.js'
 import { FlowStore } from './store.js'
 import { seedBundledExamples } from './seed-examples.js'
 
+/** Allow loopback browser origins (Swagger, local tooling). Block arbitrary web origins. */
+function isAllowedCorsOrigin(
+  origin: string | undefined,
+  cb: (err: Error | null, allow: boolean | string) => void
+): void {
+  if (!origin) {
+    cb(null, true)
+    return
+  }
+  try {
+    const { hostname } = new URL(origin)
+    if (hostname === 'localhost' || hostname === '127.0.0.1') {
+      cb(null, origin)
+      return
+    }
+  } catch {
+    // reject below
+  }
+  cb(null, false)
+}
+
 export interface StartServerOptions {
   /** TCP port. Default: process.env.PORT ?? 8787 */
   port?: number
@@ -34,7 +55,7 @@ export async function buildApp(opts: { logger?: boolean } = {}): Promise<Fastify
     app.addSchema(schema)
   }
 
-  await app.register(cors, { origin: true })
+  await app.register(cors, { origin: isAllowedCorsOrigin })
 
   try {
     const swagger = await import('@fastify/swagger')

--- a/packages/server/src/routes.test.ts
+++ b/packages/server/src/routes.test.ts
@@ -249,6 +249,11 @@ flow:
       const res = await app.inject({ method: 'GET', url: '/api/flows/does-not-exist' })
       expect(res.statusCode).toBe(404)
     })
+
+    it('rejects path traversal in flow id with 400', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/flows/..%2Fvictim' })
+      expect(res.statusCode).toBe(400)
+    })
   })
 
   describe('PATCH /api/flows/:id', () => {
@@ -334,6 +339,11 @@ flow:
 
       const second = await app.inject({ method: 'DELETE', url: `/api/flows/${id}` })
       expect(second.statusCode).toBe(404)
+    })
+
+    it('rejects path traversal in flow id with 400', async () => {
+      const res = await app.inject({ method: 'DELETE', url: '/api/flows/..%2Fdelete-me' })
+      expect(res.statusCode).toBe(400)
     })
   })
 })

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -15,6 +15,7 @@ import {
   patchOperationsJsonSchema,
 } from '@openhop/shared'
 import { FlowStore } from './store.js'
+import { FLOW_ID_JSON_PATTERN } from './flow-id.js'
 
 /** Flow-ID generator. Uses an alphanumeric-only alphabet (no `-` / `_`)
  *  because the CLI passes IDs as positional arguments to commands like
@@ -40,6 +41,14 @@ const NOT_FOUND_EXAMPLE = {
   error: 'not_found',
   details: [{ path: '', message: 'Flow "xyz" not found' }],
 }
+
+const flowIdParamsSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', pattern: FLOW_ID_JSON_PATTERN, description: 'Flow ID' },
+  },
+  required: ['id'],
+} as const
 
 export async function flowRoutes(app: FastifyInstance): Promise<void> {
   // Register patch-operations schema so routes can $ref it by its generated id.
@@ -309,13 +318,7 @@ export async function flowRoutes(app: FastifyInstance): Promise<void> {
         summary: 'Get a flow by ID',
         description: 'Returns the full flow definition including metadata, nodes, and steps.',
         tags: ['flows'],
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string', description: 'Flow ID' },
-          },
-          required: ['id'],
-        },
+        params: flowIdParamsSchema,
         response: {
           200: storedFlowJsonSchema,
           404: {
@@ -351,13 +354,7 @@ export async function flowRoutes(app: FastifyInstance): Promise<void> {
         summary: 'Get flow version',
         description: 'Returns only the version number. Used by the UI for polling.',
         tags: ['flows'],
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string', description: 'Flow ID' },
-          },
-          required: ['id'],
-        },
+        params: flowIdParamsSchema,
         response: {
           200: {
             type: 'object',
@@ -409,13 +406,7 @@ Supported operations:
 - **remove-step**: Remove a step by index
 - **replace-steps**: Replace the entire steps array`,
         tags: ['flows'],
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string', description: 'Flow ID' },
-          },
-          required: ['id'],
-        },
+        params: flowIdParamsSchema,
         body: { $ref: 'https://openhop.dev/schemas/patch-operations#' },
         response: {
           200: {
@@ -513,13 +504,7 @@ Supported operations:
         summary: 'Delete a flow',
         description: 'Permanently deletes a flow by ID.',
         tags: ['flows'],
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string', description: 'Flow ID' },
-          },
-          required: ['id'],
-        },
+        params: flowIdParamsSchema,
         response: {
           204: {
             type: 'null',

--- a/packages/server/src/store.test.ts
+++ b/packages/server/src/store.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, readFile, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { FlowStore } from './store.js'
+import { InvalidFlowIdError } from './flow-id.js'
+
+describe('FlowStore path safety', () => {
+  let dir: string
+  let store: FlowStore
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'openhop-store-test-'))
+    await writeFile(
+      join(dir, 'outside.yaml'),
+      'id: outside\nversion: 1\ncreatedAt: "2026-01-01T00:00:00.000Z"\nupdatedAt: "2026-01-01T00:00:00.000Z"\nroot:\n  meta:\n    title: Outside\n  flow:\n    nodes:\n      - id: a\n        label: A\n',
+      'utf-8'
+    )
+    store = new FlowStore(join(dir, 'flows'))
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('does not read files outside the flow directory', async () => {
+    await expect(store.get('../outside')).rejects.toBeInstanceOf(InvalidFlowIdError)
+  })
+
+  it('does not delete files outside the flow directory', async () => {
+    await expect(store.delete('../outside')).rejects.toBeInstanceOf(InvalidFlowIdError)
+    const content = await readFile(join(dir, 'outside.yaml'), 'utf-8')
+    expect(content).toContain('Outside')
+  })
+})

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os'
 import { mkdir, readFile, writeFile, readdir, unlink } from 'node:fs/promises'
 import YAML from 'yaml'
 import type { Root } from '@openhop/shared'
+import { assertValidFlowId, InvalidFlowIdError } from './flow-id.js'
 
 export interface StoredFlow {
   id: string
@@ -50,6 +51,7 @@ export class FlowStore {
   }
 
   private filePath(id: string): string {
+    assertValidFlowId(id)
     return join(this.dir, `${id}.yaml`)
   }
 
@@ -78,7 +80,8 @@ export class FlowStore {
       const content = await readFile(this.filePath(id), 'utf-8')
       const file = YAML.parse(content) as StoredFlowFile
       return this.toStoredFlow(file)
-    } catch {
+    } catch (err) {
+      if (err instanceof InvalidFlowIdError) throw err
       return null
     }
   }
@@ -104,7 +107,8 @@ export class FlowStore {
     try {
       await unlink(this.filePath(id))
       return true
-    } catch {
+    } catch (err) {
+      if (err instanceof InvalidFlowIdError) throw err
       return false
     }
   }


### PR DESCRIPTION
## Summary
- Validate flow IDs (`^[A-Za-z0-9_-]+$`) in `FlowStore.filePath()` and on all `:id` route params to prevent path traversal (GHSA-g72f-jw3w-mgh7).
- Restrict CORS to loopback origins (`localhost` / `127.0.0.1`) instead of `origin: true`, blocking cross-site browser attacks against a local API while leaving CLI and proxied UI unchanged.

## Test plan
- [x] `GET /api/flows/..%2Fvictim` returns 400 (not 200)
- [x] `DELETE /api/flows/..%2Fdelete-me` returns 400; file outside store untouched
- [x] `POST /api/flows` + `GET /api/flows/:id` still work with valid IDs
- [x] CORS allows `http://localhost:8788`, blocks `https://evil.example`
- [ ] `npm test -w @openhop/server` (vitest native binding issue in CI env — typecheck passes)
- [ ] E2E: `openhop push` + `openhop patch` against local server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted CORS access to localhost origins only, enhancing security for development environments.
  * Added validation to prevent path traversal attacks in flow operations.

* **Tests**
  * Added test coverage for CORS origin restrictions and path traversal rejection.
  * Added flow ID validation test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->