### PR TITLE
feat(web): add pixel and corporate node theme switcher

### DIFF
--- a/docs/superpowers/plans/2026-09-06-theme-switcher-completion.md
+++ b/docs/superpowers/plans/2026-09-06-theme-switcher-completion.md
@@ -1,0 +1,648 @@
+# Theme Switcher Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish PR #221 with a persisted Pixel/Corporate switch, resilient Iconify-backed corporate nodes, six-slot palettes, and green CI without including unrelated local work.
+
+**Architecture:** Theme state remains centralized in the node-theme provider, but its context and hook move to a non-component module for React Refresh compatibility. Palette data stays in `node-themes.ts`; generic Iconify resolution stays in `iconify.ts`; corporate fallback presentation stays in `CorporateBuilding.tsx`.
+
+**Tech Stack:** React 19, TypeScript 6, Vitest 4, Vite 8, ESLint, Docker Desktop with Node 22
+
+## Global Constraints
+
+- Preserve both application entry modes and persisted theme selection.
+- Pixel mode retains sprites, hue filters, carrot pixels, and custom overlays.
+- Corporate mode uses flat colors, rectangular nodes, round data pixels, and centered icons.
+- Both palettes contain exactly six aligned filter/accent slots.
+- Iconify remains CDN-backed with a textual type-badge fallback; add no icon package.
+- Explicit valid Iconify IDs and emoji override type defaults.
+- Do not stage or commit `packages/web/src/hooks/useFlowPolling.ts`, `.claude/`, or `docs/orion-slack-v1-flows.md`.
+- Rebase onto `origin/master` and update PR #221 only with `--force-with-lease`.
+- Do not merge PR #221; the repository owner performs the final merge.
+
+---
+
+### Task 1: Split theme context from the provider component
+
+**Files:**
+
+- Create: `packages/web/src/context/node-theme-context.ts`
+- Modify: `packages/web/src/context/NodeThemeContext.tsx`
+- Modify: `packages/web/src/components/ThemeToggle.tsx`
+- Modify: `packages/web/src/components/DataPixel.tsx`
+- Modify: `packages/web/src/components/FlowCanvas.tsx`
+- Modify: `packages/web/src/components/nodes/FlowNode.tsx`
+- Modify: `packages/web/src/hooks/useFlowGraphLayout.ts`
+
+**Interfaces:**
+
+- Produces: `NodeThemeContext`, `NodeThemeContextValue`, and `useNodeTheme()` from `context/node-theme-context.ts`.
+- Preserves: `NodeThemeProvider` from `context/NodeThemeContext.tsx`.
+
+- [ ] **Step 1: Prepare the supported Node toolchain**
+
+Run:
+
+```bash
+"/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe" volume create openhop-theme-node-modules
+"/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe" run --rm \
+  -v "$(wslpath -w "$PWD"):/workspace" \
+  -v openhop-theme-node-modules:/workspace/node_modules \
+  -w /workspace node:22-bookworm npm ci --no-audit
+```
+
+Expected: npm installs successfully under Node 22 without changing tracked files.
+
+- [ ] **Step 2: Confirm the existing React Refresh failure**
+
+Run:
+
+```bash
+"/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe" run --rm \
+  -v "$(wslpath -w "$PWD"):/workspace" \
+  -v openhop-theme-node-modules:/workspace/node_modules \
+  -w /workspace node:22-bookworm npm run lint -w @openhop/web
+```
+
+Expected: FAIL with `react-refresh/only-export-components` at `NodeThemeContext.tsx`.
+
+- [ ] **Step 3: Create the non-component context module**
+
+Create `packages/web/src/context/node-theme-context.ts`:
+
+```ts
+import { createContext, useContext } from "react"
+import type { NodeThemeId } from "../lib/node-themes"
+
+export interface NodeThemeContextValue {
+  themeId: NodeThemeId
+  setThemeId: (id: NodeThemeId) => void
+}
+
+export const NodeThemeContext = createContext<NodeThemeContextValue | null>(null)
+
+export function useNodeTheme(): NodeThemeContextValue {
+  const context = useContext(NodeThemeContext)
+  if (!context) throw new Error("useNodeTheme must be used within NodeThemeProvider")
+  return context
+}
+```
+
+- [ ] **Step 4: Leave the TSX module component-only**
+
+Replace `packages/web/src/context/NodeThemeContext.tsx` with:
+
+```tsx
+import { useCallback, useMemo, useState, type ReactNode } from "react"
+import { loadStoredNodeTheme, storeNodeTheme, type NodeThemeId } from "../lib/node-themes"
+import { NodeThemeContext } from "./node-theme-context"
+
+export function NodeThemeProvider({ children }: { children: ReactNode }) {
+  const [themeId, setThemeIdState] = useState<NodeThemeId>(() => loadStoredNodeTheme())
+
+  const setThemeId = useCallback((id: NodeThemeId) => {
+    setThemeIdState(id)
+    storeNodeTheme(id)
+  }, [])
+
+  const value = useMemo(() => ({ themeId, setThemeId }), [themeId, setThemeId])
+
+  return <NodeThemeContext.Provider value={value}>{children}</NodeThemeContext.Provider>
+}
+```
+
+- [ ] **Step 5: Update hook imports**
+
+Use these imports in the five consumers:
+
+```ts
+// packages/web/src/components/ThemeToggle.tsx
+import { useNodeTheme } from "../context/node-theme-context"
+
+// packages/web/src/components/DataPixel.tsx
+import { useNodeTheme } from "../context/node-theme-context"
+
+// packages/web/src/components/FlowCanvas.tsx
+import { useNodeTheme } from "../context/node-theme-context"
+
+// packages/web/src/components/nodes/FlowNode.tsx
+import { useNodeTheme } from "../../context/node-theme-context"
+
+// packages/web/src/hooks/useFlowGraphLayout.ts
+import { useNodeTheme } from "../context/node-theme-context"
+```
+
+- [ ] **Step 6: Verify the lint regression is fixed**
+
+Run the Docker lint command from Step 2.
+
+Expected: PASS with no React Refresh error.
+
+### Task 2: Restore six-slot theme palettes
+
+**Files:**
+
+- Modify: `packages/web/__tests__/pixel-palette.test.ts`
+- Modify: `packages/web/src/lib/node-themes.ts`
+
+**Interfaces:**
+
+- Consumes: `PIXEL_THEME_PALETTE`, `CORPORATE_THEME_PALETTE`, and `assignNodeVariants()`.
+- Produces: six aligned filter/accent entries per theme with deterministic wraparound.
+
+- [ ] **Step 1: Add failing six-slot tests**
+
+Add these imports and tests to `packages/web/__tests__/pixel-palette.test.ts`:
+
+```ts
+import { CORPORATE_THEME_PALETTE, PIXEL_THEME_PALETTE } from "../src/lib/node-themes"
+
+describe("theme palette shape", () => {
+  it.each([
+    { name: "pixel", palette: PIXEL_THEME_PALETTE },
+    { name: "corporate", palette: CORPORATE_THEME_PALETTE },
+  ])("$name has six aligned filter and accent slots", ({ palette }) => {
+    expect(palette.variantFilters).toHaveLength(6)
+    expect(palette.variantAccents).toHaveLength(6)
+  })
+
+  it("uses slot six before wrapping the seventh same-type node", () => {
+    const variants = assignNodeVariants(
+      Array.from({ length: 7 }, (_, index) => ({
+        id: `service-${index}`,
+        type: "service",
+      }))
+    )
+
+    expect(variants.get("service-5")?.color).toBe(PIXEL_THEME_PALETTE.variantAccents[5])
+    expect(variants.get("service-6")?.color).toBe(PIXEL_THEME_PALETTE.variantAccents[0])
+  })
+})
+```
+
+- [ ] **Step 2: Run the focused test and confirm failure**
+
+Run:
+
+```bash
+"/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe" run --rm \
+  -v "$(wslpath -w "$PWD"):/workspace" \
+  -v openhop-theme-node-modules:/workspace/node_modules \
+  -w /workspace node:22-bookworm \
+  npm test -w @openhop/web -- pixel-palette.test.ts
+```
+
+Expected: FAIL because both palettes currently contain five slots.
+
+- [ ] **Step 3: Add the sixth aligned entries**
+
+Update the palette definitions in `packages/web/src/lib/node-themes.ts`:
+
+```ts
+export const PIXEL_THEME_PALETTE: NodeThemePalette = {
+  variantFilters: [
+    undefined,
+    "hue-rotate(210deg)",
+    "hue-rotate(90deg)",
+    "hue-rotate(140deg)",
+    "hue-rotate(320deg)",
+    "hue-rotate(45deg)",
+  ],
+  variantAccents: ["#ff8a4a", "#b47aff", "#4aff7a", "#4a9eff", "#ff6b6b", "#ffd84a"],
+}
+
+export const CORPORATE_THEME_PALETTE: NodeThemePalette = {
+  variantFilters: [undefined, undefined, undefined, undefined, undefined, undefined],
+  variantAccents: ["#2563eb", "#475569", "#0d9488", "#1d4ed8", "#64748b", "#7c3aed"],
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm success**
+
+Run the Docker test command from Step 2.
+
+Expected: all `pixel-palette.test.ts` tests pass.
+
+### Task 3: Complete resilient corporate icon rendering
+
+**Files:**
+
+- Modify: `packages/web/src/lib/iconify.ts`
+- Modify: `packages/web/src/components/nodes/CorporateBuilding.tsx`
+- Modify: `packages/web/src/components/nodes/FlowNode.tsx`
+- Modify: `packages/web/__tests__/iconify.test.ts`
+- Create: `packages/web/__tests__/corporate-building.test.ts`
+- Modify: `packages/web/src/lib/node-themes.ts` to keep theme data only
+
+**Interfaces:**
+
+- Consumes: node type, optional custom `icon`, node label, and variant color.
+- Produces: validated Iconify URLs, explicit emoji rendering, and a visible textual badge when network imagery fails.
+
+- [ ] **Step 1: Extend Iconify tests with malformed-ID behavior**
+
+Add `isIconifyId` to the imports and these assertions in `packages/web/__tests__/iconify.test.ts`:
+
+```ts
+import { NODE_TYPE_ICON, iconifySvgUrl, isIconifyId, resolveNodeTypeIcon } from "../src/lib/iconify"
+
+describe("isIconifyId", () => {
+  it("accepts one valid prefix/name separator only", () => {
+    expect(isIconifyId("mdi:database")).toBe(true)
+    expect(isIconifyId("logos:kubernetes")).toBe(true)
+    expect(isIconifyId("mdi:database:extra")).toBe(false)
+    expect(isIconifyId(":database")).toBe(false)
+    expect(isIconifyId("mdi:")).toBe(false)
+  })
+})
+
+describe("resolveNodeTypeIcon malformed input", () => {
+  it("falls back to the node type icon", () => {
+    expect(resolveNodeTypeIcon("database", "mdi:database:extra")).toBe(NODE_TYPE_ICON.database)
+  })
+})
+```
+
+- [ ] **Step 2: Add the failing corporate fallback tests**
+
+Create `packages/web/__tests__/corporate-building.test.ts`:
+
+```ts
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { CorporateBuilding } from "../src/components/nodes/CorporateBuilding"
+
+describe("CorporateBuilding", () => {
+  it("renders an Iconify image over a textual type fallback", () => {
+    const markup = renderToStaticMarkup(
+      createElement(CorporateBuilding, {
+        color: "#2563eb",
+        nodeType: "database",
+        label: "Orders",
+      })
+    )
+
+    expect(markup).toContain("api.iconify.design/mdi/database.svg")
+    expect(markup).toContain(">DB</span>")
+    expect(markup).toContain('alt="Orders"')
+  })
+
+  it("renders explicit emoji without an Iconify request", () => {
+    const markup = renderToStaticMarkup(
+      createElement(CorporateBuilding, {
+        color: "#2563eb",
+        nodeType: "custom",
+        icon: "🚀",
+        label: "Launch",
+      })
+    )
+
+    expect(markup).toContain("🚀")
+    expect(markup).not.toContain("api.iconify.design")
+  })
+})
+```
+
+- [ ] **Step 3: Run both focused tests and confirm failure**
+
+Run:
+
+```bash
+"/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe" run --rm \
+  -v "$(wslpath -w "$PWD"):/workspace" \
+  -v openhop-theme-node-modules:/workspace/node_modules \
+  -w /workspace node:22-bookworm \
+  npm test -w @openhop/web -- iconify.test.ts corporate-building.test.ts
+```
+
+Expected: FAIL because malformed IDs pass the current loose check and corporate image markup lacks a badge fallback.
+
+- [ ] **Step 4: Validate Iconify IDs strictly**
+
+Replace `isIconifyId` in `packages/web/src/lib/iconify.ts`:
+
+```ts
+const ICONIFY_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*:[a-z0-9]+(?:[-_][a-z0-9]+)*$/i
+
+export function isIconifyId(icon: string | undefined): icon is string {
+  return !!icon && ICONIFY_ID_PATTERN.test(icon)
+}
+```
+
+Keep `resolveNodeTypeIcon` as:
+
+```ts
+export function resolveNodeTypeIcon(nodeType: string, customIcon?: string): string {
+  if (customIcon && isIconifyId(customIcon)) return customIcon
+  return NODE_TYPE_ICON[nodeType] ?? NODE_TYPE_ICON.service
+}
+```
+
+- [ ] **Step 5: Add the corporate badge fallback**
+
+Add the component-local badge map and helper in `CorporateBuilding.tsx`:
+
+```ts
+const CORPORATE_TYPE_BADGE: Record<string, string> = {
+  actor: "USR",
+  endpoint: "API",
+  auth: "AUTH",
+  database: "DB",
+  external: "EXT",
+  cache: "CACHE",
+  queue: "QUEUE",
+  service: "SVC",
+  docker: "DKR",
+  k8s: "K8S",
+  scheduler: "CRON",
+  ai_agent: "AI",
+  browser: "WEB",
+  transform: "XFORM",
+  validation: "VALID",
+  custom: "NODE",
+}
+
+function corporateTypeBadge(nodeType: string): string {
+  const derived = nodeType
+    .slice(0, 3)
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "")
+  return CORPORATE_TYPE_BADGE[nodeType] ?? (derived || "NODE")
+}
+```
+
+Resolve presentation state near the top of the component:
+
+```ts
+const resolvedIcon = resolveNodeTypeIcon(nodeType, icon)
+const showEmoji = Boolean(icon && !icon.includes(":"))
+const badge = corporateTypeBadge(nodeType)
+```
+
+Replace the current icon branch with:
+
+```tsx
+{
+  showEmoji ? (
+    <span style={{ fontSize: ICON_SIZE - 8, lineHeight: 1 }} aria-hidden="true">
+      {icon}
+    </span>
+  ) : (
+    <>
+      <span
+        aria-hidden="true"
+        style={{
+          fontFamily: "system-ui, -apple-system, Segoe UI, sans-serif",
+          fontSize: 13,
+          fontWeight: 700,
+          letterSpacing: 0.6,
+          color,
+          lineHeight: 1,
+        }}
+      >
+        {badge}
+      </span>
+      <img
+        src={iconifySvgUrl(resolvedIcon, color)}
+        alt={label ?? nodeType}
+        width={ICON_SIZE}
+        height={ICON_SIZE}
+        style={{
+          position: "absolute",
+          display: "block",
+          objectFit: "contain",
+          background: "#f8fafc",
+        }}
+        onError={(event) => {
+          ;(event.currentTarget as HTMLElement).style.display = "none"
+        }}
+      />
+    </>
+  )
+}
+```
+
+- [ ] **Step 6: Ignore malformed colon-delimited custom overlays in Pixel mode**
+
+Use this branch in `FlowNode.tsx`:
+
+```tsx
+if (icon) {
+  if (isIconifyId(icon)) {
+    const url = iconifySvgUrl(icon, "white")
+    customIconOverlay = (
+      <img
+        src={url}
+        alt={label}
+        style={{
+          width: 40,
+          height: 40,
+          position: "absolute",
+          top: -4,
+          left: "calc(100% - 14px)",
+          imageRendering: "auto",
+        }}
+        onError={(event) => {
+          ;(event.currentTarget as HTMLElement).style.display = "none"
+        }}
+      />
+    )
+  } else if (!icon.includes(":")) {
+    customIconOverlay = (
+      <span
+        style={{
+          position: "absolute",
+          top: -2,
+          left: "calc(100% - 14px)",
+          fontSize: 36,
+          lineHeight: 1,
+        }}
+      >
+        {icon}
+      </span>
+    )
+  }
+}
+```
+
+Render the overlay without whitespace lint noise:
+
+```tsx
+{
+  !isCorporate && customIconOverlay
+}
+```
+
+- [ ] **Step 7: Run focused and complete web tests**
+
+Run the focused command from Step 3, then:
+
+```bash
+"/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe" run --rm \
+  -v "$(wslpath -w "$PWD"):/workspace" \
+  -v openhop-theme-node-modules:/workspace/node_modules \
+  -w /workspace node:22-bookworm npm test -w @openhop/web
+```
+
+Expected: all Iconify, corporate-building, palette, and existing web tests pass.
+
+- [ ] **Step 8: Commit only theme-related implementation**
+
+Run:
+
+```bash
+git add \
+  packages/web/__tests__/corporate-building.test.ts \
+  packages/web/__tests__/iconify.test.ts \
+  packages/web/__tests__/pixel-palette.test.ts \
+  packages/web/src/components/DataPixel.tsx \
+  packages/web/src/components/FlowCanvas.tsx \
+  packages/web/src/components/ThemeToggle.tsx \
+  packages/web/src/components/nodes/CorporateBuilding.tsx \
+  packages/web/src/components/nodes/FlowNode.tsx \
+  packages/web/src/context/NodeThemeContext.tsx \
+  packages/web/src/context/node-theme-context.ts \
+  packages/web/src/hooks/useFlowGraphLayout.ts \
+  packages/web/src/lib/flow-layout.ts \
+  packages/web/src/lib/iconify.ts \
+  packages/web/src/lib/node-themes.ts \
+  packages/web/src/lib/pixel-palette.ts
+git commit -m "feat(web): complete corporate theme icons"
+```
+
+Expected: the commit excludes `useFlowPolling.ts`, `.claude/`, and the Orion document.
+
+### Task 4: Verify, rebase, and update PR #221
+
+**Files:**
+
+- No additional source files.
+
+**Interfaces:**
+
+- Consumes: committed theme implementation from Tasks 1–3.
+- Produces: an updated, green PR #221 based on current `master`, left open for owner merge.
+
+- [ ] **Step 1: Verify the complete feature before rebasing**
+
+Run:
+
+```bash
+"/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe" run --rm \
+  -v "$(wslpath -w "$PWD"):/workspace" \
+  -v openhop-theme-node-modules:/workspace/node_modules \
+  -w /workspace node:22-bookworm sh -lc '
+    npm test -w @openhop/web &&
+    npm run lint -w @openhop/web &&
+    npm run format:check &&
+    npm run typecheck -w @openhop/web &&
+    npm run build -w @openhop/web
+  '
+git diff --check
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Confirm only unrelated local work remains**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+
+```text
+ M packages/web/src/hooks/useFlowPolling.ts
+?? .claude/
+?? docs/orion-slack-v1-flows.md
+```
+
+- [ ] **Step 3: Stash only the unrelated tracked polling edit**
+
+Run:
+
+```bash
+git stash push -m preserve-local-flow-polling -- packages/web/src/hooks/useFlowPolling.ts
+git stash list -1
+```
+
+Expected: the newest stash is named `preserve-local-flow-polling`; untracked `.claude/` and Orion documentation remain in place.
+
+- [ ] **Step 4: Rebase onto current master**
+
+Run:
+
+```bash
+git fetch origin
+git rebase origin/master
+```
+
+Expected: the feature commits replay cleanly onto `origin/master`. If Git reports a conflict, stop without force-pushing and inspect the conflict before continuing.
+
+- [ ] **Step 5: Restore the polling edit immediately**
+
+Run:
+
+```bash
+git stash pop
+git diff -- packages/web/src/hooks/useFlowPolling.ts
+```
+
+Expected: the polling retry diff is restored and remains uncommitted.
+
+- [ ] **Step 6: Refresh dependencies and verify after rebase**
+
+Run:
+
+```bash
+"/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe" run --rm \
+  -v "$(wslpath -w "$PWD"):/workspace" \
+  -v openhop-theme-node-modules:/workspace/node_modules \
+  -w /workspace node:22-bookworm sh -lc '
+    npm ci --no-audit &&
+    npm test -w @openhop/web &&
+    npm run lint -w @openhop/web &&
+    npm run format:check &&
+    npm run typecheck -w @openhop/web &&
+    npm run build -w @openhop/web
+  '
+git diff --check
+```
+
+Expected: all commands exit 0; the unrelated polling edit remains uncommitted and is not part of any commit.
+
+- [ ] **Step 7: Update the existing PR branch safely**
+
+Run:
+
+```bash
+git push --force-with-lease origin feat/node-theme-switcher
+gh pr checks 221 --watch --interval 10
+```
+
+Expected: PR #221 updates without overwriting unexpected remote work, and all GitHub checks pass.
+
+- [ ] **Step 8: Verify PR scope and leave it open**
+
+Run:
+
+```bash
+gh pr view 221 --json state,mergeStateStatus,statusCheckRollup,url,title \
+  --jq '{state, mergeStateStatus, url, title, checks: [.statusCheckRollup[] | {name: (.name // .context), status, conclusion}]}'
+git status --short
+```
+
+Expected: PR #221 is `OPEN`, checks are successful, and only the excluded local polling, `.claude/`, and Orion paths remain uncommitted.
+
+- [ ] **Step 9: Remove the temporary Docker volume**
+
+Run:
+
+```bash
+"/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe" volume rm openhop-theme-node-modules
+```
+
+Expected: the temporary dependency volume is deleted. Do not run `gh pr merge`.

--- a/docs/superpowers/specs/2026-09-06-theme-switcher-completion-design.md
+++ b/docs/superpowers/specs/2026-09-06-theme-switcher-completion-design.md
@@ -1,0 +1,65 @@
+# Theme Switcher Completion Design
+
+## Goal
+
+Finish PR #221 as a reliable, persisted switch between the existing pixel-art presentation and a corporate presentation, including the in-progress Iconify work, while preserving unrelated local changes and leaving the final merge to the repository owner.
+
+## Scope
+
+The feature includes:
+
+- The existing Pixel/Corporate header toggle in both application entry modes.
+- Persisted theme selection through the existing node-theme provider.
+- Theme-aware node variants, data-pixel rendering, and graph layout.
+- Corporate node boxes with type-specific Iconify imagery.
+- Explicit custom Iconify IDs and emoji overriding type defaults.
+- Six aligned color/filter slots for each theme.
+
+The following local work is excluded:
+
+- `packages/web/src/hooks/useFlowPolling.ts`
+- `.claude/`
+- `docs/orion-slack-v1-flows.md`
+
+## Component Boundaries
+
+`node-themes.ts` remains the source of truth for theme IDs, labels, persistence, and six-slot palettes.
+
+The React context value and `useNodeTheme` hook move into a non-component module. `NodeThemeContext.tsx` exports only `NodeThemeProvider`, satisfying `react-refresh/only-export-components` without weakening lint rules.
+
+`iconify.ts` owns default node-type Iconify IDs, Iconify ID recognition, URL construction, and explicit-icon resolution. `CorporateBuilding.tsx` owns corporate presentation, including the textual type badge used as a fallback.
+
+`FlowNode.tsx` selects the corporate or pixel renderer. Pixel nodes retain the existing external custom-icon overlay; corporate nodes render the resolved icon inside the node box.
+
+## Rendering Behavior
+
+Pixel mode keeps existing sprite rendering, hue filters, neon accents, carrot data pixels, and custom overlays.
+
+Corporate mode uses flat accent colors, rectangular node boxes, round data pixels, and centered type icons. A badge is rendered beneath each network image so an Iconify load failure reveals meaningful text rather than an empty node. Explicit emoji render directly and do not make a network request.
+
+The sixth pixel slot uses a distinct yellow accent with a matching hue filter. The sixth corporate slot uses a distinct muted violet accent. Filter and accent arrays remain the same length.
+
+## Error Handling
+
+Invalid or unknown stored theme values continue falling back to Pixel mode. Local-storage access remains guarded for private-mode and quota failures.
+
+Malformed or unknown Iconify/type input falls back to the service icon. Failed CDN image loads hide only the image, exposing the underlying type badge. The feature adds no mandatory runtime package or bundled icon dependency.
+
+## Testing
+
+Focused tests verify:
+
+- Pixel and corporate palettes each contain six aligned slots.
+- The sixth same-type node receives the sixth color and the seventh wraps to the first.
+- Corporate variants do not apply hue filters.
+- Iconify URLs correctly handle monochrome recoloring and colorful icon sets.
+- Explicit Iconify IDs override type defaults, while unknown types use the service icon.
+- Corporate markup includes both the network image and badge fallback; emoji markup does not include an Iconify request.
+
+Repository verification runs web tests, lint, formatting, typecheck, and build. GitHub checks must pass after the branch is rebased and pushed.
+
+## Branch and Local-Work Safety
+
+Only theme-related files and this design are committed. The unrelated tracked polling edit is stashed by explicit path immediately before rebasing and restored immediately afterward. Untracked `.claude/` and Orion documentation remain untouched.
+
+The feature branch is rebased onto `origin/master` and updated with `--force-with-lease`, never an unconditional force push. PR #221 remains open after all checks pass; the repository owner performs the final merge.

--- a/packages/web/__tests__/corporate-building.test.ts
+++ b/packages/web/__tests__/corporate-building.test.ts
@@ -1,0 +1,34 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { CorporateBuilding } from '../src/components/nodes/CorporateBuilding'
+
+describe('CorporateBuilding', () => {
+  it('renders an Iconify image over a textual type fallback', () => {
+    const markup = renderToStaticMarkup(
+      createElement(CorporateBuilding, {
+        color: '#2563eb',
+        nodeType: 'database',
+        label: 'Orders',
+      })
+    )
+
+    expect(markup).toContain('api.iconify.design/mdi/database.svg')
+    expect(markup).toContain('>DB</span>')
+    expect(markup).toContain('alt="Orders"')
+  })
+
+  it('renders explicit emoji without an Iconify request', () => {
+    const markup = renderToStaticMarkup(
+      createElement(CorporateBuilding, {
+        color: '#2563eb',
+        nodeType: 'custom',
+        icon: '🚀',
+        label: 'Launch',
+      })
+    )
+
+    expect(markup).toContain('🚀')
+    expect(markup).not.toContain('api.iconify.design')
+  })
+})

--- a/packages/web/__tests__/iconify.test.ts
+++ b/packages/web/__tests__/iconify.test.ts
@@ -5,6 +5,8 @@ describe('isIconifyId', () => {
   it('accepts one valid prefix/name separator only', () => {
     expect(isIconifyId('mdi:database')).toBe(true)
     expect(isIconifyId('logos:kubernetes')).toBe(true)
+    expect(isIconifyId('MDI:database')).toBe(false)
+    expect(isIconifyId('mdi:database_name')).toBe(false)
     expect(isIconifyId('mdi:database:extra')).toBe(false)
     expect(isIconifyId(':database')).toBe(false)
     expect(isIconifyId('mdi:')).toBe(false)

--- a/packages/web/__tests__/iconify.test.ts
+++ b/packages/web/__tests__/iconify.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { NODE_TYPE_ICON, iconifySvgUrl, isIconifyId, resolveNodeTypeIcon } from '../src/lib/iconify'
+
+describe('isIconifyId', () => {
+  it('accepts one valid prefix/name separator only', () => {
+    expect(isIconifyId('mdi:database')).toBe(true)
+    expect(isIconifyId('logos:kubernetes')).toBe(true)
+    expect(isIconifyId('mdi:database:extra')).toBe(false)
+    expect(isIconifyId(':database')).toBe(false)
+    expect(isIconifyId('mdi:')).toBe(false)
+  })
+})
+
+describe('iconifySvgUrl', () => {
+  it('builds Iconify CDN URLs', () => {
+    expect(iconifySvgUrl('logos:postgresql')).toBe(
+      'https://api.iconify.design/logos/postgresql.svg'
+    )
+  })
+
+  it('recolors monotone icons', () => {
+    expect(iconifySvgUrl('mdi:api', '#2563eb')).toBe(
+      'https://api.iconify.design/mdi/api.svg?color=%232563eb'
+    )
+  })
+
+  it('skips recolor for colorful logo sets', () => {
+    expect(iconifySvgUrl('logos:redis', '#2563eb')).toBe(
+      'https://api.iconify.design/logos/redis.svg'
+    )
+  })
+})
+
+describe('resolveNodeTypeIcon', () => {
+  it('prefers an explicit node icon', () => {
+    expect(resolveNodeTypeIcon('database', 'logos:stripe')).toBe('logos:stripe')
+  })
+
+  it('falls back to the type default', () => {
+    expect(resolveNodeTypeIcon('database')).toBe(NODE_TYPE_ICON.database)
+    expect(resolveNodeTypeIcon('unknown')).toBe(NODE_TYPE_ICON.service)
+  })
+
+  it('rejects malformed custom IDs', () => {
+    expect(resolveNodeTypeIcon('database', 'mdi:database:extra')).toBe(NODE_TYPE_ICON.database)
+  })
+
+  it('uses graphical icons, not text abbreviations', () => {
+    expect(NODE_TYPE_ICON.endpoint).not.toBe('mdi:api')
+  })
+})

--- a/packages/web/__tests__/pixel-palette.test.ts
+++ b/packages/web/__tests__/pixel-palette.test.ts
@@ -90,3 +90,19 @@ describe('resolvePixelStyle', () => {
     })
   })
 })
+
+describe('assignNodeVariants (corporate theme)', () => {
+  it('uses flat accent colors without hue-rotate filters', () => {
+    const variants = assignNodeVariants(
+      [
+        { id: 'a', type: 'service' },
+        { id: 'b', type: 'service' },
+      ],
+      'corporate'
+    )
+    expect(variants.get('a')?.filter).toBeUndefined()
+    expect(variants.get('b')?.filter).toBeUndefined()
+    expect(variants.get('a')?.color).toBe('#2563eb')
+    expect(variants.get('b')?.color).toBe('#475569')
+  })
+})

--- a/packages/web/__tests__/pixel-palette.test.ts
+++ b/packages/web/__tests__/pixel-palette.test.ts
@@ -6,6 +6,29 @@ import {
   stepPixelColor,
   stepPixelFilter,
 } from '../src/lib/pixel-palette'
+import { CORPORATE_THEME_PALETTE, PIXEL_THEME_PALETTE } from '../src/lib/node-themes'
+
+describe('theme palette shape', () => {
+  it.each([
+    { name: 'pixel', palette: PIXEL_THEME_PALETTE },
+    { name: 'corporate', palette: CORPORATE_THEME_PALETTE },
+  ])('$name has six aligned filter and accent slots', ({ palette }) => {
+    expect(palette.variantFilters).toHaveLength(6)
+    expect(palette.variantAccents).toHaveLength(6)
+  })
+
+  it('uses slot six before wrapping the seventh same-type node', () => {
+    const variants = assignNodeVariants(
+      Array.from({ length: 7 }, (_, index) => ({
+        id: `service-${index}`,
+        type: 'service',
+      }))
+    )
+
+    expect(variants.get('service-5')?.color).toBe(PIXEL_THEME_PALETTE.variantAccents[5])
+    expect(variants.get('service-6')?.color).toBe(PIXEL_THEME_PALETTE.variantAccents[0])
+  })
+})
 
 describe('assignNodeVariants', () => {
   it('gives the first node of each independent type the original (orange) accent', () => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -10,6 +10,7 @@ const FlowEditorModal = lazy(() =>
 import { buildStarterYaml } from './lib/starter-yaml'
 import { buildPagesShareUrl } from './lib/share-url'
 import { isMobileViewport } from './lib/mobile'
+import { ThemeToggle } from './components/ThemeToggle'
 import { useFlowList, useFlowData } from './hooks/useFlowPolling'
 import { useFlowMutations } from './hooks/useFlowMutations'
 import type { FlowNode, FlowStep, FlowData, Flow } from './types'
@@ -436,6 +437,7 @@ function App() {
           </h1>
         </div>
         <div className="flex items-center gap-2">
+          <ThemeToggle />
           {apiFlow && (
             <button
               onClick={handleShareFlow}

--- a/packages/web/src/AppFragment.tsx
+++ b/packages/web/src/AppFragment.tsx
@@ -16,6 +16,7 @@ import { buildShareUrl, decodeFragment, encodeFragment } from './lib/share-url'
 import { setHashWithoutUmamiPageView, trackPageViewIfEnabled } from './lib/umami.ts'
 import { EXAMPLE_FLOWS } from './lib/example-flows'
 import { isMobileViewport } from './lib/mobile'
+import { ThemeToggle } from './components/ThemeToggle'
 import type { FlowListItem } from './hooks/useFlowPolling'
 import type { FlowNode, FlowStep, FlowData, Flow } from './types'
 
@@ -349,6 +350,7 @@ export default function AppFragment() {
           <span className="font-terminal text-text/40 text-xs">share via URL</span>
         </div>
         <div className="flex items-center gap-2">
+          <ThemeToggle />
           <button
             onClick={handleNewFlow}
             className="openhop-header-btn font-pixel text-xs px-3 py-1 border transition-colors"

--- a/packages/web/src/components/DataPixel.tsx
+++ b/packages/web/src/components/DataPixel.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { useViewport } from '@xyflow/react'
 import type { FlowStep, FlowData } from '../types'
+import { useNodeTheme } from '../context/NodeThemeContext'
+import { PIXEL_THEME_PALETTE } from '../lib/node-themes'
 import { DataTooltip } from './DataTooltip'
 
 // Use Vite's BASE_URL so the sprite resolves under the project base on
 // the Pages deploy (`/openhop/sprites/...`) and at the root in dev (`/`).
 const CARROT_SPRITE = `${import.meta.env.BASE_URL}sprites/carrot_pixels.svg`
-const DEFAULT_PIXEL_COLOR = '#ff8a4a' // VARIANT_ACCENT[0] — sprite's original orange.
+const DEFAULT_PIXEL_COLOR = PIXEL_THEME_PALETTE.variantAccents[0]
 
 interface DataPixelProps {
   edgeId: string
@@ -58,6 +60,8 @@ export function DataPixel({
   dataOverride,
   paused = false,
 }: DataPixelProps) {
+  const { themeId } = useNodeTheme()
+  const isCorporate = themeId === 'corporate'
   const pixelRef = useRef<HTMLDivElement>(null)
   const rafRef = useRef<number>(0)
   const startTimeRef = useRef<number>(0)
@@ -235,23 +239,36 @@ export function DataPixel({
         <div
           className="data-pixel-sprite"
           style={{
-            filter: `drop-shadow(0 0 6px ${color})`,
+            filter: isCorporate ? undefined : `drop-shadow(0 0 6px ${color})`,
+            width: '100%',
+            height: '100%',
           }}
         >
-          <img
-            src={CARROT_SPRITE}
-            alt=""
-            style={{
-              width: '100%',
-              height: '100%',
-              imageRendering: 'pixelated',
-              display: 'block',
-              // Hue-rotate is applied directly to the <img> so the carrot's
-              // own pixel colors shift (the wrapper's drop-shadow then reads
-              // from the rotated alpha, keeping the glow in sync).
-              filter: pixelFilter,
-            }}
-          />
+          {isCorporate ? (
+            <div
+              data-testid="corporate-pixel"
+              style={{
+                width: '100%',
+                height: '100%',
+                borderRadius: '50%',
+                background: color,
+                boxShadow: `0 0 8px ${color}aa`,
+                border: '2px solid #ffffff',
+              }}
+            />
+          ) : (
+            <img
+              src={CARROT_SPRITE}
+              alt=""
+              style={{
+                width: '100%',
+                height: '100%',
+                imageRendering: 'pixelated',
+                display: 'block',
+                filter: pixelFilter,
+              }}
+            />
+          )}
         </div>
       </div>
       {hovered && position && (

--- a/packages/web/src/components/DataPixel.tsx
+++ b/packages/web/src/components/DataPixel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { useViewport } from '@xyflow/react'
 import type { FlowStep, FlowData } from '../types'
-import { useNodeTheme } from '../context/NodeThemeContext'
+import { useNodeTheme } from '../context/node-theme-context'
 import { PIXEL_THEME_PALETTE } from '../lib/node-themes'
 import { DataTooltip } from './DataTooltip'
 

--- a/packages/web/src/components/FlowCanvas.tsx
+++ b/packages/web/src/components/FlowCanvas.tsx
@@ -22,7 +22,7 @@ import { DataPixel } from './DataPixel'
 import { buildFlowTopology } from '../lib/flow-layout'
 import { resolvePixelStyle, type ResolvedStepPixel } from '../lib/pixel-palette'
 import type { NodeThemeId } from '../lib/node-themes'
-import { useNodeTheme } from '../context/NodeThemeContext'
+import { useNodeTheme } from '../context/node-theme-context'
 import type { Flow, FlowStep, FlowData } from '../types'
 
 /** One carrot to render for a step. `dataObj` is set only for multi-data

--- a/packages/web/src/components/FlowCanvas.tsx
+++ b/packages/web/src/components/FlowCanvas.tsx
@@ -21,6 +21,8 @@ import { useFlowGraphLayout } from '../hooks/useFlowGraphLayout'
 import { DataPixel } from './DataPixel'
 import { buildFlowTopology } from '../lib/flow-layout'
 import { resolvePixelStyle, type ResolvedStepPixel } from '../lib/pixel-palette'
+import type { NodeThemeId } from '../lib/node-themes'
+import { useNodeTheme } from '../context/NodeThemeContext'
 import type { Flow, FlowStep, FlowData } from '../types'
 
 /** One carrot to render for a step. `dataObj` is set only for multi-data
@@ -35,7 +37,11 @@ interface StepPixelPlan extends ResolvedStepPixel {
   delayMs: number
 }
 
-function planStepPixels(edgeFlows: EdgeFlowRef[], fallbackStep?: FlowStep): StepPixelPlan[] {
+function planStepPixels(
+  edgeFlows: EdgeFlowRef[],
+  themeId: NodeThemeId,
+  fallbackStep?: FlowStep
+): StepPixelPlan[] {
   const totalPixels = edgeFlows.reduce((sum, ef) => {
     const data = (ef.step ?? fallbackStep)?.data
     return sum + (Array.isArray(data) ? data.length : 1)
@@ -53,7 +59,7 @@ function planStepPixels(edgeFlows: EdgeFlowRef[], fallbackStep?: FlowStep): Step
           dataObj,
           dataIndex,
           delayMs: dataIndex * 280,
-          ...resolvePixelStyle(cycle, pixelIdx++, dataObj.color),
+          ...resolvePixelStyle(cycle, pixelIdx++, dataObj.color, themeId),
         })
       })
     } else {
@@ -62,7 +68,7 @@ function planStepPixels(edgeFlows: EdgeFlowRef[], fallbackStep?: FlowStep): Step
         edgeFlow,
         edgeFlowIndex,
         delayMs: 0,
-        ...resolvePixelStyle(cycle, pixelIdx++, singleColor),
+        ...resolvePixelStyle(cycle, pixelIdx++, singleColor, themeId),
       })
     }
   })
@@ -118,6 +124,7 @@ function FlowCanvasInner({
   onInspectStep,
 }: FlowCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null)
+  const { themeId } = useNodeTheme()
   const flowSteps = useMemo(() => flow.flow.steps ?? [], [flow.flow.steps])
 
   const { nodes: baseNodes, edges: baseEdges } = useFlowGraphLayout(flow)
@@ -310,7 +317,7 @@ function FlowCanvasInner({
   // (rather than just flow.flow.nodes) also covers dynamic nodes spawned
   // by `create:` steps so their pixels get a real variant color too.
   const nodeTypeMap = useMemo(() => {
-    const topology = buildFlowTopology(flow)
+    const topology = buildFlowTopology(flow, themeId)
     const explicitColors = new Map<string, string>()
     for (const n of flow.flow.nodes) {
       // A `custom`-typed node with an explicit hex color keeps that color
@@ -325,7 +332,7 @@ function FlowCanvasInner({
       })
     }
     return map
-  }, [flow])
+  }, [flow, themeId])
 
   const {
     fireManualPixel,
@@ -607,7 +614,7 @@ function FlowCanvasInner({
 
       // Click-to-fire uses the same plan as autoplay so manual pixels get
       // the same multi-data expansion + palette cycling.
-      for (const plan of planStepPixels(entry.edgeFlows, entry.step)) {
+      for (const plan of planStepPixels(entry.edgeFlows, themeId, entry.step)) {
         fireManualPixel({
           edgeId: plan.edgeFlow.edgeId,
           reverse: plan.edgeFlow.reverse,
@@ -870,7 +877,7 @@ function FlowCanvasInner({
           one is distinct; single-carrot steps keep the source node's
           variant color via DataPixel's sourceNodeColor fallback. */}
       {animState.activeStep &&
-        planStepPixels(activeEdgeFlows, animState.activeStep).map((plan) => {
+        planStepPixels(activeEdgeFlows, themeId, animState.activeStep).map((plan) => {
           const { edgeFlow, edgeFlowIndex, dataObj, dataIndex } = plan
           const sourceInfo = nodeTypeMap.get(edgeFlow.fromId) ?? { type: 'service' }
           const edgeStep = edgeFlow.step ?? animState.activeStep!

--- a/packages/web/src/components/ThemeToggle.tsx
+++ b/packages/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,38 @@
+import { NODE_THEME_IDS, NODE_THEME_LABELS } from '../lib/node-themes'
+import { useNodeTheme } from '../context/NodeThemeContext'
+
+export function ThemeToggle() {
+  const { themeId, setThemeId } = useNodeTheme()
+
+  return (
+    <div
+      role="group"
+      aria-label="Node theme"
+      className="inline-flex rounded border overflow-hidden"
+      style={{ borderColor: '#1a4a22' }}
+    >
+      {NODE_THEME_IDS.map((id) => {
+        const active = themeId === id
+        return (
+          <button
+            key={id}
+            type="button"
+            data-testid={`theme-${id}`}
+            aria-pressed={active}
+            onClick={() => setThemeId(id)}
+            className="openhop-header-btn font-pixel text-xs px-2.5 py-1 transition-colors"
+            style={{
+              fontSize: 10,
+              background: active ? '#1a4a22' : 'transparent',
+              color: active ? '#7fff7f' : '#6b9b6b',
+              border: 'none',
+              borderRight: id === 'pixel' ? '1px solid #1a4a22' : undefined,
+            }}
+          >
+            {NODE_THEME_LABELS[id]}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/web/src/components/ThemeToggle.tsx
+++ b/packages/web/src/components/ThemeToggle.tsx
@@ -1,5 +1,5 @@
 import { NODE_THEME_IDS, NODE_THEME_LABELS } from '../lib/node-themes'
-import { useNodeTheme } from '../context/NodeThemeContext'
+import { useNodeTheme } from '../context/node-theme-context'
 
 export function ThemeToggle() {
   const { themeId, setThemeId } = useNodeTheme()

--- a/packages/web/src/components/nodes/CorporateBuilding.tsx
+++ b/packages/web/src/components/nodes/CorporateBuilding.tsx
@@ -1,13 +1,45 @@
-import { corporateTypeBadge } from '../../lib/node-themes'
+import { iconifySvgUrl, resolveNodeTypeIcon } from '../../lib/iconify'
 import { SPRITE_SIZE, type BuildingProps } from './node-sprites'
 
 const BOX_SIZE = 88
+const ICON_SIZE = 40
+
+const CORPORATE_TYPE_BADGE: Record<string, string> = {
+  actor: 'USR',
+  endpoint: 'API',
+  auth: 'AUTH',
+  database: 'DB',
+  external: 'EXT',
+  cache: 'CACHE',
+  queue: 'QUEUE',
+  service: 'SVC',
+  docker: 'DKR',
+  k8s: 'K8S',
+  scheduler: 'CRON',
+  ai_agent: 'AI',
+  browser: 'WEB',
+  transform: 'XFORM',
+  validation: 'VALID',
+  custom: 'NODE',
+}
+
+function corporateTypeBadge(nodeType: string): string {
+  const derived = nodeType
+    .slice(0, 3)
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '')
+  return CORPORATE_TYPE_BADGE[nodeType] ?? (derived || 'NODE')
+}
 
 export function CorporateBuilding({
   color,
   active,
   nodeType = 'service',
-}: BuildingProps & { nodeType?: string }) {
+  icon,
+  label,
+}: BuildingProps & { nodeType?: string; icon?: string; label?: string }) {
+  const resolvedIcon = resolveNodeTypeIcon(nodeType, icon)
+  const showEmoji = Boolean(icon && !icon.includes(':'))
   const badge = corporateTypeBadge(nodeType)
 
   return (
@@ -33,10 +65,8 @@ export function CorporateBuilding({
           border: `2px solid ${color}`,
           boxShadow: active ? `0 0 10px ${color}88, 0 2px 8px #00000044` : '0 2px 6px #00000033',
           display: 'flex',
-          flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 4,
           transition: 'box-shadow 0.2s ease',
         }}
       >
@@ -51,18 +81,42 @@ export function CorporateBuilding({
             background: color,
           }}
         />
-        <span
-          style={{
-            fontFamily: 'system-ui, -apple-system, Segoe UI, sans-serif',
-            fontSize: 13,
-            fontWeight: 700,
-            letterSpacing: 0.6,
-            color,
-            lineHeight: 1,
-          }}
-        >
-          {badge}
-        </span>
+        {showEmoji ? (
+          <span style={{ fontSize: ICON_SIZE - 8, lineHeight: 1 }} aria-hidden="true">
+            {icon}
+          </span>
+        ) : (
+          <>
+            <span
+              aria-hidden="true"
+              style={{
+                fontFamily: 'system-ui, -apple-system, Segoe UI, sans-serif',
+                fontSize: 13,
+                fontWeight: 700,
+                letterSpacing: 0.6,
+                color,
+                lineHeight: 1,
+              }}
+            >
+              {badge}
+            </span>
+            <img
+              src={iconifySvgUrl(resolvedIcon, color)}
+              alt={label ?? nodeType}
+              width={ICON_SIZE}
+              height={ICON_SIZE}
+              style={{
+                position: 'absolute',
+                display: 'block',
+                objectFit: 'contain',
+                background: '#f8fafc',
+              }}
+              onError={(event) => {
+                ;(event.currentTarget as HTMLElement).style.display = 'none'
+              }}
+            />
+          </>
+        )}
       </div>
     </div>
   )

--- a/packages/web/src/components/nodes/CorporateBuilding.tsx
+++ b/packages/web/src/components/nodes/CorporateBuilding.tsx
@@ -1,0 +1,69 @@
+import { corporateTypeBadge } from '../../lib/node-themes'
+import { SPRITE_SIZE, type BuildingProps } from './node-sprites'
+
+const BOX_SIZE = 88
+
+export function CorporateBuilding({
+  color,
+  active,
+  nodeType = 'service',
+}: BuildingProps & { nodeType?: string }) {
+  const badge = corporateTypeBadge(nodeType)
+
+  return (
+    <div
+      data-testid="corporate-node"
+      style={{
+        width: SPRITE_SIZE,
+        height: SPRITE_SIZE,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        willChange: 'transform',
+        transform: 'translate3d(0, 0, 0)',
+      }}
+    >
+      <div
+        style={{
+          position: 'relative',
+          width: BOX_SIZE,
+          height: BOX_SIZE,
+          borderRadius: 8,
+          background: '#f8fafc',
+          border: `2px solid ${color}`,
+          boxShadow: active ? `0 0 10px ${color}88, 0 2px 8px #00000044` : '0 2px 6px #00000033',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 4,
+          transition: 'box-shadow 0.2s ease',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            left: 6,
+            top: 8,
+            width: 4,
+            height: BOX_SIZE - 16,
+            borderRadius: 2,
+            background: color,
+          }}
+        />
+        <span
+          style={{
+            fontFamily: 'system-ui, -apple-system, Segoe UI, sans-serif',
+            fontSize: 13,
+            fontWeight: 700,
+            letterSpacing: 0.6,
+            color,
+            lineHeight: 1,
+          }}
+        >
+          {badge}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/nodes/FlowNode.tsx
+++ b/packages/web/src/components/nodes/FlowNode.tsx
@@ -2,7 +2,8 @@ import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import type { FlowData } from '../../types'
-import { useNodeTheme } from '../../context/NodeThemeContext'
+import { useNodeTheme } from '../../context/node-theme-context'
+import { iconifySvgUrl, isIconifyId } from '../../lib/iconify'
 import { NODE_TYPE_SPRITE } from './node-sprites'
 import { SpriteBuilding } from './NodeBuilding'
 import { CorporateBuilding } from './CorporateBuilding'
@@ -84,11 +85,8 @@ function FlowNodeComponentInner({ data, id }: NodeProps<FlowNodeType>) {
   // (e.g. type=database + icon=logos:postgresql renders the DB sprite plus the postgres logo).
   let customIconOverlay: React.ReactNode = null
   if (icon) {
-    if (icon.includes(':')) {
-      const [prefix, name] = icon.split(':')
-      // ?color=white recolors monotone icons (those that use fill/stroke="currentColor")
-      // for the dark canvas. It's a no-op on icons that have explicit fills baked in.
-      const url = `https://api.iconify.design/${prefix}/${name}.svg?color=white`
+    if (isIconifyId(icon)) {
+      const url = iconifySvgUrl(icon, 'white')
       customIconOverlay = (
         <img
           src={url}
@@ -101,12 +99,12 @@ function FlowNodeComponentInner({ data, id }: NodeProps<FlowNodeType>) {
             left: 'calc(100% - 14px)',
             imageRendering: 'auto',
           }}
-          onError={(e) => {
-            ;(e.target as HTMLElement).style.display = 'none'
+          onError={(event) => {
+            ;(event.currentTarget as HTMLElement).style.display = 'none'
           }}
         />
       )
-    } else {
+    } else if (!icon.includes(':')) {
       customIconOverlay = (
         <span
           style={{
@@ -203,6 +201,8 @@ function FlowNodeComponentInner({ data, id }: NodeProps<FlowNodeType>) {
             color={borderColor}
             active={isActive}
             nodeType={nodeType}
+            icon={icon}
+            label={label}
           />
         ) : (
           <SpriteBuilding
@@ -213,7 +213,7 @@ function FlowNodeComponentInner({ data, id }: NodeProps<FlowNodeType>) {
             variantFilter={variantFilter}
           />
         )}
-        {customIconOverlay}
+        {!isCorporate && customIconOverlay}
         {hasSubFlow && (
           <button
             aria-label="Drill down"

--- a/packages/web/src/components/nodes/FlowNode.tsx
+++ b/packages/web/src/components/nodes/FlowNode.tsx
@@ -2,8 +2,10 @@ import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import type { FlowData } from '../../types'
+import { useNodeTheme } from '../../context/NodeThemeContext'
 import { NODE_TYPE_SPRITE } from './node-sprites'
 import { SpriteBuilding } from './NodeBuilding'
+import { CorporateBuilding } from './CorporateBuilding'
 
 /** Node type color config */
 const NODE_STYLES: Record<string, { bg: string; border: string }> = {
@@ -63,6 +65,9 @@ function FlowNodeComponentInner({ data, id }: NodeProps<FlowNodeType>) {
     variantFilter,
     variantColor,
   } = data
+
+  const { themeId } = useNodeTheme()
+  const isCorporate = themeId === 'corporate'
 
   // Use outgoing step count for progress bar (how many steps this node sends)
   const progressTotal = outgoingStepCount ?? totalSteps
@@ -193,13 +198,21 @@ function FlowNodeComponentInner({ data, id }: NodeProps<FlowNodeType>) {
           transition: 'filter 0.2s ease',
         }}
       >
-        <SpriteBuilding
-          src={NODE_TYPE_SPRITE[nodeType] ?? NODE_TYPE_SPRITE.service}
-          color={borderColor}
-          active={isActive}
-          nodeType={nodeType}
-          variantFilter={variantFilter}
-        />
+        {isCorporate ? (
+          <CorporateBuilding
+            color={borderColor}
+            active={isActive}
+            nodeType={nodeType}
+          />
+        ) : (
+          <SpriteBuilding
+            src={NODE_TYPE_SPRITE[nodeType] ?? NODE_TYPE_SPRITE.service}
+            color={borderColor}
+            active={isActive}
+            nodeType={nodeType}
+            variantFilter={variantFilter}
+          />
+        )}
         {customIconOverlay}
         {hasSubFlow && (
           <button

--- a/packages/web/src/context/NodeThemeContext.tsx
+++ b/packages/web/src/context/NodeThemeContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+import {
+  loadStoredNodeTheme,
+  storeNodeTheme,
+  type NodeThemeId,
+} from '../lib/node-themes'
+
+interface NodeThemeContextValue {
+  themeId: NodeThemeId
+  setThemeId: (id: NodeThemeId) => void
+}
+
+const NodeThemeContext = createContext<NodeThemeContextValue | null>(null)
+
+export function NodeThemeProvider({ children }: { children: ReactNode }) {
+  const [themeId, setThemeIdState] = useState<NodeThemeId>(() => loadStoredNodeTheme())
+
+  const setThemeId = useCallback((id: NodeThemeId) => {
+    setThemeIdState(id)
+    storeNodeTheme(id)
+  }, [])
+
+  const value = useMemo(() => ({ themeId, setThemeId }), [themeId, setThemeId])
+
+  return <NodeThemeContext.Provider value={value}>{children}</NodeThemeContext.Provider>
+}
+
+export function useNodeTheme(): NodeThemeContextValue {
+  const ctx = useContext(NodeThemeContext)
+  if (!ctx) throw new Error('useNodeTheme must be used within NodeThemeProvider')
+  return ctx
+}

--- a/packages/web/src/context/NodeThemeContext.tsx
+++ b/packages/web/src/context/NodeThemeContext.tsx
@@ -1,16 +1,6 @@
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
-import {
-  loadStoredNodeTheme,
-  storeNodeTheme,
-  type NodeThemeId,
-} from '../lib/node-themes'
-
-interface NodeThemeContextValue {
-  themeId: NodeThemeId
-  setThemeId: (id: NodeThemeId) => void
-}
-
-const NodeThemeContext = createContext<NodeThemeContextValue | null>(null)
+import { useCallback, useMemo, useState, type ReactNode } from 'react'
+import { loadStoredNodeTheme, storeNodeTheme, type NodeThemeId } from '../lib/node-themes'
+import { NodeThemeContext } from './node-theme-context'
 
 export function NodeThemeProvider({ children }: { children: ReactNode }) {
   const [themeId, setThemeIdState] = useState<NodeThemeId>(() => loadStoredNodeTheme())
@@ -23,10 +13,4 @@ export function NodeThemeProvider({ children }: { children: ReactNode }) {
   const value = useMemo(() => ({ themeId, setThemeId }), [themeId, setThemeId])
 
   return <NodeThemeContext.Provider value={value}>{children}</NodeThemeContext.Provider>
-}
-
-export function useNodeTheme(): NodeThemeContextValue {
-  const ctx = useContext(NodeThemeContext)
-  if (!ctx) throw new Error('useNodeTheme must be used within NodeThemeProvider')
-  return ctx
 }

--- a/packages/web/src/context/node-theme-context.ts
+++ b/packages/web/src/context/node-theme-context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+import type { NodeThemeId } from '../lib/node-themes'
+
+export interface NodeThemeContextValue {
+  themeId: NodeThemeId
+  setThemeId: (id: NodeThemeId) => void
+}
+
+export const NodeThemeContext = createContext<NodeThemeContextValue | null>(null)
+
+export function useNodeTheme(): NodeThemeContextValue {
+  const context = useContext(NodeThemeContext)
+  if (!context) throw new Error('useNodeTheme must be used within NodeThemeProvider')
+  return context
+}

--- a/packages/web/src/hooks/useFlowGraphLayout.ts
+++ b/packages/web/src/hooks/useFlowGraphLayout.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Flow } from '../types'
-import { useNodeTheme } from '../context/NodeThemeContext'
+import { useNodeTheme } from '../context/node-theme-context'
 import {
   buildFlowTopology,
   buildReactFlowGraph,

--- a/packages/web/src/hooks/useFlowGraphLayout.ts
+++ b/packages/web/src/hooks/useFlowGraphLayout.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Flow } from '../types'
+import { useNodeTheme } from '../context/NodeThemeContext'
 import {
   buildFlowTopology,
   buildReactFlowGraph,
@@ -8,7 +9,8 @@ import {
 } from '../lib/flow-layout'
 
 export function useFlowGraphLayout(flow: Flow) {
-  const topology = useMemo(() => buildFlowTopology(flow), [flow])
+  const { themeId } = useNodeTheme()
+  const topology = useMemo(() => buildFlowTopology(flow, themeId), [flow, themeId])
 
   const fallbackGraph = useMemo(() => {
     const fallbackPositions = computeFallbackPositions(topology)

--- a/packages/web/src/lib/flow-layout.ts
+++ b/packages/web/src/lib/flow-layout.ts
@@ -3,6 +3,7 @@ import type { Edge, Node } from '@xyflow/react'
 import type { Flow } from '../types'
 import type { FlowNodeData } from '../components/nodes/FlowNode'
 import { assignNodeVariants, type NodeVariant } from './pixel-palette'
+import type { NodeThemeId } from './node-themes'
 
 const elk = new ELK()
 
@@ -89,7 +90,7 @@ function pushOrdered(ordered: string[], seen: Set<string>, id?: string | null) {
   ordered.push(id)
 }
 
-export function buildFlowTopology(flow: Flow): FlowTopology {
+export function buildFlowTopology(flow: Flow, themeId: NodeThemeId = 'pixel'): FlowTopology {
   const flowNodes = flow.flow.nodes
   const steps = flow.flow.steps ?? []
   const ordered: string[] = []
@@ -251,7 +252,8 @@ export function buildFlowTopology(flow: Flow): FlowTopology {
   }
 
   const nodeVariants = assignNodeVariants(
-    ordered.map((id) => ({ id, type: nodeSnapshots.get(id)?.nodeType ?? 'service' }))
+    ordered.map((id) => ({ id, type: nodeSnapshots.get(id)?.nodeType ?? 'service' })),
+    themeId
   )
 
   return {

--- a/packages/web/src/lib/iconify.ts
+++ b/packages/web/src/lib/iconify.ts
@@ -1,0 +1,56 @@
+/**
+ * Iconify CDN helpers — same source as FlowNode custom service overlays
+ * (`https://api.iconify.design/{prefix}/{name}.svg`).
+ */
+
+/** Default Iconify icon per node type. Pick graphical icons — avoid text glyphs like `mdi:api`. */
+export const NODE_TYPE_ICON: Record<string, string> = {
+  actor: 'mdi:account-circle',
+  endpoint: 'mdi:access-point-network',
+  auth: 'mdi:shield-lock',
+  database: 'mdi:database',
+  external: 'mdi:cloud-outline',
+  cache: 'logos:redis',
+  queue: 'mdi:message-arrow-outline',
+  service: 'mdi:hexagon-multiple-outline',
+  docker: 'logos:docker-icon',
+  k8s: 'logos:kubernetes',
+  scheduler: 'mdi:calendar-clock',
+  ai_agent: 'mdi:robot-outline',
+  browser: 'logos:chrome',
+  transform: 'mdi:swap-horizontal',
+  validation: 'mdi:shield-check',
+  custom: 'mdi:shape-outline',
+}
+
+/** @deprecated use NODE_TYPE_ICON */
+export const CORPORATE_TYPE_ICON = NODE_TYPE_ICON
+
+/** Iconify sets that ship with their own colors — skip ?color= recoloring. */
+const COLORFUL_ICON_PREFIXES = new Set(['logos', 'twemoji', 'emojione', 'noto', 'fluent-emoji'])
+
+const ICONIFY_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*:[a-z0-9]+(?:[-_][a-z0-9]+)*$/i
+
+export function isIconifyId(icon: string | undefined): boolean {
+  return !!icon && ICONIFY_ID_PATTERN.test(icon)
+}
+
+/** Build an Iconify SVG URL. Pass `recolor` to tint monotone icons (e.g. white on dark canvas). */
+export function iconifySvgUrl(icon: string, recolor?: string): string {
+  const [prefix, name] = icon.split(':')
+  const base = `https://api.iconify.design/${prefix}/${name}.svg`
+  if (!recolor) return base
+  const [iconPrefix] = icon.split(':')
+  if (COLORFUL_ICON_PREFIXES.has(iconPrefix)) return base
+  const hex = recolor.replace('#', '')
+  return `${base}?color=%23${hex}`
+}
+
+/** Node's explicit `icon` wins; otherwise fall back to the type default. */
+export function resolveNodeTypeIcon(nodeType: string, customIcon?: string): string {
+  if (customIcon && isIconifyId(customIcon)) return customIcon
+  return NODE_TYPE_ICON[nodeType] ?? NODE_TYPE_ICON.service
+}
+
+/** @deprecated use resolveNodeTypeIcon */
+export const resolveCorporateNodeIcon = resolveNodeTypeIcon

--- a/packages/web/src/lib/iconify.ts
+++ b/packages/web/src/lib/iconify.ts
@@ -29,7 +29,7 @@ export const CORPORATE_TYPE_ICON = NODE_TYPE_ICON
 /** Iconify sets that ship with their own colors — skip ?color= recoloring. */
 const COLORFUL_ICON_PREFIXES = new Set(['logos', 'twemoji', 'emojione', 'noto', 'fluent-emoji'])
 
-const ICONIFY_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*:[a-z0-9]+(?:[-_][a-z0-9]+)*$/i
+const ICONIFY_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*:[a-z0-9]+(?:-[a-z0-9]+)*$/
 
 export function isIconifyId(icon: string | undefined): boolean {
   return !!icon && ICONIFY_ID_PATTERN.test(icon)

--- a/packages/web/src/lib/node-themes.ts
+++ b/packages/web/src/lib/node-themes.ts
@@ -23,14 +23,15 @@ export const PIXEL_THEME_PALETTE: NodeThemePalette = {
     'hue-rotate(90deg)',
     'hue-rotate(140deg)',
     'hue-rotate(320deg)',
+    'hue-rotate(45deg)',
   ],
-  variantAccents: ['#ff8a4a', '#b47aff', '#4aff7a', '#4a9eff', '#ff6b6b'],
+  variantAccents: ['#ff8a4a', '#b47aff', '#4aff7a', '#4a9eff', '#ff6b6b', '#ffd84a'],
 }
 
 /** Muted corporate palette — flat accent colors, no sprite filters. */
 export const CORPORATE_THEME_PALETTE: NodeThemePalette = {
-  variantFilters: [undefined, undefined, undefined, undefined, undefined],
-  variantAccents: ['#2563eb', '#475569', '#0d9488', '#1d4ed8', '#64748b'],
+  variantFilters: [undefined, undefined, undefined, undefined, undefined, undefined],
+  variantAccents: ['#2563eb', '#475569', '#0d9488', '#1d4ed8', '#64748b', '#7c3aed'],
 }
 
 export const NODE_THEME_PALETTES: Record<NodeThemeId, NodeThemePalette> = {
@@ -65,29 +66,4 @@ export function storeNodeTheme(themeId: NodeThemeId): void {
   } catch {
     // ignore quota / private mode
   }
-}
-
-/** Short type badge for corporate node boxes. */
-export const CORPORATE_TYPE_BADGE: Record<string, string> = {
-  actor: 'USR',
-  endpoint: 'API',
-  auth: 'AUTH',
-  database: 'DB',
-  external: 'EXT',
-  cache: 'CACHE',
-  queue: 'QUEUE',
-  service: 'SVC',
-  docker: 'DKR',
-  k8s: 'K8S',
-  scheduler: 'CRON',
-  ai_agent: 'AI',
-  browser: 'WEB',
-  transform: 'XFORM',
-  validation: 'VALID',
-  custom: 'NODE',
-}
-
-export function corporateTypeBadge(nodeType: string): string {
-  const derived = nodeType.slice(0, 3).toUpperCase().replace(/[^A-Z0-9]/g, '')
-  return CORPORATE_TYPE_BADGE[nodeType] ?? (derived || 'NODE')
 }

--- a/packages/web/src/lib/node-themes.ts
+++ b/packages/web/src/lib/node-themes.ts
@@ -1,0 +1,93 @@
+/**
+ * Node + data-pixel visual themes. Canvas chrome (background, edges, labels)
+ * stays unchanged — only sprite/pixel rendering switches.
+ */
+
+export type NodeThemeId = 'pixel' | 'corporate'
+
+export const NODE_THEME_IDS: readonly NodeThemeId[] = ['pixel', 'corporate']
+
+export const NODE_THEME_STORAGE_KEY = 'openhop-node-theme'
+
+export interface NodeThemePalette {
+  /** CSS filter for sprite hue cycling (pixel theme); undefined = use accent color directly. */
+  variantFilters: readonly (string | undefined)[]
+  variantAccents: readonly string[]
+}
+
+/** Current pixel-art palette — hue-rotate filters + neon accents. */
+export const PIXEL_THEME_PALETTE: NodeThemePalette = {
+  variantFilters: [
+    undefined,
+    'hue-rotate(210deg)',
+    'hue-rotate(90deg)',
+    'hue-rotate(140deg)',
+    'hue-rotate(320deg)',
+  ],
+  variantAccents: ['#ff8a4a', '#b47aff', '#4aff7a', '#4a9eff', '#ff6b6b'],
+}
+
+/** Muted corporate palette — flat accent colors, no sprite filters. */
+export const CORPORATE_THEME_PALETTE: NodeThemePalette = {
+  variantFilters: [undefined, undefined, undefined, undefined, undefined],
+  variantAccents: ['#2563eb', '#475569', '#0d9488', '#1d4ed8', '#64748b'],
+}
+
+export const NODE_THEME_PALETTES: Record<NodeThemeId, NodeThemePalette> = {
+  pixel: PIXEL_THEME_PALETTE,
+  corporate: CORPORATE_THEME_PALETTE,
+}
+
+export const NODE_THEME_LABELS: Record<NodeThemeId, string> = {
+  pixel: 'Pixel',
+  corporate: 'Corporate',
+}
+
+export function getNodeThemePalette(themeId: NodeThemeId): NodeThemePalette {
+  return NODE_THEME_PALETTES[themeId]
+}
+
+export function parseNodeThemeId(raw: string | null | undefined): NodeThemeId {
+  return raw === 'corporate' ? 'corporate' : 'pixel'
+}
+
+export function loadStoredNodeTheme(): NodeThemeId {
+  try {
+    return parseNodeThemeId(localStorage.getItem(NODE_THEME_STORAGE_KEY))
+  } catch {
+    return 'pixel'
+  }
+}
+
+export function storeNodeTheme(themeId: NodeThemeId): void {
+  try {
+    localStorage.setItem(NODE_THEME_STORAGE_KEY, themeId)
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+/** Short type badge for corporate node boxes. */
+export const CORPORATE_TYPE_BADGE: Record<string, string> = {
+  actor: 'USR',
+  endpoint: 'API',
+  auth: 'AUTH',
+  database: 'DB',
+  external: 'EXT',
+  cache: 'CACHE',
+  queue: 'QUEUE',
+  service: 'SVC',
+  docker: 'DKR',
+  k8s: 'K8S',
+  scheduler: 'CRON',
+  ai_agent: 'AI',
+  browser: 'WEB',
+  transform: 'XFORM',
+  validation: 'VALID',
+  custom: 'NODE',
+}
+
+export function corporateTypeBadge(nodeType: string): string {
+  const derived = nodeType.slice(0, 3).toUpperCase().replace(/[^A-Z0-9]/g, '')
+  return CORPORATE_TYPE_BADGE[nodeType] ?? (derived || 'NODE')
+}

--- a/packages/web/src/lib/pixel-palette.ts
+++ b/packages/web/src/lib/pixel-palette.ts
@@ -6,21 +6,16 @@
  * agree.
  */
 
-export const VARIANT_FILTER: readonly string[] = [
-  '', // original (orange)
-  'hue-rotate(210deg)', // purple
-  'hue-rotate(90deg)', // green
-  'hue-rotate(140deg)', // blue
-  'hue-rotate(320deg)', // red
-]
+import {
+  getNodeThemePalette,
+  PIXEL_THEME_PALETTE,
+  type NodeThemeId,
+} from './node-themes'
 
-export const VARIANT_ACCENT: readonly string[] = [
-  '#ff8a4a', // orange
-  '#b47aff', // purple
-  '#4aff7a', // green
-  '#4a9eff', // blue
-  '#ff6b6b', // red
-]
+/** @deprecated import from node-themes — kept for tests referencing palette slots */
+export const VARIANT_FILTER = PIXEL_THEME_PALETTE.variantFilters
+/** @deprecated import from node-themes — kept for tests referencing palette slots */
+export const VARIANT_ACCENT = PIXEL_THEME_PALETTE.variantAccents
 
 const FALLBACK_SPRITE_KEY = 'service'
 const TYPES_SHARING_SERVICE_SPRITE = new Set(['service', 'custom'])
@@ -30,6 +25,10 @@ export interface NodeVariant {
   color: string
 }
 
+function paletteFor(themeId: NodeThemeId = 'pixel') {
+  return getNodeThemePalette(themeId)
+}
+
 /**
  * Compute per-node variant assignments. `nodes` MUST be passed in the same
  * canonical order across all callers (this is what `topology.orderedIds`
@@ -37,17 +36,20 @@ export interface NodeVariant {
  * land on the same palette index for the same node.
  */
 export function assignNodeVariants(
-  nodes: ReadonlyArray<{ id: string; type: string }>
+  nodes: ReadonlyArray<{ id: string; type: string }>,
+  themeId: NodeThemeId = 'pixel'
 ): Map<string, NodeVariant> {
+  const { variantFilters, variantAccents } = paletteFor(themeId)
   const counters = new Map<string, number>()
   const out = new Map<string, NodeVariant>()
   for (const node of nodes) {
     const counterKey = TYPES_SHARING_SERVICE_SPRITE.has(node.type) ? FALLBACK_SPRITE_KEY : node.type
     const n = counters.get(counterKey) ?? 0
     counters.set(counterKey, n + 1)
+    const idx = n % variantAccents.length
     out.set(node.id, {
-      filter: VARIANT_FILTER[n % VARIANT_FILTER.length] || undefined,
-      color: VARIANT_ACCENT[n % VARIANT_ACCENT.length],
+      filter: variantFilters[idx] || undefined,
+      color: variantAccents[idx],
     })
   }
   return out
@@ -58,8 +60,9 @@ export function assignNodeVariants(
  * (multi-data, broadcast, or parallel). Each pixel cycles through
  * VARIANT_ACCENT so they render with distinguishable shadows.
  */
-export function stepPixelColor(index: number): string {
-  return VARIANT_ACCENT[index % VARIANT_ACCENT.length]
+export function stepPixelColor(index: number, themeId: NodeThemeId = 'pixel'): string {
+  const { variantAccents } = paletteFor(themeId)
+  return variantAccents[index % variantAccents.length]
 }
 
 /**
@@ -68,8 +71,9 @@ export function stepPixelColor(index: number): string {
  * without it, all carrots stay orange (the sprite's original hue) and only
  * the surrounding glow cycles.
  */
-export function stepPixelFilter(index: number): string | undefined {
-  return VARIANT_FILTER[index % VARIANT_FILTER.length] || undefined
+export function stepPixelFilter(index: number, themeId: NodeThemeId = 'pixel'): string | undefined {
+  const { variantFilters } = paletteFor(themeId)
+  return variantFilters[index % variantFilters.length] || undefined
 }
 
 /**
@@ -87,21 +91,17 @@ export interface ResolvedStepPixel {
 /**
  * Resolve the carrot styling for one pixel given its global index in the
  * step and the data entry it represents (if any).
- *
- * - When `cycle` is true (the step emits 2+ carrots) and the data entry
- *   has no explicit color, both pixelColor and pixelFilter come from the
- *   variant palette so each carrot in the step looks distinct.
- * - An explicit `data.color` always wins; the sprite filter is dropped
- *   so we don't tint over the user-chosen color.
- * - When `cycle` is false (single-carrot step) we leave both undefined,
- *   so DataPixel falls back to the source node's variant color.
  */
 export function resolvePixelStyle(
   cycle: boolean,
   index: number,
-  dataColor?: string
+  dataColor?: string,
+  themeId: NodeThemeId = 'pixel'
 ): ResolvedStepPixel {
   if (dataColor) return { pixelColor: dataColor, pixelFilter: undefined }
   if (!cycle) return { pixelColor: undefined, pixelFilter: undefined }
-  return { pixelColor: stepPixelColor(index), pixelFilter: stepPixelFilter(index) }
+  return {
+    pixelColor: stepPixelColor(index, themeId),
+    pixelFilter: stepPixelFilter(index, themeId),
+  }
 }

--- a/packages/web/src/lib/pixel-palette.ts
+++ b/packages/web/src/lib/pixel-palette.ts
@@ -6,11 +6,7 @@
  * agree.
  */
 
-import {
-  getNodeThemePalette,
-  PIXEL_THEME_PALETTE,
-  type NodeThemeId,
-} from './node-themes'
+import { getNodeThemePalette, PIXEL_THEME_PALETTE, type NodeThemeId } from './node-themes'
 
 /** @deprecated import from node-themes — kept for tests referencing palette slots */
 export const VARIANT_FILTER = PIXEL_THEME_PALETTE.variantFilters

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import AppFragment from './AppFragment.tsx'
+import { NodeThemeProvider } from './context/NodeThemeContext.tsx'
 import { initUmamiHashTracking } from './lib/umami.ts'
 
 initUmamiHashTracking()
@@ -15,5 +16,9 @@ initUmamiHashTracking()
 // Refresh requires component-shaped consts to be exported, and main.tsx
 // is the entry point that shouldn't export.
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>{import.meta.env.VITE_FRAGMENT_MODE === '1' ? <AppFragment /> : <App />}</StrictMode>
+  <StrictMode>
+    <NodeThemeProvider>
+      {import.meta.env.VITE_FRAGMENT_MODE === '1' ? <AppFragment /> : <App />}
+    </NodeThemeProvider>
+  </StrictMode>
 )


### PR DESCRIPTION
## Summary

- Add a **Pixel | Corporate** toggle in the header (local app + Pages fragment mode)
- **Pixel** — existing pixel-art node sprites and carrot data pixels (unchanged behavior)
- **Corporate** — flat rounded node boxes with type badges (API, DB, SVC…) and solid-circle data pixels; muted blue/slate/teal accent palette
- Theme choice persists in `localStorage` (`openhop-node-theme`); only nodes and traveling data pixels change — canvas background, edges, labels, and chrome stay the same

## Test plan

- [ ] Toggle Pixel ↔ Corporate on a flow with multiple node types — nodes and pixels update, edges/labels unchanged
- [ ] Refresh page — theme preference restored from localStorage
- [ ] Step through a flow in both themes — data pixels animate correctly
- [ ] `npm test -w @openhop/web` passes (52 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a theme selector for switching between Pixel and Corporate node styles.
  * Corporate mode adds branded building visuals, badges, accent colors, borders, and glow effects.
  * Added themed node icons with accessible fallbacks for unsupported or custom icons.
  * Selected themes are remembered between sessions.
  * Theme changes update layouts, node colors, and animated pixels throughout the app.

* **Bug Fixes**
  * Preserved existing Pixel styling and behavior when Pixel mode is selected.

* **Tests**
  * Added coverage for theme palettes, corporate visuals, and icon handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->