### PR TITLE
fix(web): keep mobile UI above browser chrome with dvh and safe-area

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     <title>OpenHop — animated data-flow diagrams your AI agent can write</title>
     <meta

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -412,10 +412,7 @@ function App() {
   }, [flowStack.length])
 
   return (
-    <div
-      className="flex flex-col h-screen w-screen overflow-hidden"
-      style={{ background: '#0a1f0e' }}
-    >
+    <div className="openhop-app flex flex-col" style={{ background: '#0a1f0e' }}>
       {/* Header */}
       <header
         className="flex items-center justify-between px-4 py-2 shrink-0"

--- a/packages/web/src/AppFragment.tsx
+++ b/packages/web/src/AppFragment.tsx
@@ -330,10 +330,7 @@ export default function AppFragment() {
   }, [])
 
   return (
-    <div
-      className="flex flex-col h-screen w-screen overflow-hidden"
-      style={{ background: '#0a1f0e' }}
-    >
+    <div className="openhop-app flex flex-col" style={{ background: '#0a1f0e' }}>
       <header
         className="flex items-center justify-between px-4 py-2 shrink-0"
         style={{

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -20,7 +20,26 @@ html {
 body {
   @apply bg-bg text-text font-terminal;
   margin: 0;
+  /* 100vh on mobile includes area behind the browser chrome; dvh tracks
+   * the actually-visible viewport. svh/vh are fallbacks for older engines. */
   min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
+}
+
+/* Full-viewport app shell — safe-area padding keeps bottom tabs and
+ * controls above the home indicator / browser toolbar on notched phones. */
+.openhop-app {
+  box-sizing: border-box;
+  width: 100vw;
+  height: 100vh;
+  height: 100svh;
+  height: 100dvh;
+  overflow: hidden;
+  padding-top: env(safe-area-inset-top, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  padding-left: env(safe-area-inset-left, 0px);
 }
 
 /* Drill-down: sub-flow appears from far away, zooms in */


### PR DESCRIPTION
## Summary
- Add `viewport-fit=cover` so iOS exposes `env(safe-area-inset-*)` for notches and the home indicator
- Replace `h-screen` (`100vh`) with a shared `.openhop-app` shell using `100dvh` (with `svh`/`vh` fallbacks) so the layout tracks the actually-visible viewport on mobile browsers
- Apply safe-area padding on the app shell so bottom-docked controls (INSPECT bookmark tab) sit above Safari/Chrome toolbars

Fixes the issue where the INSPECT toggle was hidden on real phones but visible in DevTools mobile emulation (which doesn't simulate browser chrome).

## Test plan
- [ ] Open https://naorsabag.github.io/openhop/ on an iPhone or Android phone in portrait
- [ ] Confirm the INSPECT tab is visible and tappable at the bottom center of the canvas
- [ ] Confirm the FLOWS tab and header are not clipped at the top
- [ ] Desktop layout unchanged at ≥768px width
- [ ] DevTools mobile emulation at 390px width still shows bottom INSPECT tab above the canvas edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-screen behavior on mobile devices, including better handling of browser viewport changes.
  * Added support for safe areas on devices with display cutouts, reducing content overlap with notches and system UI.
  * Standardized the app shell styling for more consistent layout across screens and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->