### PR TITLE
chore: bump @openhop/server to 0.3.6 and openhop to 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-06-20
+
+### Security
+
+- `@openhop/server@0.3.6`: validate flow IDs before filesystem access and restrict CORS to loopback origins, fixing path traversal in `GET`/`DELETE /api/flows/:id` ([GHSA-g72f-jw3w-mgh7](https://github.com/naorsabag/openhop/security/advisories/GHSA-g72f-jw3w-mgh7)). `openhop@0.3.7` pins the patched server for `openhop serve`.
+
 ## [0.3.6] - 2026-06-19
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -5659,12 +5659,12 @@
     },
     "packages/cli": {
       "name": "openhop",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "^11.5.0",
         "@fastify/static": "^9.1.3",
-        "@openhop/server": "0.3.5",
+        "@openhop/server": "0.3.6",
         "@openhop/web": "0.3.5",
         "commander": "^12.0.0",
         "fastify": "^5.0.0",
@@ -5997,7 +5997,7 @@
     },
     "packages/server": {
       "name": "@openhop/server",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^10.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhop",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Animated data-flow diagrams your AI agent can write. CLI.",
   "repository": {
     "type": "git",
@@ -46,7 +46,7 @@
   "dependencies": {
     "@fastify/http-proxy": "^11.5.0",
     "@fastify/static": "^9.1.3",
-    "@openhop/server": "0.3.5",
+    "@openhop/server": "0.3.6",
     "@openhop/web": "0.3.5",
     "commander": "^12.0.0",
     "fastify": "^5.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhop/server",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "OpenHop API server. Fastify app for storing and serving data-flow definitions.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Publish `@openhop/server@0.3.6` with the path-traversal + CORS fix (GHSA-g72f-jw3w-mgh7).
- Bump `openhop` CLI to `0.3.7` and pin `@openhop/server@0.3.6` so `npx openhop serve` ships the patched server.

## Test plan
- [ ] CI passes
- [ ] After merge, `publish.yml` publishes `@openhop/server@0.3.6` and `openhop@0.3.7`
- [ ] Security advisory updated with patched version `0.3.6`, CVE requested, and published