### PR TITLE
fix(deps): consolidate production security updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1164,9 +1164,9 @@
       "license": "MIT"
     },
     "node_modules/@fastify/http-proxy": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@fastify/http-proxy/-/http-proxy-11.5.0.tgz",
-      "integrity": "sha512-UxmqkVvTRzbN8A8xSRBmKFhGufhFGDxoBCzPkp5+GDYRb4ew/WwmsZTYd13yJ3TWyOlpRhoQVVLHfcb0wPVkCg==",
+      "version": "11.6.2",
+      "resolved": "https://registry.npmjs.org/@fastify/http-proxy/-/http-proxy-11.6.2.tgz",
+      "integrity": "sha512-SR/rDXL3RihOOPYx0Han41G2ksXvAj9WpSy9MqjdOL7U1s4EbUXLKkEi7S8zM/ockDLXjwVuT2qB8d5unL3XKg==",
       "funding": [
         {
           "type": "github",
@@ -1181,9 +1181,25 @@
       "dependencies": {
         "@fastify/reply-from": "^12.6.2",
         "fast-querystring": "^1.1.2",
-        "fastify-plugin": "^5.1.0",
+        "fastify-plugin": "^6.0.0",
         "ws": "^8.18.3"
       }
+    },
+    "node_modules/@fastify/http-proxy/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
@@ -1313,9 +1329,9 @@
       "license": "MIT"
     },
     "node_modules/@fastify/swagger": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@fastify/swagger/-/swagger-9.7.0.tgz",
-      "integrity": "sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/@fastify/swagger/-/swagger-9.8.1.tgz",
+      "integrity": "sha512-VpHMnqZTY8iBZYJE8WWkbKPrXIYWy2rDfIf5qLr6DzZSpQYZ+KxQVcJFiq/AMlvNwI4gCBd66++iUlxXXGT0IQ==",
       "funding": [
         {
           "type": "github",
@@ -1328,7 +1344,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fastify-plugin": "^5.0.0",
+        "fastify-plugin": "^6.0.0",
         "json-schema-resolver": "^3.0.0",
         "openapi-types": "^12.1.3",
         "rfdc": "^1.3.1",
@@ -1359,6 +1375,22 @@
       }
     },
     "node_modules/@fastify/swagger-ui/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/swagger/node_modules/fastify-plugin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
       "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
@@ -3831,9 +3863,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -3847,9 +3879,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.8.5",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
-      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.1.tgz",
+      "integrity": "sha512-FWi+tQvwxR/PeRX7Z2mhfEF5ozJ3jn9asiiclzKXNSzJRHAYcU924aIOKAdHFJ+YIKieh3cqr1IwCOvTr41B3Q==",
       "funding": [
         {
           "type": "github",
@@ -3860,6 +3892,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
@@ -3867,11 +3900,11 @@
         "@fastify/proxy-addr": "^5.0.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
-        "find-my-way": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
         "pino": "^9.14.0 || ^10.1.0",
-        "process-warning": "^5.0.0",
+        "process-warning": "^5.1.0",
         "rfdc": "^1.3.1",
         "secure-json-parse": "^4.0.0",
         "semver": "^7.6.0",
@@ -3892,6 +3925,68 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/fastify/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fastify/node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fastify/node_modules/fast-json-stringify/node_modules/fast-uri": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/fastify/node_modules/semver": {
@@ -5126,9 +5221,9 @@
       }
     },
     "node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
       "funding": [
         {
           "type": "github",
@@ -6035,12 +6130,12 @@
       "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
-        "@fastify/http-proxy": "^11.5.0",
+        "@fastify/http-proxy": "^11.6.2",
         "@fastify/static": "^10.1.3",
         "@openhop/server": "0.3.6",
         "@openhop/web": "0.3.5",
         "commander": "^12.0.0",
-        "fastify": "^5.0.0",
+        "fastify": "^5.12.1",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },
@@ -6066,10 +6161,10 @@
       "dependencies": {
         "@fastify/cors": "^10.0.0",
         "@fastify/static": "10.1.3",
-        "@fastify/swagger": "^9.0.0",
+        "@fastify/swagger": "^9.8.1",
         "@fastify/swagger-ui": "^6.1.1",
-        "fastify": "^5.0.0",
-        "nanoid": "^5.1.15",
+        "fastify": "^5.12.1",
+        "nanoid": "^5.1.16",
         "yaml": "^2.9.0",
         "zod": "^4.4.3",
         "zod-to-json-schema": "^3.24.0"
@@ -6088,9 +6183,9 @@
       }
     },
     "packages/server/node_modules/nanoid": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.15.tgz",
-      "integrity": "sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,12 +44,12 @@
     "prepack": "npm run build && rm -rf skills && cp -r ../../skills ./skills"
   },
   "dependencies": {
-    "@fastify/http-proxy": "^11.5.0",
+    "@fastify/http-proxy": "^11.6.2",
     "@fastify/static": "^10.1.3",
     "@openhop/server": "0.3.6",
     "@openhop/web": "0.3.5",
     "commander": "^12.0.0",
-    "fastify": "^5.0.0",
+    "fastify": "^5.12.1",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -48,10 +48,10 @@
   "dependencies": {
     "@fastify/cors": "^10.0.0",
     "@fastify/static": "10.1.3",
-    "@fastify/swagger": "^9.0.0",
+    "@fastify/swagger": "^9.8.1",
     "@fastify/swagger-ui": "^6.1.1",
-    "fastify": "^5.0.0",
-    "nanoid": "^5.1.15",
+    "fastify": "^5.12.1",
+    "nanoid": "^5.1.16",
     "yaml": "^2.9.0",
     "zod": "^4.4.3",
     "zod-to-json-schema": "^3.24.0"


### PR DESCRIPTION
## Summary
- upgrade Fastify from 5.8.5 to 5.12.1
- upgrade nanoid from 5.1.15 to 5.1.16
- upgrade transitive fast-uri from 3.1.5 to 3.1.7
- upgrade @fastify/http-proxy from 11.5.0 to 11.6.2
- upgrade @fastify/swagger from 9.7.0 to 9.8.1

This consolidates and supersedes #223, #224, #227, and #228 so their overlapping lockfile changes and security fixes are tested together.

## Security
Addresses the currently open production advisories for Fastify, nanoid, and fast-uri, plus the security release of @fastify/http-proxy.

## Verification
Run under Node 22 in a clean container:
- `npm ci --no-audit`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck --workspaces --if-present`
- `npm run build --workspaces --if-present`
- `npm test --workspaces --if-present`
- `npm run test:coverage --workspaces --if-present`

The local npm audit endpoint was unavailable/returning HTTP 400 during verification; GitHub CI audit remains the authoritative merge gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated the command-line and server components to newer runtime versions.
  - Improved compatibility and stability across supported CLI and server workflows.
  - No changes were made to public APIs, commands, scripts, or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->