### PR TITLE
feat(web): add optional GA4 for GitHub Pages demo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,6 +38,9 @@ jobs:
           # https://naorsabag.github.io/openhop/ — is the asset base path.
           VITE_BASE: /openhop/
           VITE_FRAGMENT_MODE: "1"
+          # GA4 for the public Pages demo only. Add repo secret GA_MEASUREMENT_ID
+          # (Settings → Secrets → Actions) with your G-XXXXXXXXXX ID. Unset = no analytics.
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
       - uses: actions/configure-pages@v6
         with:
           enablement: true

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -11,6 +11,7 @@ The package contains a built Vite bundle (HTML + JS + sprites) that:
 - Animates data pixels traveling between nodes
 - Supports drill-down into sub-flows
 - Reads flows from URL fragments for the static GitHub Pages deploy
+- Optional GA4 on GitHub Pages only (`GA_MEASUREMENT_ID` repo secret → `pages.yml`); local dev and CLI deploys never load it
 
 ## Documentation
 

--- a/packages/web/src/lib/analytics.ts
+++ b/packages/web/src/lib/analytics.ts
@@ -1,0 +1,42 @@
+declare global {
+  interface Window {
+    dataLayer?: unknown[]
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
+const MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID?.trim()
+
+/** GitHub Pages demo only — local `npm run dev` and CLI deploys omit the ID. */
+export function initAnalytics(): void {
+  if (!MEASUREMENT_ID) return
+  if (import.meta.env.VITE_FRAGMENT_MODE !== '1') return
+
+  window.dataLayer = window.dataLayer ?? []
+  window.gtag = function gtag(...args: unknown[]) {
+    window.dataLayer!.push(args)
+  }
+  window.gtag('js', new Date())
+  window.gtag('config', MEASUREMENT_ID, { send_page_view: false })
+
+  const script = document.createElement('script')
+  script.async = true
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(MEASUREMENT_ID)}`
+  script.onload = () => trackPageView()
+  document.head.appendChild(script)
+
+  window.addEventListener('hashchange', trackPageView)
+  trackPageView()
+}
+
+export function trackPageView(): void {
+  if (!MEASUREMENT_ID || !window.gtag) return
+  const page_path = `${window.location.pathname}${window.location.search}${window.location.hash}`
+  window.gtag('event', 'page_view', {
+    page_path,
+    page_location: window.location.href,
+    page_title: document.title,
+  })
+}
+
+export {}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,6 +3,9 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import AppFragment from './AppFragment.tsx'
+import { initAnalytics } from './lib/analytics.ts'
+
+initAnalytics()
 
 // `VITE_FRAGMENT_MODE=1` switches the bundle into the GitHub Pages variant:
 // no API server, flows live in the URL fragment, "Save" copies a share URL.

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BASE: string
+  readonly VITE_FRAGMENT_MODE?: string
+  /** GA4 measurement ID (G-…). Set in pages.yml only — not used locally. */
+  readonly VITE_GA_MEASUREMENT_ID?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json-summary'],
       include: ['src/**'],
-      exclude: ['src/**/*.test.ts', 'src/main.tsx', 'src/types.ts', 'src/globals.d.ts'],
+      exclude: ['src/**/*.test.ts', 'src/main.tsx', 'src/lib/analytics.ts', 'src/types.ts', 'src/globals.d.ts'],
       // Web is canvas/React Flow-heavy; component tests are deferred. These
       // thresholds lock the Vitest 4 V8-provider baseline.
       thresholds: {

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -7,7 +7,13 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json-summary'],
       include: ['src/**'],
-      exclude: ['src/**/*.test.ts', 'src/main.tsx', 'src/lib/analytics.ts', 'src/types.ts', 'src/globals.d.ts'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/main.tsx',
+        'src/lib/analytics.ts',
+        'src/types.ts',
+        'src/globals.d.ts',
+      ],
       // Web is canvas/React Flow-heavy; component tests are deferred. These
       // thresholds lock the Vitest 4 V8-provider baseline.
       thresholds: {


### PR DESCRIPTION
## Summary
- Add GA4 page-view tracking for the public GitHub Pages demo (`https://naorsabag.github.io/openhop/`).
- Analytics loads only when `VITE_FRAGMENT_MODE=1` and `VITE_GA_MEASUREMENT_ID` is set at build time.
- Local `npm run dev` and `openhop serve` are unchanged — no measurement ID, no gtag script.

## Setup after merge
1. Create a GA4 property for the Pages site.
2. Add repo secret **`GA_MEASUREMENT_ID`** (Actions) with your `G-XXXXXXXXXX` ID.
3. Merge → `pages.yml` redeploys with analytics enabled.

## Test plan
- [ ] `npx tsc --noEmit -p packages/web` passes
- [ ] Pages build without secret: no gtag in bundle behavior (init is no-op)
- [ ] After secret + deploy: Real-Time report shows visits on naorsabag.github.io/openhop
- [ ] Hash navigation (example flow links) fires additional page_view events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Analytics 4 integration to monitor page views and user interactions on the public demo site.
  * Analytics is automatically enabled for GitHub Pages deployments and can be configured through repository settings.
  * Local development and custom deployments exclude analytics by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->